### PR TITLE
Rider Web App Deploy

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -2,7 +2,6 @@ import org.apache.tools.ant.filters.*
 
 buildscript {
     repositories {
-        mavenLocal()
         maven { url "https://cache-redirector.jetbrains.com/intellij-repository/snapshots" }
         maven { url "https://cache-redirector.jetbrains.com/maven-central" }
     }
@@ -20,7 +19,6 @@ processResources {
 }
 
 repositories {
-    mavenLocal()
     maven { url "https://cache-redirector.jetbrains.com/intellij-repository/snapshots" }
     maven { url "https://cache-redirector.jetbrains.com/maven-central" }
 }
@@ -61,9 +59,9 @@ allprojects {
     group 'com.microsoft.azuretools'
 
     repositories {
+        maven { url new File(rootProject.projectDir, '../../.repository').toURI() } // to snap to the private maven repo on Jenkins if any
         mavenLocal()
-        maven { url "https://cache-redirector.jetbrains.com/intellij-repository/snapshots" }
-        maven { url "https://cache-redirector.jetbrains.com/maven-central" }
+        mavenCentral()
     }
 
     compileJava {


### PR DESCRIPTION
- Add support for using java forms in rider plugin
- Add support for publishing separate projects from solution filtered by the availability (publish is supported for Core Web App + .Net Web App on Windows only)
- Get Rid of redundant components (RiderSettingModel, Deploy to root, WAR deploy)
- App Service Plan - show service plans from all resource groups
- Replace custom context menu with existing "Publish..." context option for a web project
- Add client side validation for Azure entries that are created through publish configuration dialog