### PR TITLE
Fix RIDER-23413. Replace an old sync call for project target check wi…

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/component/PublishableProjectComponent.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/component/PublishableProjectComponent.kt
@@ -25,9 +25,7 @@ package com.microsoft.intellij.component
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
-import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.util.IconLoader
-import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.ui.LayeredIcon
 import com.intellij.ui.ListCellRendererWrapper
@@ -37,7 +35,6 @@ import com.jetbrains.rider.projectView.nodes.isProject
 import com.jetbrains.rider.projectView.nodes.isUnloadedProject
 import com.microsoft.intellij.component.extension.fillComboBox
 import com.microsoft.intellij.component.extension.getSelectedValue
-import com.microsoft.intellij.helpers.validator.ProjectValidator
 import net.miginfocom.swing.MigLayout
 import java.io.File
 import javax.swing.JLabel

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/component/appservice/ExistingAppsTableComponent.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/component/appservice/ExistingAppsTableComponent.kt
@@ -149,7 +149,7 @@ open class ExistingAppsTableComponent<T : WebAppBase> :
         val table = object : JBTable(tableModel) {
             override fun getPreferredScrollableViewportSize(): Dimension? {
                 val minHeight = JBUI.scale(200)
-                val subtractHeight = JBUI.scale(420) // Height of all components, but web apps table (experimental value)
+                val subtractHeight = JBUI.scale(430) // Height of all components, but web apps table (experimental value)
                 return Dimension(-1, Math.max(topLevelAncestor?.height?.minus(subtractHeight) ?: minHeight, minHeight))
             }
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/component/extension/ComboBoxExtensions.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/component/extension/ComboBoxExtensions.kt
@@ -33,6 +33,8 @@ fun <T>JComboBox<T>.getSelectedValue(): T? {
     return getItemAt(index)
 }
 
+fun <T>JComboBox<T>.getAllItems() = List(itemCount) { index -> getItemAt(index) }
+
 fun <T>JComboBox<T>.fillComboBox(elements: List<T>, defaultElement: T? = null) {
     fillComboBox<T>(elements) { element -> element != null && element == defaultElement }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/helpers/validator/ProjectValidator.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/helpers/validator/ProjectValidator.kt
@@ -23,7 +23,6 @@
 package com.microsoft.intellij.helpers.validator
 
 import com.intellij.openapi.util.SystemInfo
-import com.jetbrains.rd.framework.impl.RpcTimeouts
 import com.jetbrains.rider.model.PublishableProjectModel
 
 object ProjectValidator : AzureResourceValidator() {
@@ -37,14 +36,10 @@ object ProjectValidator : AzureResourceValidator() {
             "Selected project '%s' cannot be published. Publishing .Net Web Apps is not yet supported on '%s'"
 
     private const val PROJECT_TARGETS_NOT_DEFINED =
-            "Selected project '%s' cannot be published. Required target '%s' was not found."
+            "Selected project '%s' cannot be published. Required target 'WebPublish' was not found."
 
     private const val PROJECT_NOT_FUNCTION_APP =
             "Selected project '%s' cannot be published. Please select a Function App"
-
-    private const val WEB_APP_TARGET_NAME = "Microsoft.WebApplication.targets"
-
-    private val timeouts = RpcTimeouts(500L, 2000L)
 
     /**
      * Validate publishable project in the config
@@ -64,9 +59,9 @@ object ProjectValidator : AzureResourceValidator() {
             return status.setInvalid(
                     String.format(PROJECT_PUBLISHING_OS_NOT_SUPPORTED, publishableProject.projectName, SystemInfo.OS_NAME))
 
-        if (!publishableProject.isDotNetCore && !isWebTargetsPresent(publishableProject))
+        if (!publishableProject.isDotNetCore && !publishableProject.hasWebPublishTarget)
             return status.setInvalid(
-                    String.format(PROJECT_TARGETS_NOT_DEFINED, publishableProject.projectName, WEB_APP_TARGET_NAME))
+                    String.format(PROJECT_TARGETS_NOT_DEFINED, publishableProject.projectName))
 
         return status
     }
@@ -87,13 +82,4 @@ object ProjectValidator : AzureResourceValidator() {
 
     private fun isPublishToFunctionAppSupported(publishableProject: PublishableProjectModel) =
             publishableProject.isAzureFunction
-
-    /**
-     * Check whether necessary targets exists in a project that are necessary for web app deployment
-     * Note: On Windows only
-     *
-     * @return [Boolean] whether WebApplication targets are present in publishable project
-     */
-    private fun isWebTargetsPresent(publishableProject: PublishableProjectModel) =
-            publishableProject.hasTarget.sync(WEB_APP_TARGET_NAME, timeouts)
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/ui/WebAppPublishComponent.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/ui/WebAppPublishComponent.kt
@@ -38,11 +38,12 @@ import com.microsoft.azuretools.core.mvp.model.ResourceEx
 import com.microsoft.intellij.component.ExistingOrNewSelector
 import com.microsoft.intellij.component.AzureComponent
 import com.microsoft.intellij.component.PublishableProjectComponent
-import com.microsoft.intellij.component.appservice.*
 import com.microsoft.intellij.component.extension.getSelectedValue
 import com.microsoft.intellij.component.extension.setComponentsVisible
 import com.microsoft.intellij.configuration.AzureRiderSettings
 import com.microsoft.intellij.runner.webapp.model.WebAppPublishModel
+import com.microsoft.intellij.component.appservice.AppAfterPublishSettingPanel
+import com.microsoft.intellij.component.appservice.AppExistingComponent
 import net.miginfocom.swing.MigLayout
 import javax.swing.JPanel
 


### PR DESCRIPTION
…th property check

- Repace logic that make a sync call to backend to get information about targets for a publishable project with checking for a predefined publish targets for a project that already exists. This fi the UI thread freeze when checking run configuration