### PR TITLE
Cloud Shell - Support web preview #199

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -176,6 +176,7 @@
            text="Azure Cloud Shell"
            description="Contains Azure Cloud Shell actions"
            icon="/icons/AzureOpenCloudShell.svg">
+
       <add-to-group group-id="AzureToolkit.AzureActionGroup"
                     anchor="before"
                     relative-to-action="AzureToolkit.AzureSignIn" />
@@ -191,6 +192,25 @@
               text="Upload file to Azure Cloud Shell..."
               description="Upload file to Azure Cloud Shell"
               icon="AllIcons.Actions.Upload" />
+
+      <group id="AzureToolkit.AzureCloudShell.WebPreview"
+             class="com.intellij.openapi.actionSystem.DefaultActionGroup"
+             text="Web preview"
+             description="Web preview"
+             popup="true">
+
+        <action id="AzureToolkit.AzureCloudShell.WebPreview.OpenPortAction"
+                class="org.jetbrains.plugins.azure.cloudshell.actions.OpenCloudShellPortAction"
+                text="Open port..."
+                description="Open web preview port..."
+                icon="AllIcons.Actions.Preview" />
+
+        <group id="AzureToolkit.AzureCloudShell.WebPreview.ClosePortAction"
+                class="org.jetbrains.plugins.azure.cloudshell.actions.CloseCloudShellPortActionGroup"
+                text="Close port"
+                description="Close web preview port..."
+                popup="true" />
+      </group>
 
       <separator />
     </group>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/CloseCloudShellPortActionGroup.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/CloseCloudShellPortActionGroup.kt
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2019 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jetbrains.plugins.azure.cloudshell.actions
+
+import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.PerformInBackgroundOption
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
+import com.jetbrains.rider.util.idea.getComponent
+import org.jetbrains.plugins.azure.cloudshell.CloudShellComponent
+
+class CloseCloudShellPortActionGroup : ActionGroup() {
+    private val logger = Logger.getInstance(OpenCloudShellPortAction::class.java)
+
+    override fun update(e: AnActionEvent) {
+        val project = CommonDataKeys.PROJECT.getData(e.dataContext)
+        val cloudShellComponent = project?.getComponent<CloudShellComponent>()
+
+        e.presentation.isEnabled = CommonDataKeys.PROJECT.getData(e.dataContext) != null
+                && cloudShellComponent != null
+                && cloudShellComponent.activeConnector() != null
+                && cloudShellComponent.activeConnector()!!.openPreviewPorts.any()
+    }
+
+    override fun getChildren(e: AnActionEvent?): Array<AnAction> {
+        if (e?.dataContext == null) return emptyArray()
+
+        val project = CommonDataKeys.PROJECT.getData(e.dataContext)
+        val cloudShellComponent = project?.getComponent<CloudShellComponent>() ?: return emptyArray()
+        val currentConnector = cloudShellComponent.activeConnector() ?: return emptyArray()
+
+        if (!currentConnector.openPreviewPorts.any()) return emptyArray()
+
+        val actions = currentConnector.openPreviewPorts.sorted()
+                .map { CloseCloudShellPortAction(it) }
+                .toMutableList<AnAction>()
+
+        actions.add(Separator())
+        actions.add(CloseAllCloudShellPortsAction)
+
+        return actions.toTypedArray()
+    }
+
+    override fun hideIfNoVisibleChildren(): Boolean {
+        return true
+    }
+}
+
+private class CloseCloudShellPortAction(val port: Int) : AnAction(port.toString()) {
+    private val logger = Logger.getInstance(CloseCloudShellPortAction::class.java)
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabled = true
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = CommonDataKeys.PROJECT.getData(e.dataContext) ?: return
+        val activeConnector = project.getComponent<CloudShellComponent>().activeConnector() ?: return
+
+        ApplicationManager.getApplication().invokeLater {
+            object : Task.Backgroundable(project, "Closing preview port $port in Azure Cloud Shell...", true, PerformInBackgroundOption.DEAF)
+            {
+                override fun run(indicator: ProgressIndicator)
+                {
+                    logger.info("Closing preview port $port in Azure Cloud Shell...")
+                    activeConnector.closePreviewPort(port)
+                }
+            }.queue()
+        }
+    }
+}
+
+private object CloseAllCloudShellPortsAction : AnAction("Close all") {
+    private val logger = Logger.getInstance(CloseCloudShellPortAction::class.java)
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabled = true
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = CommonDataKeys.PROJECT.getData(e.dataContext) ?: return
+        val activeConnector = project.getComponent<CloudShellComponent>().activeConnector() ?: return
+
+        ApplicationManager.getApplication().invokeLater {
+            object : Task.Backgroundable(project, "Closing all preview ports in Azure Cloud Shell...", true, PerformInBackgroundOption.DEAF)
+            {
+                override fun run(indicator: ProgressIndicator)
+                {
+                    logger.info("Closing all preview ports in Azure Cloud Shell...")
+                    val ports = activeConnector.openPreviewPorts.toIntArray()
+                    for (port in ports) {
+                        logger.info("Closing port: $port")
+                        activeConnector.closePreviewPort(port)
+                    }
+                }
+            }.queue()
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/OpenCloudShellPortAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/OpenCloudShellPortAction.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 JetBrains s.r.o.
+ * Copyright (c) 2019 JetBrains s.r.o.
  * <p/>
  * All rights reserved.
  * <p/>
@@ -19,6 +19,7 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package org.jetbrains.plugins.azure.cloudshell.actions
 
 import com.intellij.openapi.actionSystem.AnAction
@@ -26,17 +27,16 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.fileChooser.FileChooser
-import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.progress.PerformInBackgroundOption
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
-import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.ui.InputValidator
+import com.intellij.openapi.ui.Messages
 import com.jetbrains.rider.util.idea.getComponent
 import org.jetbrains.plugins.azure.cloudshell.CloudShellComponent
 
-class UploadToAzureCloudShellAction : AnAction() {
-    private val logger = Logger.getInstance(UploadToAzureCloudShellAction::class.java)
+class OpenCloudShellPortAction : AnAction() {
+    private val logger = Logger.getInstance(OpenCloudShellPortAction::class.java)
 
     override fun update(e: AnActionEvent) {
         val project = CommonDataKeys.PROJECT.getData(e.dataContext)
@@ -51,25 +51,42 @@ class UploadToAzureCloudShellAction : AnAction() {
         val project = CommonDataKeys.PROJECT.getData(e.dataContext) ?: return
         val activeConnector = project.getComponent<CloudShellComponent>().activeConnector() ?: return
 
-        ApplicationManager.getApplication().invokeLater {
-            val descriptor = FileChooserDescriptor(true, false, false, true, false, true)
-            descriptor.title = "Select file(s) to upload to Azure Cloud Shell"
-            FileChooser.chooseFiles(descriptor, project, null, null, object : FileChooser.FileChooserConsumer {
-                override fun consume(files: List<VirtualFile>) {
-                    files.forEach {
-                        object : Task.Backgroundable(project, "Uploading file " + it.presentableName + " to Azure Cloud Shell...", true, PerformInBackgroundOption.DEAF)
-                        {
-                            override fun run(indicator: ProgressIndicator)
-                            {
-                                logger.info("Uploading ${it.name} to Azure Cloud Shell...")
-                                activeConnector.uploadFile(it.name, it)
-                            }
-                        }.queue()
-                    }
-                }
+        val port = Messages.showInputDialog(project,
+                "Configure port to preview (in ranges [1025-8079] and [8091-49151]):",
+                "Configure port to preview",
+                null,
+                null,
+                PreviewPortInputValidator.INSTANCE)?.toIntOrNull() ?: return
 
-                override fun cancelled() {}
-            })
+        ApplicationManager.getApplication().invokeLater {
+            object : Task.Backgroundable(project, "Opening preview port $port in Azure Cloud Shell...", true, PerformInBackgroundOption.DEAF)
+            {
+                override fun run(indicator: ProgressIndicator)
+                {
+                    logger.info("Opening preview port $port in Azure Cloud Shell...")
+                    activeConnector.openPreviewPort(port, true)
+                }
+            }.queue()
+        }
+    }
+
+    private class PreviewPortInputValidator : InputValidator {
+        companion object {
+            val INSTANCE = PreviewPortInputValidator()
+        }
+
+        override fun checkInput(input: String?): Boolean {
+            return try {
+                val port = input?.toIntOrNull()
+
+                port != null && ((port in 1025..8079) || (port in 8091..49151))
+            } catch(e: Exception) {
+                false
+            }
+        }
+
+        override fun canClose(input: String?): Boolean {
+            return checkInput(input)
         }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/rest/CloudConsoleService.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/rest/CloudConsoleService.kt
@@ -44,6 +44,14 @@ interface CloudConsoleService {
     fun resizeTerminal(@Url shellUrl: String, @Query("cols") columns: Int, @Query("rows") rows: Int, @Query("version") version: String = "2018-06-01"): Call<Void>
 
     @POST
+    @Headers(*arrayOf("Accept: application/json", "Content-type: application/json"))
+    fun openPreviewPort(@Url portUrl: String): Call<PreviewPortResult>
+
+    @POST
+    @Headers(*arrayOf("Accept: application/json", "Content-type: application/json"))
+    fun closePreviewPort(@Url portUrl: String): Call<PreviewPortResult>
+
+    @POST
     @Multipart
     fun uploadFileToTerminal(@Url shellUrl: String, @Part file: MultipartBody.Part, @Query("version") version: String = "2018-06-01"): Call<Void>
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/rest/PreviewPortResult.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/rest/PreviewPortResult.kt
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2019 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jetbrains.plugins.azure.cloudshell.rest
+
+class PreviewPortResult(val message: String?, val url: String?)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/terminal/AzureCloudProcessTtyConnector.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/terminal/AzureCloudProcessTtyConnector.kt
@@ -32,6 +32,12 @@ abstract class AzureCloudProcessTtyConnector(process: CloudTerminalProcess)
 
     abstract fun uploadFile(fileName: String, file: VirtualFile)
 
+    val openPreviewPorts = mutableListOf<Int>()
+
+    abstract fun openPreviewPort(port: Int, openInBrowser: Boolean)
+
+    abstract fun closePreviewPort(port: Int)
+
     override fun read(buf: CharArray?, offset: Int, length: Int): Int {
         try {
             return super.read(buf, offset, length)


### PR DESCRIPTION
Fixes #199 and adds support for opening up preview ports (proxying cloud shell over the public Internet).

Demo:

![webpreviewport](https://user-images.githubusercontent.com/485230/57605767-b1686180-7567-11e9-947d-c1c4379f465d.gif)
