### PR TITLE
Added live templates for Durable Functions methods

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/dotnet/Extensions/com.intellij.resharper.azure/settings/templates.dotSettings
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/dotnet/Extensions/com.intellij.resharper.azure/settings/templates.dotSettings
@@ -531,6 +531,87 @@ namespace $NAMESPACE$
         }
     }
 }</s:String>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/@KeyIndexDefined">True</s:Boolean>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/Applicability/=Live/@EntryIndexedValue">True</s:Boolean>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/Description/@EntryValue">Creates an activity function method</s:String>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/Field/=ActivityClassName/@KeyIndexDefined">True</s:Boolean>
+    <s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/Field/=ActivityClassName/Order/@EntryValue">0</s:Int64>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/Field/=InputType/@KeyIndexDefined">True</s:Boolean>
+    <s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/Field/=InputType/Order/@EntryValue">2</s:Int64>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/Field/=OutputType/@KeyIndexDefined">True</s:Boolean>
+    <s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/Field/=OutputType/Order/@EntryValue">1</s:Int64>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/Reformat/@EntryValue">True</s:Boolean>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/Scope/=C3001E7C0DA78E4487072B7E050D86C5/@KeyIndexDefined">True</s:Boolean>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/Scope/=C3001E7C0DA78E4487072B7E050D86C5/CustomProperties/=minimumLanguageVersion/@EntryIndexedValue">2.0</s:String>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/Scope/=C3001E7C0DA78E4487072B7E050D86C5/Type/@EntryValue">InCSharpFile</s:String>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/Shortcut/@EntryValue">funcac</s:String>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/ShortenQualifiedReferences/@EntryValue">True</s:Boolean>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=30111C58960418448EBD57679251F1B5/Text/@EntryValue">[FunctionName(nameof($ActivityClassName$))]
+public async Task&lt;$OutputType$&gt; Run(
+    [ActivityTrigger] $InputType$ input,
+    ILogger logger)
+{
+    $END$
+    // TODO
+}</s:String>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=5D9C03E36C88DE4C9BBC9E1155D879EE/@KeyIndexDefined">True</s:Boolean>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=5D9C03E36C88DE4C9BBC9E1155D879EE/Applicability/=Live/@EntryIndexedValue">True</s:Boolean>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=5D9C03E36C88DE4C9BBC9E1155D879EE/Description/@EntryValue">Creates an orchestration client function method</s:String>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=5D9C03E36C88DE4C9BBC9E1155D879EE/Field/=OrchestrationClientClassName/@KeyIndexDefined">True</s:Boolean>
+    <s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=5D9C03E36C88DE4C9BBC9E1155D879EE/Field/=OrchestrationClientClassName/Order/@EntryValue">0</s:Int64>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=5D9C03E36C88DE4C9BBC9E1155D879EE/Field/=Trigger/@KeyIndexDefined">True</s:Boolean>
+    <s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=5D9C03E36C88DE4C9BBC9E1155D879EE/Field/=Trigger/Order/@EntryValue">1</s:Int64>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=5D9C03E36C88DE4C9BBC9E1155D879EE/Reformat/@EntryValue">True</s:Boolean>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=5D9C03E36C88DE4C9BBC9E1155D879EE/Scope/=C3001E7C0DA78E4487072B7E050D86C5/@KeyIndexDefined">True</s:Boolean>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=5D9C03E36C88DE4C9BBC9E1155D879EE/Scope/=C3001E7C0DA78E4487072B7E050D86C5/CustomProperties/=minimumLanguageVersion/@EntryIndexedValue">2.0</s:String>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=5D9C03E36C88DE4C9BBC9E1155D879EE/Scope/=C3001E7C0DA78E4487072B7E050D86C5/Type/@EntryValue">InCSharpFile</s:String>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=5D9C03E36C88DE4C9BBC9E1155D879EE/Shortcut/@EntryValue">funccl</s:String>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=5D9C03E36C88DE4C9BBC9E1155D879EE/ShortenQualifiedReferences/@EntryValue">True</s:Boolean>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=5D9C03E36C88DE4C9BBC9E1155D879EE/Text/@EntryValue">[FunctionName(nameof($OrchestrationClientClassName$))]
+public async Task Run(
+    $Trigger$,
+    [OrchestrationClient] DurableOrchestrationClientBase client,
+    ILogger logger)
+{
+    $END$
+    // TODO
+    // var input = ;
+    // string instanceId = await client.StartNewAsync(
+    //    nameof(OrchestrationClassName), 
+    //    input);
+}</s:String>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=D828595513AC9A46AAD55B3EF6AD3DC6/@KeyIndexDefined">True</s:Boolean>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=D828595513AC9A46AAD55B3EF6AD3DC6/Applicability/=Live/@EntryIndexedValue">True</s:Boolean>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=D828595513AC9A46AAD55B3EF6AD3DC6/Description/@EntryValue">Creates an orchestrator function method</s:String>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=D828595513AC9A46AAD55B3EF6AD3DC6/Field/=OrchestratorClassName/@KeyIndexDefined">True</s:Boolean>
+    <s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=D828595513AC9A46AAD55B3EF6AD3DC6/Field/=OrchestratorClassName/Order/@EntryValue">0</s:Int64>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=D828595513AC9A46AAD55B3EF6AD3DC6/Reformat/@EntryValue">True</s:Boolean>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=D828595513AC9A46AAD55B3EF6AD3DC6/Scope/=C3001E7C0DA78E4487072B7E050D86C5/@KeyIndexDefined">True</s:Boolean>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=D828595513AC9A46AAD55B3EF6AD3DC6/Scope/=C3001E7C0DA78E4487072B7E050D86C5/CustomProperties/=minimumLanguageVersion/@EntryIndexedValue">2.0</s:String>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=D828595513AC9A46AAD55B3EF6AD3DC6/Scope/=C3001E7C0DA78E4487072B7E050D86C5/Type/@EntryValue">InCSharpFile</s:String>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=D828595513AC9A46AAD55B3EF6AD3DC6/Shortcut/@EntryValue">funcor</s:String>
+    <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=D828595513AC9A46AAD55B3EF6AD3DC6/ShortenQualifiedReferences/@EntryValue">True</s:Boolean>
+    <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=D828595513AC9A46AAD55B3EF6AD3DC6/Text/@EntryValue">[FunctionName(nameof($OrchestratorClassName$))]
+public async Task Run(
+    [OrchestrationTrigger] DurableOrchestrationContextBase context,
+    ILogger logger)
+{
+    $END$
+    // Since the orchestrator code is being replayed many times
+    // don't depend on non-deterministic behavior or blocking calls such as:
+    // - DateTime.Now (use context.CurrentUtcDateTime instead)
+    // - Guid.NewGuid (use context.NewGuid instead)
+    // - System.IO
+    // - Thread.Sleep/Task.Delay (use context.CreateTimer instead)
+    //
+    // More info: https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-checkpointing-and-replay#orchestrator-code-constraints
+ 
+    // TODO
+    // var input = context.GetInput&lt;T&gt;();
+    // var activityResult = await context.CallActivityAsync&lt;string&gt;(
+    //    nameof(ActivityClassName),
+    //    input));
+}</s:String>
     <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=F7EE3A0674610547AB87B8FC949B596A/@KeyIndexDefined">True</s:Boolean>
     <s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=F7EE3A0674610547AB87B8FC949B596A/Applicability/=File/@EntryIndexedValue">True</s:Boolean>
     <s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=F7EE3A0674610547AB87B8FC949B596A/CustomProperties/=Extension/@EntryIndexedValue">cs</s:String>


### PR DESCRIPTION
Based on [a tweet](https://twitter.com/maartenballiauw/status/1146791359296212992) from @maartenba here's a PR which adds three inline live templates related to Azure Durable Functions:
 
- `funccl` to create an orchestration client function method
- `funcor` to create an orchestrator function method
- `funcac` to create an activity function method

1. I noticed that the other templates are creating a full class file while my inline snippets only add the function method. Let me know if you want anything changed there.
2. It is not required anymore to have your functions in static classes and methods. So there's some inconsistency between my samples, which don't use static, and the other samples, which do. Again, let me know what your preference is.