### PR TITLE
Functions: Development: Configure Azure Core Tools path

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -110,6 +110,8 @@
     <programRunner implementation="com.microsoft.intellij.runner.webapp.webappconfig.RiderWebAppRunner"/>
     <rider.publishConfigurationProvider implementation="com.microsoft.intellij.runner.webapp.AzureDotNetWebAppContextPublishProvider" order="last" />
 
+    <solutionLoadNotification implementation="org.jetbrains.plugins.azure.functions.AzureCoreToolsNotification" />
+
     <stepsBeforeRunProvider implementation="org.jetbrains.plugins.azure.functions.buildTasks.BuildFunctionsProjectBeforeRunTaskProvider"/>
     <configurationType implementation="org.jetbrains.plugins.azure.functions.run.AzureFunctionsHostConfigurationType"/>
     <runConfigurationProducer implementation="org.jetbrains.plugins.azure.functions.run.AzureFunctionsConfigurationProducer"/>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -110,11 +110,11 @@
     <programRunner implementation="com.microsoft.intellij.runner.webapp.webappconfig.RiderWebAppRunner"/>
     <rider.publishConfigurationProvider implementation="com.microsoft.intellij.runner.webapp.AzureDotNetWebAppContextPublishProvider" order="last" />
 
-    <solutionLoadNotification implementation="org.jetbrains.plugins.azure.functions.AzureCoreToolsNotification" />
-
     <stepsBeforeRunProvider implementation="org.jetbrains.plugins.azure.functions.buildTasks.BuildFunctionsProjectBeforeRunTaskProvider"/>
     <configurationType implementation="org.jetbrains.plugins.azure.functions.run.AzureFunctionsHostConfigurationType"/>
     <runConfigurationProducer implementation="org.jetbrains.plugins.azure.functions.run.AzureFunctionsConfigurationProducer"/>
+
+    <postStartupActivity implementation="org.jetbrains.plugins.azure.functions.AzureCoreToolsNotification" />
   </extensions>
 
   <extensions defaultExtensionNs="com.microsoft.intellij">

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/ui/AzureFunctionsConfigurationPanel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/ui/AzureFunctionsConfigurationPanel.kt
@@ -44,6 +44,17 @@ class AzureFunctionsConfigurationPanel: AzureRiderAbstractConfigurablePanel {
 
     companion object {
         private const val DISPLAY_NAME = "Functions"
+
+        private const val PATH_TO_CORE_TOOLS = "Azure Functions Core Tools path:"
+        private const val CURRENT_VERSION = "Current version:"
+        private const val LATEST_VERSION = "Latest available version:"
+        private const val UNKNOWN = "<unknown>"
+
+        private const val PATH_TO_CORE_TOOLS_DESCRIPTION = "Path to Azure Functions Core Tools"
+        private const val INSTALL_LATEST = "Download latest version..."
+
+        private const val CARD_BUTTON = "button"
+        private const val CARD_PROGRESS = "progress"
     }
 
     private val properties = PropertiesComponent.getInstance()
@@ -51,16 +62,16 @@ class AzureFunctionsConfigurationPanel: AzureRiderAbstractConfigurablePanel {
     private val coreToolsPathField = TextFieldWithBrowseButton().apply {
         addBrowseFolderListener(
                 "",
-                "Path to Azure Functions Core Tools",
+                PATH_TO_CORE_TOOLS_DESCRIPTION,
                 null,
                 FileChooserDescriptorFactory.createSingleFolderDescriptor(),
                 TextComponentAccessor.TEXT_FIELD_WHOLE_TEXT
         )
     }
 
-    private val currentVersionLabel = JLabel()
-    private val latestVersionLabel = JLabel()
-    private val installButton = LinkLabel<Any>("Download latest version", null) { _, _ -> installLatestCoreTools() }
+    private val currentVersionLabel = JLabel(UNKNOWN)
+    private val latestVersionLabel = JLabel(UNKNOWN)
+    private val installButton = LinkLabel<Any>(INSTALL_LATEST, null) { _, _ -> installLatestCoreTools() }
             .apply {
                 isEnabled = false
             }
@@ -68,8 +79,8 @@ class AzureFunctionsConfigurationPanel: AzureRiderAbstractConfigurablePanel {
     private val wrapperLayout = CardLayout()
     private val installActionPanel = OpaquePanel(wrapperLayout)
             .apply {
-                add(installButton, "button")
-                add(TwoLineProgressIndicator().component, "progress")
+                add(installButton, CARD_BUTTON)
+                add(TwoLineProgressIndicator().component, CARD_PROGRESS)
             }
 
 
@@ -85,17 +96,17 @@ class AzureFunctionsConfigurationPanel: AzureRiderAbstractConfigurablePanel {
         val installIndicator = TwoLineProgressIndicator()
         installIndicator.setCancelRunnable {
             if (installIndicator.isRunning) installIndicator.stop()
-            wrapperLayout.show(installActionPanel, "button")
+            wrapperLayout.show(installActionPanel, CARD_BUTTON)
         }
 
-        installActionPanel.add(installIndicator.component, "progress")
-        wrapperLayout.show(installActionPanel, "progress")
+        installActionPanel.add(installIndicator.component, CARD_PROGRESS)
+        wrapperLayout.show(installActionPanel, CARD_PROGRESS)
 
         FunctionsCoreToolsManager.downloadLatestRelease(installIndicator) {
             UIUtil.invokeAndWaitIfNeeded(Runnable {
                 coreToolsPathField.text = it
                 installButton.isEnabled = false
-                wrapperLayout.show(installActionPanel, "button")
+                wrapperLayout.show(installActionPanel, CARD_BUTTON)
             })
 
             updateVersionLabels()
@@ -108,8 +119,8 @@ class AzureFunctionsConfigurationPanel: AzureRiderAbstractConfigurablePanel {
             val remote = FunctionsCoreToolsManager.determineLatestRemote()
 
             UIUtil.invokeAndWaitIfNeeded(Runnable {
-                currentVersionLabel.text = local?.version ?: "<unknown>"
-                latestVersionLabel.text = remote?.version ?: "<unknown>"
+                currentVersionLabel.text = local?.version ?: UNKNOWN
+                latestVersionLabel.text = remote?.version ?: UNKNOWN
 
                 installButton.isEnabled = local == null || remote != null && local < remote
             })
@@ -118,9 +129,9 @@ class AzureFunctionsConfigurationPanel: AzureRiderAbstractConfigurablePanel {
 
     override val panel = FormBuilder
             .createFormBuilder()
-            .addLabeledComponent("Azure Functions Core Tools path:", coreToolsPathField)
-            .addLabeledComponent("Current version:", currentVersionLabel)
-            .addLabeledComponent("Latest available version:", latestVersionLabel, JBUI.scale(8))
+            .addLabeledComponent(PATH_TO_CORE_TOOLS, coreToolsPathField)
+            .addLabeledComponent(CURRENT_VERSION, currentVersionLabel)
+            .addLabeledComponent(LATEST_VERSION, latestVersionLabel, JBUI.scale(8))
             .addComponentToRightColumn(installActionPanel)
             .addComponentFillVertically(JPanel(), 0)
             .panel

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/ui/AzureFunctionsConfigurationPanel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/ui/AzureFunctionsConfigurationPanel.kt
@@ -28,7 +28,6 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.ui.TextComponentAccessor
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
-import com.intellij.openapi.ui.VerticalFlowLayout
 import com.intellij.ui.components.labels.LinkLabel
 import com.intellij.ui.components.panels.OpaquePanel
 import com.intellij.util.ui.FormBuilder
@@ -37,8 +36,6 @@ import com.intellij.util.ui.UIUtil
 import com.microsoft.intellij.configuration.AzureRiderSettings
 import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsManager
 import java.awt.CardLayout
-import java.awt.Dimension
-import java.awt.FlowLayout
 import java.io.File
 import javax.swing.JLabel
 import javax.swing.JPanel
@@ -71,9 +68,7 @@ class AzureFunctionsConfigurationPanel: AzureRiderAbstractConfigurablePanel {
     private val wrapperLayout = CardLayout()
     private val installActionPanel = OpaquePanel(wrapperLayout)
             .apply {
-                // TODO sdubov any ideas to align this nicely?
-                add(JPanel(FlowLayout(FlowLayout.LEFT, 0, JBUI.scale(32))).apply {
-                    add(installButton) }, "button")
+                add(installButton, "button")
                 add(TwoLineProgressIndicator().component, "progress")
             }
 
@@ -126,13 +121,7 @@ class AzureFunctionsConfigurationPanel: AzureRiderAbstractConfigurablePanel {
             .addLabeledComponent("Azure Functions Core Tools path:", coreToolsPathField)
             .addLabeledComponent("Current version:", currentVersionLabel)
             .addLabeledComponent("Latest available version:", latestVersionLabel, JBUI.scale(8))
-            .addComponentToRightColumn(OpaquePanel(VerticalFlowLayout(VerticalFlowLayout.TOP, 0, JBUI.scale(4), false, false))
-                    .apply {
-                        preferredSize = Dimension(JBUI.scale(400), JBUI.scale(100))
-
-                        add(installActionPanel)
-                    }
-            )
+            .addComponentToRightColumn(installActionPanel)
             .addComponentFillVertically(JPanel(), 0)
             .panel
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/ui/AzureFunctionsConfigurationPanel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/ui/AzureFunctionsConfigurationPanel.kt
@@ -91,6 +91,7 @@ class AzureFunctionsConfigurationPanel: AzureRiderAbstractConfigurablePanel {
             FunctionsCoreToolsManager.downloadLatestRelease(installIndicator) {
                 UIUtil.invokeAndWaitIfNeeded(Runnable {
                     coreToolsPathField.text = it
+                    installButton.isEnabled = false
                     wrapperLayout.show(installActionPanel, "button")
                 })
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/AzureCoreToolsNotification.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/AzureCoreToolsNotification.kt
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2019 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jetbrains.plugins.azure.functions
+
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.notification.*
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.jetbrains.rider.projectView.notifications.SolutionLoadNotification
+import com.microsoft.intellij.configuration.AzureRiderSettings
+import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsInfoProvider
+import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsManager
+import javax.swing.event.HyperlinkEvent
+
+class AzureCoreToolsNotification(project: Project) : SolutionLoadNotification(project) {
+    companion object {
+        private val notificationGroup = NotificationGroup("AzureFunctions", NotificationDisplayType.BALLOON, true, null, null)
+    }
+
+    override val settingName: String
+        get() = "AzureCoreToolsNotification"
+
+    override fun createNotification(): Notification? {
+        val funcCoreToolsInfo = FunctionsCoreToolsInfoProvider.build()
+
+        val local = FunctionsCoreToolsManager.determineVersion(funcCoreToolsInfo?.coreToolsPath)
+        val remote = FunctionsCoreToolsManager.determineLatestRemote()
+
+        if (local == null || remote != null && local < remote) {
+            val title = if (local == null) {
+                "Install Azure Functions Core Tools"
+            } else {
+                "Update Azure Functions Core Tools"
+            }
+
+            val description = if (local == null) {
+                "<a href='install'>Install the Azure Functions Core Tools</a> to develop, run and debug Azure Functions locally."
+            } else {
+                "A newer version of the Azure Functions Core Tools is available. <a href='install'>Update now</a>"
+            }
+
+            return notificationGroup.createNotification(
+                    title, null, description,
+                    NotificationType.INFORMATION,
+                    object : NotificationListener.Adapter() {
+                        override fun hyperlinkActivated(notification: Notification, e: HyperlinkEvent) {
+                            if (!project.isDisposed) {
+                                when (e.description) {
+                                    "install" -> {
+                                        ProgressManager.getInstance().run(
+                                            FunctionsCoreToolsManager.downloadLatestRelease(project) {
+                                                PropertiesComponent.getInstance().setValue(
+                                                        AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH, it)
+                                                notification.expire()
+                                            })
+                                    }
+                                }
+                            }
+                        }
+                    })
+        }
+
+        return null
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/AzureCoreToolsNotification.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/AzureCoreToolsNotification.kt
@@ -44,47 +44,47 @@ class AzureCoreToolsNotification : StartupActivity {
 
     override fun runActivity(project: Project) {
         project.solution.runnableProjectsModel.projects.adviseOnce(project.createLifetime()) { runnableProjects ->
-            if (runnableProjects.any { it.kind == RunnableProjectKind.AzureFunctions }) {
-                val funcCoreToolsInfo = FunctionsCoreToolsInfoProvider.build()
+            if (runnableProjects.none { it.kind == RunnableProjectKind.AzureFunctions }) return@adviseOnce
 
-                val local = FunctionsCoreToolsManager.determineVersion(funcCoreToolsInfo?.coreToolsPath)
-                val remote = FunctionsCoreToolsManager.determineLatestRemote()
+            val funcCoreToolsInfo = FunctionsCoreToolsInfoProvider.build()
 
-                if (local == null || remote != null && local < remote) {
-                    val title = if (local == null) {
-                        "Install Azure Functions Core Tools"
-                    } else {
-                        "Update Azure Functions Core Tools"
-                    }
+            val local = FunctionsCoreToolsManager.determineVersion(funcCoreToolsInfo?.coreToolsPath)
+            val remote = FunctionsCoreToolsManager.determineLatestRemote()
 
-                    val description = if (local == null) {
-                        "<a href='install'>Install the Azure Functions Core Tools</a> to develop, run and debug Azure Functions locally."
-                    } else {
-                        "A newer version of the Azure Functions Core Tools is available. <a href='install'>Update now</a>"
-                    }
+            if (local == null || remote != null && local < remote) {
+                val title = if (local == null) {
+                    "Install Azure Functions Core Tools"
+                } else {
+                    "Update Azure Functions Core Tools"
+                }
 
-                    val notification = notificationGroup.createNotification(
-                            title, null, description,
-                            NotificationType.INFORMATION,
-                            object : NotificationListener.Adapter() {
-                                override fun hyperlinkActivated(notification: Notification, e: HyperlinkEvent) {
-                                    if (!project.isDisposed) {
-                                        when (e.description) {
-                                            "install" -> {
-                                                ProgressManager.getInstance().run(
-                                                        FunctionsCoreToolsManager.downloadLatestRelease(project) {
-                                                            PropertiesComponent.getInstance().setValue(
-                                                                    AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH, it)
-                                                            notification.expire()
-                                                        })
-                                            }
+                val description = if (local == null) {
+                    "<a href='install'>Install the Azure Functions Core Tools</a> to develop, run and debug Azure Functions locally."
+                } else {
+                    "A newer version of the Azure Functions Core Tools is available. <a href='install'>Update now</a>"
+                }
+
+                val notification = notificationGroup.createNotification(
+                        title, null, description,
+                        NotificationType.INFORMATION,
+                        object : NotificationListener.Adapter() {
+                            override fun hyperlinkActivated(notification: Notification, e: HyperlinkEvent) {
+                                if (!project.isDisposed) {
+                                    when (e.description) {
+                                        "install" -> {
+                                            ProgressManager.getInstance().run(
+                                                    FunctionsCoreToolsManager.downloadLatestRelease(project) {
+                                                        PropertiesComponent.getInstance().setValue(
+                                                                AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH, it)
+                                                        notification.expire()
+                                                    })
                                         }
                                     }
                                 }
-                            })
+                            }
+                        })
 
-                    Notifications.Bus.notify(notification, project)
-                }
+                Notifications.Bus.notify(notification, project)
             }
         }
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/GitHubReleases.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/GitHubReleases.kt
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2019 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jetbrains.plugins.azure.functions
+
+import com.google.gson.annotations.SerializedName
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.Url
+
+interface GitHubReleasesService {
+    companion object {
+        fun createInstance(baseUrl: String = "https://api.github.com/"): GitHubReleasesService =
+                Retrofit.Builder()
+                        .baseUrl(baseUrl)
+                        .addConverterFactory(GsonConverterFactory.create())
+                        .build()
+                        .create(GitHubReleasesService::class.java)
+    }
+
+    @GET
+    @Headers("Accept: application/json")
+    fun getLatestRelease(@Url latestReleaseUrl: String): Call<GitHubRelease>
+}
+
+class GitHubRelease(val url: String?,
+                    @SerializedName("assets_url") val assetsUrl: String?,
+                    val name: String?,
+                    @SerializedName("tag_name") val tagName: String?,
+                    val assets: List<GitHubReleaseAsset> = mutableListOf()) {
+}
+
+class GitHubReleaseAsset(val url: String?,
+                         @SerializedName("browser_download_url") val browserDownloadUrl: String?,
+                         val name: String?,
+                         val label: String?,
+                         @SerializedName("content_type")  val contentType: String?,
+                         val size: Long?)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsInfoProvider.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsInfoProvider.kt
@@ -52,11 +52,11 @@ object FunctionsCoreToolsInfoProvider {
         }
 
         if (!coreToolsExecutablePath.canExecute()) {
-            logger.warn { "Updating executable flag for {$coreToolsExecutablePath}..." }
+            logger.warn { "Updating executable flag for $coreToolsExecutablePath..." }
             try {
                 coreToolsExecutablePath.setExecutable(true)
             } catch (s: SecurityException) {
-                logger.error("Failed setting executable flag for {$coreToolsExecutablePath}", s)
+                logger.error("Failed setting executable flag for $coreToolsExecutablePath", s)
             }
         }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsInfoProvider.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsInfoProvider.kt
@@ -24,12 +24,17 @@ package org.jetbrains.plugins.azure.functions.coreTools
 
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.util.SystemInfo
+import com.jetbrains.rd.util.error
+import com.jetbrains.rd.util.getLogger
+import com.jetbrains.rd.util.warn
 import com.microsoft.intellij.configuration.AzureRiderSettings
 import java.io.File
 
 data class FunctionsCoreToolsInfo(val coreToolsPath: String, var coreToolsExecutable: String)
 
 object FunctionsCoreToolsInfoProvider {
+    private val logger = getLogger<FunctionsCoreToolsInfoProvider>()
+
     fun build(): FunctionsCoreToolsInfo? {
         val funcCoreToolsPath = PropertiesComponent.getInstance().getValue(AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH)
         if (funcCoreToolsPath.isNullOrEmpty() || !File(funcCoreToolsPath).exists()) {
@@ -37,13 +42,22 @@ object FunctionsCoreToolsInfoProvider {
         }
 
         val coreToolsExecutablePath = if (SystemInfo.isWindows) {
-            File(funcCoreToolsPath + File.separator + "func.exe")
+            File(funcCoreToolsPath).resolve("func.exe")
         } else {
-            File(funcCoreToolsPath + File.separator + "func")
+            File(funcCoreToolsPath).resolve("func")
         }
 
         if (!coreToolsExecutablePath.exists()) {
             return null
+        }
+
+        if (!coreToolsExecutablePath.canExecute()) {
+            logger.warn { "Updating executable flag for {$coreToolsExecutablePath}..." }
+            try {
+                coreToolsExecutablePath.setExecutable(true)
+            } catch (s: SecurityException) {
+                logger.error("Failed setting executable flag for {$coreToolsExecutablePath}", s)
+            }
         }
 
         return FunctionsCoreToolsInfo(funcCoreToolsPath!!, coreToolsExecutablePath.path)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsManager.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsManager.kt
@@ -117,7 +117,7 @@ object FunctionsCoreToolsManager {
         try {
             if (latestDirectory.exists()) latestDirectory.deleteRecursively()
         } catch (e: Exception) {
-            logger.error("Error while removing latest directory {$latestDirectory.path}", e)
+            logger.error("Error while removing latest directory $latestDirectory.path", e)
         }
 
         pi.text = "Extracting..."
@@ -125,7 +125,7 @@ object FunctionsCoreToolsManager {
         try {
             ZipUtil.extract(tempFile, latestDirectory, null)
         } catch (e: Exception) {
-            logger.error("Error while extracting {$tempFile.path} to {$latestDirectory.path}", e)
+            logger.error("Error while extracting $tempFile.path to $latestDirectory.path", e)
         }
 
         pi.text = "Cleaning up older versions..."
@@ -135,7 +135,7 @@ object FunctionsCoreToolsManager {
             try {
                 if (latestLocalDirectory.exists()) latestLocalDirectory.deleteRecursively()
             } catch (e: Exception) {
-                logger.error("Error while removing older version directory {$latestLocalDirectory.path}", e)
+                logger.error("Error while removing older version directory $latestLocalDirectory.path", e)
             }
         }
 
@@ -144,7 +144,7 @@ object FunctionsCoreToolsManager {
         try {
             if (tempFile.exists()) tempFile.delete()
         } catch (e: Exception) {
-            logger.error("Error while removing temporary file {$tempFile.path}", e)
+            logger.error("Error while removing temporary file $tempFile.path", e)
         }
 
 //      // TODO: Should we register project templates?
@@ -177,11 +177,11 @@ object FunctionsCoreToolsManager {
         try {
             if (coreToolsExecutablePath.exists()) {
                 if (!coreToolsExecutablePath.canExecute()) {
-                    logger.warn { "Updating executable flag for {$coreToolsPath}..." }
+                    logger.warn { "Updating executable flag for $coreToolsPath..." }
                     try {
                         coreToolsExecutablePath.setExecutable(true)
                     } catch (s: SecurityException) {
-                        logger.error("Failed setting executable flag for {$coreToolsPath}", s)
+                        logger.error("Failed setting executable flag for $coreToolsPath", s)
                     }
                 }
 
@@ -197,7 +197,7 @@ object FunctionsCoreToolsManager {
                 }
             }
         } catch (e: Exception) {
-            logger.error("Error while determining version of tools in {$coreToolsPath}", e)
+            logger.error("Error while determining version of tools in $coreToolsPath", e)
         }
 
         return null

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsManager.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsManager.kt
@@ -39,6 +39,8 @@ import com.jetbrains.rd.util.getLogger
 import com.jetbrains.rd.util.warn
 import org.jetbrains.plugins.azure.functions.GitHubReleasesService
 import java.io.File
+import java.io.IOException
+import java.net.UnknownHostException
 
 object FunctionsCoreToolsManager {
     private const val DOWNLOADTASK_TITLE = "Downloading latest Azure Functions Core Tools..."
@@ -218,31 +220,37 @@ object FunctionsCoreToolsManager {
     }
 
     fun determineLatestRemote(): AzureFunctionsCoreToolsRemoteAsset? {
-        val latestGitHubRelease = GitHubReleasesService.createInstance()
-                .getLatestRelease(LATEST_RELEASE_URL)
-                .execute()
-                .body()
+        try {
+            val latestGitHubRelease = GitHubReleasesService.createInstance()
+                    .getLatestRelease(LATEST_RELEASE_URL)
+                    .execute()
+                    .body()
 
-        if (latestGitHubRelease != null) {
-            val expectedFileNamePrefix = "Azure.Functions.Cli." + if (SystemInfo.isWindows && SystemInfo.is64Bit) {
-                "win-x64"
-            } else if (SystemInfo.isWindows) {
-                "win-x86"
-            } else if (SystemInfo.isMac) {
-                "osx-x64"
-            } else if (SystemInfo.isLinux) {
-                "linux-x64"
-            } else {
-                "unknown"
+            if (latestGitHubRelease != null) {
+                val expectedFileNamePrefix = "Azure.Functions.Cli." + if (SystemInfo.isWindows && SystemInfo.is64Bit) {
+                    "win-x64"
+                } else if (SystemInfo.isWindows) {
+                    "win-x86"
+                } else if (SystemInfo.isMac) {
+                    "osx-x64"
+                } else if (SystemInfo.isLinux) {
+                    "linux-x64"
+                } else {
+                    "unknown"
+                }
+
+                val latestReleaseVersion = latestGitHubRelease.tagName!!.trimStart('v')
+
+                val latestAsset = latestGitHubRelease.assets.first {
+                    it.name!!.startsWith(expectedFileNamePrefix, true) && it.name.endsWith(".zip")
+                }
+
+                return AzureFunctionsCoreToolsRemoteAsset(latestReleaseVersion, latestAsset.name!!, latestAsset.browserDownloadUrl!!)
             }
-
-            val latestReleaseVersion = latestGitHubRelease.tagName!!.trimStart('v')
-
-            val latestAsset = latestGitHubRelease.assets.first {
-                it.name!!.startsWith(expectedFileNamePrefix, true) && it.name.endsWith(".zip")
-            }
-
-            return  AzureFunctionsCoreToolsRemoteAsset(latestReleaseVersion, latestAsset.name!!, latestAsset.browserDownloadUrl!!)
+        } catch (e: UnknownHostException) {
+            logger.error("Could not determine latest remote.", e)
+        } catch (e: IOException) {
+            logger.error("Could not determine latest remote.", e)
         }
 
         return null

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsManager.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsManager.kt
@@ -1,0 +1,246 @@
+/**
+ * Copyright (c) 2019 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jetbrains.plugins.azure.functions.coreTools
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.util.io.HttpRequests
+import com.intellij.util.io.ZipUtil
+import com.jetbrains.rd.util.error
+import com.jetbrains.rd.util.getLogger
+import org.jetbrains.plugins.azure.functions.GitHubReleasesService
+import java.io.File
+
+object FunctionsCoreToolsManager {
+    private const val CORETOOLS_DIR = "azure-functions-coretools"
+    private const val LATEST_RELEASE_URL = "repos/Azure/azure-functions-core-tools/releases/latest"
+
+    private val downloadPath = PathManager.getConfigPath() + File.separator + FunctionsCoreToolsManager.CORETOOLS_DIR
+
+    private val logger = getLogger<FunctionsCoreToolsManager>()
+
+    fun downloadLatestRelease(indicator: ProgressIndicator, completed: (String) -> Unit) {
+        object : Task.Backgroundable(null, "Downloading latest Azure Functions Core Tools...", true) {
+            override fun run(pi: ProgressIndicator) {
+                ApplicationManager.getApplication().executeOnPooledThread {
+                    downloadLatestReleaseInternal(pi, completed)
+                    return@executeOnPooledThread
+                }
+            }
+        }.run(indicator)
+    }
+
+    fun downloadLatestRelease(project: Project, completed: (String) -> Unit): Task {
+        return object : Task.Backgroundable(project, "Downloading latest Azure Functions Core Tools...", true) {
+            override fun run(pi: ProgressIndicator) {
+                downloadLatestReleaseInternal(pi, completed)
+            }
+        }
+    }
+
+    private fun downloadLatestReleaseInternal(pi: ProgressIndicator, completed: (String) -> Unit) {
+        if (!pi.isRunning) pi.start()
+
+        // Grab latest URL
+        pi.text = "Determining download URL..."
+        pi.isIndeterminate = true
+
+        val latestLocal = determineVersion(determineLatestLocalCoreToolsPath())
+        val latestRemote = determineLatestRemote()
+        if (latestRemote == null || latestLocal?.compareTo(latestRemote) == 0) {
+            pi.text = "Finished."
+            if (pi.isRunning) pi.stop()
+
+            if (latestLocal != null) {
+                completed(latestLocal.fullPath)
+            }
+
+            return
+        }
+
+        val tempFile = FileUtil.createTempFile(
+                File(FileUtil.getTempDirectory()),
+                latestRemote.fileName,
+                "download", true, true)
+
+        // Download
+        pi.text = "Preparing to download..."
+        pi.isIndeterminate = false
+        HttpRequests.request(latestRemote.downloadUrl)
+                .productNameAsUserAgent()
+                .connect {
+                    pi.text = "Downloading..."
+                    it.saveToFile(tempFile, pi)
+                }
+
+        pi.checkCanceled()
+
+        // Extract
+        pi.startNonCancelableSection()
+        pi.text = "Preparing to extract..."
+        pi.isIndeterminate = true
+        val latestDirectory = File(downloadPath + File.separator + latestRemote.version)
+        try {
+            if (latestDirectory.exists()) latestDirectory.deleteRecursively()
+        } catch (e: Exception) {
+            logger.error("Error while removing latest directory {$latestDirectory.path}", e)
+        }
+
+        pi.text = "Extracting..."
+        pi.isIndeterminate = true
+        try {
+            ZipUtil.extract(tempFile, latestDirectory, null)
+        } catch (e: Exception) {
+            logger.error("Error while extracting {$tempFile.path} to {$latestDirectory.path}", e)
+        }
+
+        pi.text = "Cleaning up older versions..."
+        pi.isIndeterminate = true
+        if (latestLocal != null) {
+            val latestLocalDirectory = File(latestLocal.fullPath)
+            try {
+                if (latestLocalDirectory.exists()) latestLocalDirectory.deleteRecursively()
+            } catch (e: Exception) {
+                logger.error("Error while removing older version directory {$latestLocalDirectory.path}", e)
+            }
+        }
+
+        pi.text = "Cleaning up temporary files..."
+        pi.isIndeterminate = true
+        try {
+            if (tempFile.exists()) tempFile.delete()
+        } catch (e: Exception) {
+            logger.error("Error while removing temporary file {$tempFile.path}", e)
+        }
+
+//      // TODO: Should we register project templates?
+//      indicator.text = "Registering templates..."
+//      val templatesFolder = File(latestDirectory.path + File.separator + "templates")
+//      if (templatesFolder.exists()) {
+//          templatesFolder
+//              .listFiles { f: File? -> f != null && f.isFile && f.name.contains("projectTemplates", true) }
+//              .forEach {
+//                  ReSharperProjectTemplateProvider.addUserTemplateSource(it)
+//              }
+//       }
+
+        pi.finishNonCancelableSection()
+        pi.text = "Finished."
+        if (pi.isRunning) pi.stop()
+
+        completed(latestDirectory.path)
+    }
+
+    fun determineVersion(coreToolsPath: String?): AzureFunctionsCoreToolsLocalAsset? {
+        if (coreToolsPath == null) return null
+
+        val coreToolsExecutablePath = if (SystemInfo.isWindows) {
+            File(coreToolsPath + File.separator + "func.exe")
+        } else {
+            File(coreToolsPath + File.separator + "func")
+        }
+
+        try {
+            if (coreToolsExecutablePath.exists()) {
+                val commandLine = GeneralCommandLine()
+                        .withExePath(coreToolsExecutablePath.path)
+                        .withParameters("--version")
+
+                val processHandler = CapturingProcessHandler(commandLine)
+                val output = processHandler.runProcess(15000, true)
+                val version = output.stdoutLines.firstOrNull()?.trim('\r', '\n')
+                if (!version.isNullOrEmpty()) {
+                    return AzureFunctionsCoreToolsLocalAsset(version!!, coreToolsPath)
+                }
+            }
+        } catch (e: Exception) {
+            logger.error("Error while determining version of tools in {$coreToolsPath}", e)
+        }
+
+        return null
+    }
+
+    private fun determineLatestLocalCoreToolsPath(): String? {
+        val downloadDirectory = File(downloadPath)
+        if (downloadDirectory.exists()) {
+            val latestDirectory = downloadDirectory
+                    .listFiles { f: File? -> f != null && f.isDirectory }
+                    .sortedWith(Comparator<File> { o1, o2 -> StringUtil.compareVersionNumbers(o1?.name, o2?.name) })
+                    .lastOrNull()
+
+            if (latestDirectory != null) {
+                return latestDirectory.path
+            }
+        }
+
+        return null
+    }
+
+    fun determineLatestRemote(): AzureFunctionsCoreToolsRemoteAsset? {
+        val latestGitHubRelease = GitHubReleasesService.createInstance()
+                .getLatestRelease(LATEST_RELEASE_URL)
+                .execute()
+                .body()
+
+        if (latestGitHubRelease != null) {
+            val expectedFileNamePrefix = "Azure.Functions.Cli." + if (SystemInfo.isWindows && SystemInfo.is64Bit) {
+                "win-x64"
+            } else if (SystemInfo.isWindows) {
+                "win-x86"
+            } else if (SystemInfo.isMac) {
+                "osx-x64"
+            } else if (SystemInfo.isMac) {
+                "linux-x64"
+            } else {
+                "unknown"
+            }
+
+            val latestReleaseVersion = latestGitHubRelease.tagName!!.trimStart('v')
+
+            val latestAsset = latestGitHubRelease.assets.first {
+                it.name!!.startsWith(expectedFileNamePrefix, true) && it.name.endsWith(".zip")
+            }
+
+            return  AzureFunctionsCoreToolsRemoteAsset(latestReleaseVersion, latestAsset.name!!, latestAsset.browserDownloadUrl!!)
+        }
+
+        return null
+    }
+
+    open class AzureFunctionsCoreToolsAsset(val version: String) : Comparable<AzureFunctionsCoreToolsAsset> {
+        override fun compareTo(other: AzureFunctionsCoreToolsAsset): Int {
+            return StringUtil.compareVersionNumbers(version, other.version)
+        }
+    }
+
+    class AzureFunctionsCoreToolsLocalAsset(version: String, val fullPath: String) : AzureFunctionsCoreToolsAsset(version)
+    class AzureFunctionsCoreToolsRemoteAsset(version: String, val fileName: String, val downloadUrl: String) : AzureFunctionsCoreToolsAsset(version)
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsManager.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsManager.kt
@@ -34,8 +34,10 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.util.io.HttpRequests
 import com.intellij.util.io.ZipUtil
+import com.jetbrains.rd.util.debug
 import com.jetbrains.rd.util.error
 import com.jetbrains.rd.util.getLogger
+import com.jetbrains.rd.util.string.printToString
 import com.jetbrains.rd.util.warn
 import org.jetbrains.plugins.azure.functions.GitHubReleasesService
 import java.io.File
@@ -248,9 +250,9 @@ object FunctionsCoreToolsManager {
                 return AzureFunctionsCoreToolsRemoteAsset(latestReleaseVersion, latestAsset.name!!, latestAsset.browserDownloadUrl!!)
             }
         } catch (e: UnknownHostException) {
-            logger.error("Could not determine latest remote.", e)
+            logger.warn { "Could not determine latest remote: " + e.printToString() }
         } catch (e: IOException) {
-            logger.error("Could not determine latest remote.", e)
+            logger.warn { "Could not determine latest remote: " + e.printToString() }
         }
 
         return null

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationParameters.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationParameters.kt
@@ -50,6 +50,7 @@ import com.microsoft.intellij.configuration.AzureRiderSettings
 import org.jdom.Element
 import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsInfo
 import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsInfoProvider
+import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsManager
 import java.io.File
 
 open class AzureFunctionsHostConfigurationParameters(
@@ -184,10 +185,8 @@ open class AzureFunctionsHostConfigurationParameters(
                 throw RuntimeConfigurationError("Invalid working directory: ${if (workingDirectory.isNotEmpty()) workingDirectory else "<empty>"}")
         }
 
-        val funcCoreToolsPath = PropertiesComponent.getInstance().getValue(AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH)
-        if (funcCoreToolsPath.isNullOrEmpty() || !File(funcCoreToolsPath).exists()) {
-            throw RuntimeConfigurationError("Path to Azure Functions core tools has not been configured. This can be done in the settings under Tools | Azure | Functions.")
-        }
+        FunctionsCoreToolsInfoProvider.build()
+                ?: throw RuntimeConfigurationError("Path to Azure Functions core tools has not been configured. This can be done in the settings under Tools | Azure | Functions.")
 
         if (useMonoRuntime && riderDotNetActiveRuntimeHost.monoRuntime == null)
             throw RuntimeConfigurationError("Mono runtime not found. " +


### PR DESCRIPTION
Fixes #163:

* There is some commented code for adding project templates into Rider as well, but not yet sure about a good flow there.
* Adds a notification popup that suggests installing/updating functions core tools

![image](https://user-images.githubusercontent.com/485230/54933308-b3755300-4f1c-11e9-8259-96eab5bdaf36.png)

* Adds a configuration page that allows installing/updating/manually setting functions core tools path

![image](https://user-images.githubusercontent.com/485230/54933315-b7a17080-4f1c-11e9-84ee-df77329a63a6.png)