### PR TITLE
Fix the issue with toolwindow live indicator not updated with run state

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/webappconfig/RiderWebAppRunState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/webappconfig/RiderWebAppRunState.kt
@@ -107,6 +107,7 @@ class RiderWebAppRunState(project: Project,
     }
 
     override fun onFail(errMsg: String, processHandler: RunProcessHandler) {
+        if (processHandler.isProcessTerminated || processHandler.isProcessTerminating) return
         processHandler.println(errMsg, ProcessOutputTypes.STDERR)
         processHandler.notifyComplete()
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/AzureRunProfileState.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/runner/AzureRunProfileState.java
@@ -54,7 +54,6 @@ public abstract class AzureRunProfileState <T> implements RunProfileState {
         final RunProcessHandler processHandler = new RunProcessHandler();
         processHandler.addDefaultListener();
         ConsoleView consoleView = TextConsoleBuilderFactory.getInstance().createBuilder(this.project).getConsole();
-        processHandler.startNotify();
         consoleView.attachToProcess(processHandler);
         Map<String, String> telemetryMap = new HashMap<>();
         Observable.fromCallable(


### PR DESCRIPTION
When starting an execition task we check if process handler is already started notifying. We start notifying manually, so, logic did not run