### PR TITLE
Azure Functions - Can't check/download core tools when last release is not a full release

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/GitHubReleases.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/GitHubReleases.kt
@@ -42,7 +42,7 @@ interface GitHubReleasesService {
 
     @GET
     @Headers("Accept: application/json")
-    fun getLatestRelease(@Url latestReleaseUrl: String): Call<GitHubRelease>
+    fun getReleases(@Url releasesUrl: String): Call<List<GitHubRelease>>
 }
 
 class GitHubRelease(val url: String?,


### PR DESCRIPTION
Cherry-pick bugfix for #207 against `192`