### PR TITLE
Functions: Development: Project templates

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -115,6 +115,7 @@
     <runConfigurationProducer implementation="org.jetbrains.plugins.azure.functions.run.AzureFunctionsConfigurationProducer"/>
 
     <postStartupActivity implementation="org.jetbrains.plugins.azure.functions.AzureCoreToolsNotification" />
+    <projectTemplateProvider implementation="org.jetbrains.plugins.azure.functions.projectTemplating.FunctionsCoreToolsTemplatesProvider" order="first"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.microsoft.intellij">

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/AzureRiderAbstractConfigurable.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/AzureRiderAbstractConfigurable.kt
@@ -25,6 +25,7 @@ package com.microsoft.intellij.configuration
 import com.intellij.application.options.OptionsContainingConfigurable
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.options.SearchableConfigurable
+import com.microsoft.intellij.AzureConfigurable.AZURE_CONFIGURABLE_PREFIX
 import com.microsoft.intellij.configuration.ui.AzureRiderAbstractConfigurablePanel
 import org.jetbrains.annotations.Nls
 import javax.swing.JComponent
@@ -56,7 +57,7 @@ class AzureRiderAbstractConfigurable(private val panel: AzureRiderAbstractConfig
     override fun isModified() = true
 
     override fun getId(): String {
-        return "preferences.sourceCode.$displayName"
+        return AZURE_CONFIGURABLE_PREFIX + displayName
     }
 
     override fun enableSearch(option: String?): Runnable? {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/ui/AzureFunctionsConfigurationPanel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/ui/AzureFunctionsConfigurationPanel.kt
@@ -44,7 +44,7 @@ import javax.swing.JPanel
 class AzureFunctionsConfigurationPanel: AzureRiderAbstractConfigurablePanel {
 
     companion object {
-        private const val DISPLAY_NAME = "Functions"
+        const val DISPLAY_NAME = "Functions"
 
         private const val PATH_TO_CORE_TOOLS = "Azure Functions Core Tools path:"
         private const val CURRENT_VERSION = "Current version:"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/ui/AzureFunctionsConfigurationPanel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/ui/AzureFunctionsConfigurationPanel.kt
@@ -35,6 +35,7 @@ import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import com.microsoft.intellij.configuration.AzureRiderSettings
 import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsManager
+import org.jetbrains.plugins.azure.functions.projectTemplating.FunctionsCoreToolsTemplateManager
 import java.awt.CardLayout
 import java.io.File
 import javax.swing.JLabel
@@ -103,6 +104,8 @@ class AzureFunctionsConfigurationPanel: AzureRiderAbstractConfigurablePanel {
         wrapperLayout.show(installActionPanel, CARD_PROGRESS)
 
         FunctionsCoreToolsManager.downloadLatestRelease(installIndicator) {
+            FunctionsCoreToolsTemplateManager.tryReload()
+
             UIUtil.invokeAndWaitIfNeeded(Runnable {
                 coreToolsPathField.text = it
                 installButton.isEnabled = false

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/AzureCoreToolsNotification.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/AzureCoreToolsNotification.kt
@@ -46,7 +46,7 @@ class AzureCoreToolsNotification : StartupActivity {
         project.solution.runnableProjectsModel.projects.adviseOnce(project.createLifetime()) { runnableProjects ->
             if (runnableProjects.none { it.kind == RunnableProjectKind.AzureFunctions }) return@adviseOnce
 
-            val funcCoreToolsInfo = FunctionsCoreToolsInfoProvider.build()
+            val funcCoreToolsInfo = FunctionsCoreToolsInfoProvider.retrieve()
 
             val local = FunctionsCoreToolsManager.determineVersion(funcCoreToolsInfo?.coreToolsPath)
             val remote = FunctionsCoreToolsManager.determineLatestRemote()

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsInfoProvider.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsInfoProvider.kt
@@ -35,7 +35,7 @@ data class FunctionsCoreToolsInfo(val coreToolsPath: String, var coreToolsExecut
 object FunctionsCoreToolsInfoProvider {
     private val logger = getLogger<FunctionsCoreToolsInfoProvider>()
 
-    fun build(): FunctionsCoreToolsInfo? {
+    fun retrieve(): FunctionsCoreToolsInfo? {
         val funcCoreToolsPath = PropertiesComponent.getInstance().getValue(AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH)
         if (funcCoreToolsPath.isNullOrEmpty() || !File(funcCoreToolsPath).exists()) {
             return null

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsManager.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsManager.kt
@@ -34,11 +34,11 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.util.io.HttpRequests
 import com.intellij.util.io.ZipUtil
-import com.jetbrains.rd.util.debug
 import com.jetbrains.rd.util.error
 import com.jetbrains.rd.util.getLogger
 import com.jetbrains.rd.util.string.printToString
 import com.jetbrains.rd.util.warn
+import com.jetbrains.rider.projectView.actions.projectTemplating.backend.ReSharperProjectTemplateProvider
 import org.jetbrains.plugins.azure.functions.GitHubReleasesService
 import java.io.File
 import java.io.IOException
@@ -148,17 +148,6 @@ object FunctionsCoreToolsManager {
         } catch (e: Exception) {
             logger.error("Error while removing temporary file $tempFile.path", e)
         }
-
-//      // TODO: Should we register project templates?
-//      indicator.text = "Registering templates..."
-//      val templatesFolder = File(latestDirectory.path + File.separator + "templates")
-//      if (templatesFolder.exists()) {
-//          templatesFolder
-//              .listFiles { f: File? -> f != null && f.isFile && f.name.contains("projectTemplates", true) }
-//              .forEach {
-//                  ReSharperProjectTemplateProvider.addUserTemplateSource(it)
-//              }
-//       }
 
         pi.finishNonCancelableSection()
         pi.text = "Finished."

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/FunctionsCoreToolsTemplateManager.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/FunctionsCoreToolsTemplateManager.kt
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2019 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jetbrains.plugins.azure.functions.projectTemplating
+
+import com.jetbrains.rd.util.error
+import com.jetbrains.rd.util.getLogger
+import com.jetbrains.rider.projectView.actions.projectTemplating.backend.ReSharperProjectTemplateProvider
+import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsInfoProvider
+import java.io.File
+
+object FunctionsCoreToolsTemplateManager {
+    private val logger = getLogger<FunctionsCoreToolsTemplateManager>()
+
+    private fun isFunctionsProjectTemplate(file: File?): Boolean =
+            file != null && file.isFile && file.name.startsWith("projectTemplates.", true) && file.name.endsWith(".nupkg", true)
+
+    fun areRegistered(): Boolean =
+            ReSharperProjectTemplateProvider.getUserTemplateSources().any { isFunctionsProjectTemplate(it) }
+
+    fun tryReload() {
+        val coreToolsInfo = FunctionsCoreToolsInfoProvider.retrieve() ?: return
+
+        // Remove previous templates
+        ReSharperProjectTemplateProvider.getUserTemplateSources().forEach {
+            if (isFunctionsProjectTemplate(it)) {
+                ReSharperProjectTemplateProvider.removeUserTemplateSource(it)
+            }
+        }
+
+        // Add available templates
+        val templatesToBeRegisteredFolder = File(coreToolsInfo.coreToolsPath).resolve("templates")
+        if (templatesToBeRegisteredFolder.exists()) {
+            try {
+                templatesToBeRegisteredFolder
+                        .listFiles { f: File? -> isFunctionsProjectTemplate(f) }
+                        .forEach {
+                            ReSharperProjectTemplateProvider.addUserTemplateSource(it)
+                        }
+            } catch (e: Exception) {
+                logger.error("Could not register project templates from ${templatesToBeRegisteredFolder.path}", e)
+            }
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/FunctionsCoreToolsTemplatesProvider.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/FunctionsCoreToolsTemplatesProvider.kt
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2019 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jetbrains.plugins.azure.functions.projectTemplating
+
+import com.intellij.openapi.util.IconLoader
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.reactive.IOptProperty
+import com.jetbrains.rd.util.reactive.OptProperty
+import com.jetbrains.rd.util.reactive.Property
+import com.jetbrains.rider.projectView.actions.projectTemplating.RiderProjectTemplate
+import com.jetbrains.rider.projectView.actions.projectTemplating.RiderProjectTemplateGenerator
+import com.jetbrains.rider.projectView.actions.projectTemplating.RiderProjectTemplateProvider
+import com.jetbrains.rider.projectView.actions.projectTemplating.RiderProjectTemplateState
+import com.jetbrains.rider.projectView.actions.projectTemplating.common.InfoProjectTemplateGeneratorBase
+import com.jetbrains.rider.projectView.actions.projectTemplating.impl.ProjectTemplateDialog
+import com.jetbrains.rider.projectView.actions.projectTemplating.impl.ProjectTemplateDialogContext
+import com.jetbrains.rider.projectView.actions.projectTemplating.impl.ProjectTemplateTransferableModel
+import com.jetbrains.rider.util.idea.application
+import javax.swing.*
+
+class FunctionsCoreToolsTemplatesProvider : RiderProjectTemplateProvider {
+    override val isReady = Property(true)
+
+    override fun load(lifetime: Lifetime, context: ProjectTemplateDialogContext): IOptProperty<RiderProjectTemplateState> {
+        val state = RiderProjectTemplateState(arrayListOf(), arrayListOf())
+
+        if (!FunctionsCoreToolsTemplateManager.areRegistered()) {
+            FunctionsCoreToolsTemplateManager.tryReload()
+        }
+
+        if (!FunctionsCoreToolsTemplateManager.areRegistered()) {
+            state.new.add(InstallTemplates())
+        }
+
+        return OptProperty(state)
+    }
+
+    private class InstallTemplates : RiderProjectTemplate {
+        override val group: String?
+            get() = ".NET Core"
+        override val name: String
+            get() = "Azure Functions"
+        override val icon: Icon
+            get() = IconLoader.getIcon("icons/FunctionApp.svg")
+
+        override fun getKeywords() = arrayOf(name)
+
+        override fun createGenerator(context: ProjectTemplateDialogContext, transferableModel: ProjectTemplateTransferableModel): RiderProjectTemplateGenerator {
+            return object : InfoProjectTemplateGeneratorBase() {
+
+                override val expandActionName: String
+                    get() = "Reload"
+
+                override fun expand() {
+                    // just close dialog and show again to refresh templates
+                    application.invokeLater {
+                        ProjectTemplateDialog.show(context.project, context.item)
+                    }
+                }
+
+                override fun getComponent(): JComponent {
+                    return InstallFunctionsCoreToolsComponent(this.validationError).getView()
+                }
+            }
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/InstallFunctionsCoreToolsComponent.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/InstallFunctionsCoreToolsComponent.kt
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2019 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jetbrains.plugins.azure.functions.projectTemplating
+
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.util.ui.JBUI
+import com.jetbrains.rd.util.reactive.IProperty
+import com.jetbrains.rider.ui.components.ComponentFactories
+import com.jetbrains.rider.ui.components.base.Viewable
+import net.miginfocom.swing.MigLayout
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+class InstallFunctionsCoreToolsComponent(private val validationError: IProperty<String?>) : Viewable<JComponent> {
+    val pane = JPanel(MigLayout("fill, ins 0, flowy, gap ${JBUI.scale(2)}", "[push]", "[min!][grow]"))
+
+    override fun getView(): JComponent {
+        return pane
+    }
+
+    init {
+        val topPane = JPanel(MigLayout("ins 0, gap ${JBUI.scale(1)}, flowy, fill, left", "[push]")).apply {
+            add(ComponentFactories.titleLabel("Azure Functions Project Templates"))
+            add(ComponentFactories.multiLineLabelPane("Rider requires the Azure Functions Core Tools to be installed and configured to create new Azure Functions projects."),
+                    "growx, gapbottom ${JBUI.scale(1)}")
+            add(ComponentFactories.hyperlinkLabel("Configure Azure Functions Core Tools...") {
+                ShowSettingsUtil.getInstance().showSettingsDialog(null, "preferences.sourceCode.Functions")
+                validationError.set(null)
+            })
+        }
+        pane.add(topPane, "growx")
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/InstallFunctionsCoreToolsComponent.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/InstallFunctionsCoreToolsComponent.kt
@@ -22,7 +22,8 @@
 
 package org.jetbrains.plugins.azure.functions.projectTemplating
 
-import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.ide.actions.ShowSettingsUtilImpl
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.util.ui.JBUI
 import com.jetbrains.rd.util.reactive.IProperty
 import com.jetbrains.rider.ui.components.ComponentFactories
@@ -46,7 +47,8 @@ class InstallFunctionsCoreToolsComponent(private val validationError: IProperty<
             add(ComponentFactories.multiLineLabelPane("Rider requires the Azure Functions Core Tools to be installed and configured to create new Azure Functions projects."),
                     "growx, gapbottom ${JBUI.scale(1)}")
             add(ComponentFactories.hyperlinkLabel("Configure Azure Functions Core Tools...") {
-                ShowSettingsUtil.getInstance().showSettingsDialog(null, AZURE_CONFIGURABLE_PREFIX + AzureFunctionsConfigurationPanel.DISPLAY_NAME)
+                val project = ProjectManager.getInstance().defaultProject
+                ShowSettingsUtilImpl.showSettingsDialog(project, AZURE_CONFIGURABLE_PREFIX + AzureFunctionsConfigurationPanel.DISPLAY_NAME, "")
                 validationError.set(null)
             })
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/InstallFunctionsCoreToolsComponent.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/InstallFunctionsCoreToolsComponent.kt
@@ -27,6 +27,8 @@ import com.intellij.util.ui.JBUI
 import com.jetbrains.rd.util.reactive.IProperty
 import com.jetbrains.rider.ui.components.ComponentFactories
 import com.jetbrains.rider.ui.components.base.Viewable
+import com.microsoft.intellij.AzureConfigurable.AZURE_CONFIGURABLE_PREFIX
+import com.microsoft.intellij.configuration.ui.AzureFunctionsConfigurationPanel
 import net.miginfocom.swing.MigLayout
 import javax.swing.JComponent
 import javax.swing.JPanel
@@ -44,7 +46,7 @@ class InstallFunctionsCoreToolsComponent(private val validationError: IProperty<
             add(ComponentFactories.multiLineLabelPane("Rider requires the Azure Functions Core Tools to be installed and configured to create new Azure Functions projects."),
                     "growx, gapbottom ${JBUI.scale(1)}")
             add(ComponentFactories.hyperlinkLabel("Configure Azure Functions Core Tools...") {
-                ShowSettingsUtil.getInstance().showSettingsDialog(null, "preferences.sourceCode.Functions")
+                ShowSettingsUtil.getInstance().showSettingsDialog(null, AZURE_CONFIGURABLE_PREFIX + AzureFunctionsConfigurationPanel.DISPLAY_NAME)
                 validationError.set(null)
             })
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationParameters.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationParameters.kt
@@ -102,7 +102,7 @@ open class AzureFunctionsHostConfigurationParameters(
         val runnableProject = tryGetRunnableProject() ?: throw CantRunException("Project is not specified")
         val projectOutput = tryGetProjectOutput(runnableProject)
 
-        val coreToolsInfo: FunctionsCoreToolsInfo? = FunctionsCoreToolsInfoProvider.build()
+        val coreToolsInfo: FunctionsCoreToolsInfo? = FunctionsCoreToolsInfoProvider.retrieve()
                 ?: throw CantRunException("Can't run Azure Functions host - path to core tools has not been configured.")
 
         val effectiveWorkingDirectory = if (trackProjectWorkingDirectory && projectOutput != null) {
@@ -185,7 +185,7 @@ open class AzureFunctionsHostConfigurationParameters(
                 throw RuntimeConfigurationError("Invalid working directory: ${if (workingDirectory.isNotEmpty()) workingDirectory else "<empty>"}")
         }
 
-        FunctionsCoreToolsInfoProvider.build()
+        FunctionsCoreToolsInfoProvider.retrieve()
                 ?: throw RuntimeConfigurationError("Path to Azure Functions core tools has not been configured. This can be done in the settings under Tools | Azure | Functions.")
 
         if (useMonoRuntime && riderDotNetActiveRuntimeHost.monoRuntime == null)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostExecutorFactory.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostExecutorFactory.kt
@@ -39,7 +39,7 @@ class AzureFunctionsHostExecutorFactory(
     private val logger = getLogger<AzureFunctionsHostExecutorFactory>()
 
     override fun create(executorId: String, environment: ExecutionEnvironment): RunProfileState {
-        val coreToolsInfo: FunctionsCoreToolsInfo? = FunctionsCoreToolsInfoProvider.build()
+        val coreToolsInfo: FunctionsCoreToolsInfo? = FunctionsCoreToolsInfoProvider.retrieve()
                 ?: throw CantRunException("Can't run Azure Functions host - path to core tools has not been configured.")
 
         val projectKind = parameters.projectKind

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzureConfigurable.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzureConfigurable.java
@@ -42,6 +42,7 @@ import static com.microsoft.intellij.ui.messages.AzureBundle.message;
 public class AzureConfigurable extends SearchableConfigurable.Parent.Abstract implements OptionsContainingConfigurable {
     public static final String AZURE_PLUGIN_NAME = "Microsoft Tools";
     public static final String AZURE_PLUGIN_ID = "com.microsoft.intellij";
+    public static final String AZURE_CONFIGURABLE_PREFIX = "preferences.sourceCode.";
 
     private java.util.List<Configurable> myPanels;
     private final Project myProject;
@@ -151,7 +152,7 @@ public class AzureConfigurable extends SearchableConfigurable.Parent.Abstract im
         @NotNull
         @Override
         public String getId() {
-            return "preferences.sourceCode." + getDisplayName();
+            return AZURE_CONFIGURABLE_PREFIX + getDisplayName();
         }
 
         @Nullable


### PR DESCRIPTION
Fixes #151.

When Azure Functions Core Tools are not configured, the new solution/new project dialog renders a placeholder project template:

![Placeholder template](https://user-images.githubusercontent.com/485230/55069653-d0c53100-5084-11e9-991c-5397e3dbc87e.png)

Once downloaded/configured, the project template from Azure Functions Core Tools (and its default unattractive name/icon for which I [opened a PR](https://github.com/Azure/azure-functions-templates/pull/856)) are displayed instead:

![Azure Functions Project Template](https://user-images.githubusercontent.com/485230/55069723-ffdba280-5084-11e9-8784-d88b57e6c333.png)