### PR TITLE
Connect to DB: add firewall rule to access the db automatically

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/RiderNodeActionsMap.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/RiderNodeActionsMap.kt
@@ -40,12 +40,14 @@ class RiderNodeActionsMap : NodeActionsMap() {
         init {
             node2Actions[SqlServerNode::class.java] = ImmutableList.Builder<Class<out NodeActionListener>>()
                     .add(SqlServerOpenInBrowserAction::class.java)
-                    .add(ConnectServerAction::class.java)
+                    .add(SqlServerAddCurrentIpAddressToFirewallAction::class.java)
+                    .add(SqlServerConnectDataSourceAction::class.java)
                     .build()
 
             node2Actions[SqlDatabaseNode::class.java] = ImmutableList.Builder<Class<out NodeActionListener>>()
                     .add(SqlDatabaseOpenInBrowserAction::class.java)
-                    .add(ConnectDatabaseAction::class.java)
+                    .add(SqlDatabaseAddCurrentIpAddressToFirewallAction::class.java)
+                    .add(SqlDatabaseConnectDataSourceAction::class.java)
                     .build()
         }
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/AddCurrentIpAddressToFirewallAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/AddCurrentIpAddressToFirewallAction.kt
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2018 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.intellij.serviceexplorer.azure.database.actions
+
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.PerformInBackgroundOption
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.IconLoader
+import com.intellij.openapi.vcs.VcsShowConfirmationOption
+import com.intellij.util.ui.ConfirmationDialog
+import com.microsoft.azure.management.sql.SqlServer
+import com.microsoft.azuretools.authmanage.AuthMethodManager
+import com.microsoft.azuretools.ijidea.actions.AzureSignInAction
+import com.microsoft.intellij.runner.db.AzureDatabaseMvpModel
+import com.microsoft.tooling.msservices.serviceexplorer.Node
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener
+import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqldatabase.SqlDatabaseNode
+import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqlserver.SqlServerNode
+import org.jetbrains.plugins.azure.cloudshell.AzureCloudShellNotifications
+import org.jetbrains.plugins.azure.util.PublicIpAddressProvider
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+abstract class AddCurrentIpAddressToFirewallAction(private val node: Node) : NodeActionListener() {
+    public override fun actionPerformed(e: NodeActionEvent) {
+        val project = node.project as? Project ?: return
+
+        if (!AzureSignInAction.doSignIn(AuthMethodManager.getInstance(), project)) return
+
+        // Get server details
+        val databaseServerNode = when (node) {
+            is SqlDatabaseNode -> node.parent as SqlServerNode
+            is SqlServerNode -> node
+            else -> return
+        }
+
+        val sqlServer = AzureDatabaseMvpModel.getSqlServerById(databaseServerNode.subscriptionId, databaseServerNode.sqlServerId)
+
+        // Fetch current IP address
+        ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Retrieving current public IP address...", true, PerformInBackgroundOption.DEAF) {
+            override fun run(indicator: ProgressIndicator) {
+                val publicIpAddressResult = PublicIpAddressProvider.retrieveCurrentPublicIpAddress()
+
+                if (publicIpAddressResult != PublicIpAddressProvider.Result.none) {
+                    ApplicationManager.getApplication().invokeLater {
+                        requestAddFirewallRule(project, databaseServerNode, sqlServer, publicIpAddressResult)
+                    }
+                } else {
+                    AzureCloudShellNotifications.notify(project,
+                            "Could not retrieve current public IP address",
+                            "An error occurred while retrieving current public IP address",
+                            "Try adding your IP address from the Azure management portal.",
+                            NotificationType.ERROR)
+                }
+            }
+        })
+    }
+
+    private fun requestAddFirewallRule(project: Project, databaseServerNode: SqlServerNode, sqlServer: SqlServer, publicIpAddressResult: PublicIpAddressProvider.Result) {
+        if (!ConfirmationDialog.requestForConfirmation(VcsShowConfirmationOption.STATIC_SHOW_CONFIRMATION, project,
+                        "Do you want to add a firewall rule for your public IP address '${publicIpAddressResult.ipv4address}' to Sql Database server '${databaseServerNode.name}'?",
+                        "Confirm add firewall rule", IconLoader.getIcon("/icons/Database.svg")))
+            return
+
+        // Add current IP address
+        ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Adding firewall rule for current public IP address...", true, PerformInBackgroundOption.DEAF) {
+            override fun run(indicator: ProgressIndicator) {
+                val currentFirewallRules = sqlServer.firewallRules().list()
+
+                if (!currentFirewallRules.any {
+                            it.startIPAddress() == publicIpAddressResult.ipv4address
+                                    || it.endIPAddress() == publicIpAddressResult.ipv4address }) {
+
+                    val formatter = DateTimeFormatter.ofPattern("yyyy_MM_dd_HH_mm_ss")
+                    val now = LocalDateTime.now(Clock.systemUTC())
+
+                    sqlServer.firewallRules()
+                            .define("ClientIPAddress_${now.format(formatter)}")
+                            .withIPAddressRange(publicIpAddressResult.ipv4address, publicIpAddressResult.ipv4address)
+                            .create()
+                }
+
+                AzureCloudShellNotifications.notify(project,
+                        "Added firewall rule",
+                        "Added firewall rule for your current public IP address",
+                        "You can now connect to your Sql Database from within the IDE.",
+                        NotificationType.INFORMATION)
+            }
+        })
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/ConnectDataSourceAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/ConnectDataSourceAction.kt
@@ -69,3 +69,4 @@ abstract class ConnectDataSourceAction(protected val node: Node) : NodeActionLis
         }
     }
 }
+

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlDatabaseAddCurrentIpAddressToFirewallAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlDatabaseAddCurrentIpAddressToFirewallAction.kt
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2018 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.intellij.serviceexplorer.azure.database.actions
+
+import com.microsoft.tooling.msservices.helpers.Name
+import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqldatabase.SqlDatabaseNode
+
+@Name("Add firewall rule for my IP")
+class SqlDatabaseAddCurrentIpAddressToFirewallAction(private val sqlDatabaseNode: SqlDatabaseNode)
+    : AddCurrentIpAddressToFirewallAction(sqlDatabaseNode)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlDatabaseConnectDataSourceAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlDatabaseConnectDataSourceAction.kt
@@ -24,21 +24,26 @@ package com.microsoft.intellij.serviceexplorer.azure.database.actions
 import com.intellij.database.autoconfig.DataSourceDetector
 import com.microsoft.intellij.runner.db.AzureDatabaseMvpModel
 import com.microsoft.tooling.msservices.helpers.Name
+import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqldatabase.SqlDatabaseNode
 import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqlserver.SqlServerNode
 
-@Name("Connect to server")
-class ConnectServerAction(private val databaseServerNode: SqlServerNode)
-    : ConnectDataSourceAction(databaseServerNode) {
+@Name("Connect to database")
+class SqlDatabaseConnectDataSourceAction(private val databaseNode: SqlDatabaseNode)
+    : ConnectDataSourceAction(databaseNode) {
 
     override fun populateConnectionBuilder(builder: DataSourceDetector.Builder): DataSourceDetector.Builder? {
+        val databaseServerNode = databaseNode.parent as SqlServerNode
+
         val sqlServer = AzureDatabaseMvpModel.getSqlServerById(databaseServerNode.subscriptionId, databaseServerNode.sqlServerId)
 
         return builder
-                .withName("Azure SQL Database Server - " + databaseServerNode.sqlServerName)
+                .withName("Azure SQL Database - "  + databaseServerNode.sqlServerName + " - " + databaseNode.sqlDatabaseName)
                 .withDriverClass(AzureSqlConnectionStringBuilder.defaultDriverClass)
                 .withUrl(AzureSqlConnectionStringBuilder.build(
-                        sqlServer.fullyQualifiedDomainName()
+                        sqlServer.fullyQualifiedDomainName(),
+                        databaseNode.sqlDatabaseName
                 ))
                 .withUser(sqlServer.administratorLogin())
     }
 }
+

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlServerAddCurrentIpAddressToFirewallAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlServerAddCurrentIpAddressToFirewallAction.kt
@@ -21,30 +21,9 @@
  */
 package com.microsoft.intellij.serviceexplorer.azure.database.actions
 
-import com.intellij.database.autoconfig.DataSourceDetector
-import com.microsoft.intellij.runner.db.AzureDatabaseMvpModel
 import com.microsoft.tooling.msservices.helpers.Name
-import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqldatabase.SqlDatabaseNode
 import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqlserver.SqlServerNode
 
-
-@Name("Connect to database")
-class ConnectDatabaseAction(private val databaseNode: SqlDatabaseNode)
-    : ConnectDataSourceAction(databaseNode) {
-
-    override fun populateConnectionBuilder(builder: DataSourceDetector.Builder): DataSourceDetector.Builder? {
-        val databaseServerNode = databaseNode.parent as SqlServerNode
-
-        val sqlServer = AzureDatabaseMvpModel.getSqlServerById(databaseServerNode.subscriptionId, databaseServerNode.sqlServerId)
-
-        return builder
-                .withName("Azure SQL Database - "  + databaseServerNode.sqlServerName + " - " + databaseNode.sqlDatabaseName)
-                .withDriverClass(AzureSqlConnectionStringBuilder.defaultDriverClass)
-                .withUrl(AzureSqlConnectionStringBuilder.build(
-                        sqlServer.fullyQualifiedDomainName(),
-                        databaseNode.sqlDatabaseName
-                ))
-                .withUser(sqlServer.administratorLogin())
-    }
-}
-
+@Name("Add firewall rule for my IP")
+class SqlServerAddCurrentIpAddressToFirewallAction(private val sqlServerNode: SqlServerNode)
+    : AddCurrentIpAddressToFirewallAction(sqlServerNode)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlServerConnectDataSourceAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlServerConnectDataSourceAction.kt
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2018 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.intellij.serviceexplorer.azure.database.actions
+
+import com.intellij.database.autoconfig.DataSourceDetector
+import com.microsoft.intellij.runner.db.AzureDatabaseMvpModel
+import com.microsoft.tooling.msservices.helpers.Name
+import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqlserver.SqlServerNode
+
+@Name("Connect to server")
+class SqlServerConnectDataSourceAction(private val databaseServerNode: SqlServerNode)
+    : ConnectDataSourceAction(databaseServerNode) {
+
+    override fun populateConnectionBuilder(builder: DataSourceDetector.Builder): DataSourceDetector.Builder? {
+        val sqlServer = AzureDatabaseMvpModel.getSqlServerById(databaseServerNode.subscriptionId, databaseServerNode.sqlServerId)
+
+        return builder
+                .withName("Azure SQL Database Server - " + databaseServerNode.sqlServerName)
+                .withDriverClass(AzureSqlConnectionStringBuilder.defaultDriverClass)
+                .withUrl(AzureSqlConnectionStringBuilder.build(
+                        sqlServer.fullyQualifiedDomainName()
+                ))
+                .withUser(sqlServer.administratorLogin())
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/util/PublicIpAddressProvider.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/util/PublicIpAddressProvider.kt
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2018 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jetbrains.plugins.azure.util
+
+import com.intellij.openapi.diagnostic.Logger
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+
+class PublicIpAddressProvider {
+    companion object {
+        private const val userAgentHeaderName: String = "User-Agent"
+        private const val userAgentHeaderValue: String = "Azure Tookit for JetBrains Rider"
+
+        private val logger = Logger.getInstance(PublicIpAddressProvider::class.java)
+
+        private val plainTextProviderUrls = listOf(
+                "http://ipv4bot.whatismyipaddress.com",
+                "http://ip4.seeip.org",
+                "http://v4.ident.me"
+        )
+
+        fun retrieveCurrentPublicIpAddress() : Result {
+            val httpClient = OkHttpClient()
+                    .newBuilder()
+                    .connectTimeout(30, TimeUnit.SECONDS)
+                    .readTimeout(30, TimeUnit.SECONDS)
+                    .writeTimeout(30, TimeUnit.SECONDS)
+                    .build()
+
+            for (plainTextProviderUrl in plainTextProviderUrls.shuffled()) {
+                val request = Request.Builder()
+                        .url(plainTextProviderUrl)
+                        .header(userAgentHeaderName, userAgentHeaderValue)
+                        .build()
+
+                try {
+                    val response = httpClient.newCall(request).execute()
+
+                    if (response.isSuccessful && response.body() != null) {
+                        logger.info("Public IP address retrieved succesfully from $plainTextProviderUrl")
+
+                        val ipAddress = response.body()!!.string()
+
+                        return Result(ipAddress.trim())
+                    }
+                } catch (e: Exception) {
+                    logger.error("Error retrieving public IP address from $plainTextProviderUrl", e)
+                }
+            }
+
+            logger.warn("Public IP address could not be retrieved from any provider.")
+
+            return Result.none
+        }
+    }
+
+    class Result(val ipv4address: String) {
+        companion object {
+            val none = Result("0.0.0.0")
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The plugin can be downloaded and installed in JetBrains Rider and is available [
 * Basic management of container hosts (create/delete, start/stop, view details)
 * List container registries
 * Basic management of Redis caches (create/delete, start/stop, view details, list keys/values)
-* Basic management of Sql databases (list, delete, open in browser, connect to database in database tools)
+* Basic management of Sql databases (list, delete, open in browser, add firewall rule for current public IP, connect to database in database tools)
 * Basic management of storage accounts (create/delete, list/create/delete blob container, list/upload/download/delete blobs)
 * Basic management of virtual machines (create/delete, start/stop, view details)
 * Basic management of web apps and deployment slots (create/delete, start/stop, view details, edit settings, swap slot)


### PR DESCRIPTION
Fixes #114

![fw-myip](https://user-images.githubusercontent.com/485230/49022968-6d8ac700-f196-11e8-8a2e-f92e02013299.gif)

In terms of the API's for getting public IP used: (checked on 2018-11-26)

* https://whatismyipaddress.com/api - "You may programmatically query that server"
* http://ip4.seeip.org - "You can use it without any real limit."
* http://v4.ident.me - No license info (http://api.ident.me/)
