### PR TITLE
Deploy to Docker host should not mention .jar/.war #48

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/idea/src/com/microsoft/intellij/serviceexplorer/NodeJavaActionsMap.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/idea/src/com/microsoft/intellij/serviceexplorer/NodeJavaActionsMap.java
@@ -56,6 +56,15 @@ public class NodeJavaActionsMap extends NodeActionsMap {
         node2Actions.put(HDInsightRootModuleImpl.class,
                 new ImmutableList.Builder<Class<? extends NodeActionListener>>()
                         .add(AddNewClusterAction.class, AddNewEmulatorAction.class).build());
+
+        //noinspection unchecked
+        node2Actions.put(DockerHostNode.class,
+                new ImmutableList.Builder<Class<? extends NodeActionListener>>()
+                        .add(DeployDockerContainerAction.class).build());
+        //noinspection unchecked
+        node2Actions.put(DockerHostModule.class,
+                new ImmutableList.Builder<Class<? extends NodeActionListener>>()
+                        .add(PublishDockerContainerAction.class).build());
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/DefaultNodeActionsMap.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/DefaultNodeActionsMap.java
@@ -68,12 +68,11 @@ public class DefaultNodeActionsMap extends NodeActionsMap {
         //noinspection unchecked
         node2Actions.put(DockerHostNode.class,
                 new ImmutableList.Builder<Class<? extends NodeActionListener>>()
-                        .add(ViewDockerHostAction.class, DeployDockerContainerAction.class,
-                                DeleteDockerHostAction.class).build());
+                        .add(ViewDockerHostAction.class, DeleteDockerHostAction.class).build());
         //noinspection unchecked
         node2Actions.put(DockerHostModule.class,
                 new ImmutableList.Builder<Class<? extends NodeActionListener>>()
-                        .add(CreateNewDockerHostAction.class, PublishDockerContainerAction.class).build());
+                        .add(CreateNewDockerHostAction.class).build());
     }
 
     @Override


### PR DESCRIPTION
Should only be available in IntelliJ plugin (not Rider). Fixes "Deploy to Docker host should not mention .jar/.war #48"

Fixes #48 

@sdubov @IvanPashchenko Not sure this is the way to move a node from platform plugin to just the IntelliJ plugin?