### PR TITLE
Default name when saving file

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/storage/BlobExplorerFileEditor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/storage/BlobExplorerFileEditor.java
@@ -579,7 +579,9 @@ public class BlobExplorerFileEditor implements FileEditor, TelemetryProperties {
 
         FileSaverDescriptor fileDescriptor = new FileSaverDescriptor(SAVE_AS, "Select location to save blob file.");
         final FileSaverDialog dialog = FileChooserFactory.getInstance().createSaveFileDialog(fileDescriptor, this.project);
-        final VirtualFileWrapper save = dialog.save(LocalFileSystem.getInstance().findFileByPath(System.getProperty("user.home")), "");
+        final VirtualFileWrapper save = dialog.save(
+                LocalFileSystem.getInstance().findFileByPath(System.getProperty("user.home")),
+                fileSelection.getName());
 
         if (save != null) {
             downloadSelectedFile(save.getFile(), false);


### PR DESCRIPTION
The name should be defaulted in the "SaveAs" dialog When saving a file from Azure storage

Fixes #44