### PR TITLE
Replace the providerId for build task

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/buildTasks/BuildFunctionsProjectBeforeRunTaskProvider.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/buildTasks/BuildFunctionsProjectBeforeRunTaskProvider.kt
@@ -41,14 +41,14 @@ import javax.swing.Icon
 
 class BuildFunctionsProjectBeforeRunTaskProvider : BeforeRunTaskProvider<BuildProjectBeforeRunTask>(){
     companion object {
-        val providerId = Key.create<BuildProjectBeforeRunTask>("Build")
+        val providerId = Key.create<BuildProjectBeforeRunTask>("BuildFunctionsProject")
     }
 
     override fun getId(): Key<BuildProjectBeforeRunTask>? = providerId
 
-    override fun getName(): String? = "Build Project"
+    override fun getName(): String? = "Build Functions Project"
 
-    override fun getDescription(task: BuildProjectBeforeRunTask?): String? = "Build project"
+    override fun getDescription(task: BuildProjectBeforeRunTask?): String? = "Build Functions project"
 
     override fun isConfigurable(): Boolean {
         return false


### PR DESCRIPTION
This PR will fix [RIDER-27409](https://youtrack.jetbrains.com/issue/RIDER-27409).

The build task provider was clashing with the provider inside of the Rider core, and was discovered instead of the default one, which caused disappearance of the default "Build" task from the standard project types.