### PR TITLE
Azure Functions - Can't check/download core tools when last release is not a full release

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -1,7 +1,7 @@
 javaVersion=1.8
 org.gradle.jvmargs='-Duser.language=en'
 sources=false
-idea_version=IC-LATEST-EAP-SNAPSHOT
+idea_version=IC-191-EAP-SNAPSHOT
 rider_version=RD-2019.1-SNAPSHOT
 build_common_code_with=rider
 dep_plugins=org.intellij.scala:2019.1.5

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -101,7 +101,7 @@
   <xi:include href="/META-INF/platformPlugin.xml" xpointer="xpointer(/idea-plugin/*)"/>
 
   <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-  <idea-version since-build="181.*" until-build="181.*"/>
+  <idea-version since-build="191.*" until-build="191.*"/>
 
   <depends>com.intellij.modules.rider</depends>
   <depends>com.intellij.database</depends>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/AzureCoreToolsNotification.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/AzureCoreToolsNotification.kt
@@ -24,6 +24,7 @@ package org.jetbrains.plugins.azure.functions
 
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.notification.*
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
@@ -46,45 +47,47 @@ class AzureCoreToolsNotification : StartupActivity {
         project.solution.runnableProjectsModel.projects.adviseOnce(project.createLifetime()) { runnableProjects ->
             if (runnableProjects.none { it.kind == RunnableProjectKind.AzureFunctions }) return@adviseOnce
 
-            val funcCoreToolsInfo = FunctionsCoreToolsInfoProvider.retrieve()
+            ApplicationManager.getApplication().executeOnPooledThread {
+                val funcCoreToolsInfo = FunctionsCoreToolsInfoProvider.retrieve()
 
-            val local = FunctionsCoreToolsManager.determineVersion(funcCoreToolsInfo?.coreToolsPath)
-            val remote = FunctionsCoreToolsManager.determineLatestRemote()
+                val local = FunctionsCoreToolsManager.determineVersion(funcCoreToolsInfo?.coreToolsPath)
+                val remote = FunctionsCoreToolsManager.determineLatestRemote()
 
-            if (local == null || remote != null && local < remote) {
-                val title = if (local == null) {
-                    "Install Azure Functions Core Tools"
-                } else {
-                    "Update Azure Functions Core Tools"
-                }
+                if (local == null || remote != null && local < remote) {
+                    val title = if (local == null) {
+                        "Install Azure Functions Core Tools"
+                    } else {
+                        "Update Azure Functions Core Tools"
+                    }
 
-                val description = if (local == null) {
-                    "<a href='install'>Install the Azure Functions Core Tools</a> to develop, run and debug Azure Functions locally."
-                } else {
-                    "A newer version of the Azure Functions Core Tools is available. <a href='install'>Update now</a>"
-                }
+                    val description = if (local == null) {
+                        "<a href='install'>Install the Azure Functions Core Tools</a> to develop, run and debug Azure Functions locally."
+                    } else {
+                        "A newer version of the Azure Functions Core Tools is available. <a href='install'>Update now</a>"
+                    }
 
-                val notification = notificationGroup.createNotification(
-                        title, null, description,
-                        NotificationType.INFORMATION,
-                        object : NotificationListener.Adapter() {
-                            override fun hyperlinkActivated(notification: Notification, e: HyperlinkEvent) {
-                                if (!project.isDisposed) {
-                                    when (e.description) {
-                                        "install" -> {
-                                            ProgressManager.getInstance().run(
-                                                    FunctionsCoreToolsManager.downloadLatestRelease(project) {
-                                                        PropertiesComponent.getInstance().setValue(
-                                                                AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH, it)
-                                                        notification.expire()
-                                                    })
+                    val notification = notificationGroup.createNotification(
+                            title, null, description,
+                            NotificationType.INFORMATION,
+                            object : NotificationListener.Adapter() {
+                                override fun hyperlinkActivated(notification: Notification, e: HyperlinkEvent) {
+                                    if (!project.isDisposed) {
+                                        when (e.description) {
+                                            "install" -> {
+                                                ProgressManager.getInstance().run(
+                                                        FunctionsCoreToolsManager.downloadLatestRelease(project) {
+                                                            PropertiesComponent.getInstance().setValue(
+                                                                    AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH, it)
+                                                            notification.expire()
+                                                        })
+                                            }
                                         }
                                     }
                                 }
-                            }
-                        })
+                            })
 
-                Notifications.Bus.notify(notification, project)
+                    Notifications.Bus.notify(notification, project)
+                }
             }
         }
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/GitHubReleases.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/GitHubReleases.kt
@@ -42,7 +42,7 @@ interface GitHubReleasesService {
 
     @GET
     @Headers("Accept: application/json")
-    fun getLatestRelease(@Url latestReleaseUrl: String): Call<GitHubRelease>
+    fun getReleases(@Url releasesUrl: String): Call<List<GitHubRelease>>
 }
 
 class GitHubRelease(val url: String?,


### PR DESCRIPTION
Fixes #207 by checking latest page of releases instead of only latest.