### PR TITLE
Fix #285. Avoid duplicating Azure Functions host configuration groups

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/config/FunctionAppConfigurationFactory.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/config/FunctionAppConfigurationFactory.kt
@@ -30,8 +30,11 @@ import com.intellij.openapi.project.Project
 class FunctionAppConfigurationFactory(type: ConfigurationType) : ConfigurationFactory(type) {
 
     companion object {
+        private const val FACTORY_ID = "AzureFunctionAppFactory"
         private const val FACTORY_NAME = "Azure Function App"
     }
+
+    override fun getId(): String = FACTORY_ID
 
     override fun getName() = FACTORY_NAME
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/config/FunctionAppConfigurationType.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/config/FunctionAppConfigurationType.kt
@@ -24,7 +24,6 @@ package com.microsoft.intellij.runner.functionapp.config
 
 import com.intellij.execution.configurations.ConfigurationType
 import com.microsoft.icons.CommonIcons
-import org.jetbrains.annotations.Nls
 import javax.swing.Icon
 
 class FunctionAppConfigurationType : ConfigurationType {
@@ -35,18 +34,13 @@ class FunctionAppConfigurationType : ConfigurationType {
         private const val RUN_CONFIG_TYPE_DESCRIPTION = "Azure Publish Function App configuration"
     }
 
-    override fun getId(): String {
-        return RUN_CONFIG_TYPE_ID
-    }
+    override fun getId(): String = RUN_CONFIG_TYPE_ID
 
-    @Nls
     override fun getDisplayName() = RUN_CONFIG_TYPE_NAME
 
-    @Nls
     override fun getConfigurationTypeDescription() = RUN_CONFIG_TYPE_DESCRIPTION
 
     override fun getIcon(): Icon = CommonIcons.AzureFunctions.FunctionAppConfigurationType
 
-    override fun getConfigurationFactories() =
-            arrayOf(FunctionAppConfigurationFactory(this))
+    override fun getConfigurationFactories() = arrayOf(FunctionAppConfigurationFactory(this))
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/RiderWebAppConfigurationFactory.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/RiderWebAppConfigurationFactory.kt
@@ -30,8 +30,11 @@ import com.intellij.openapi.project.Project
 class RiderWebAppConfigurationFactory(type: ConfigurationType) : ConfigurationFactory(type) {
 
     companion object {
+        private const val FACTORY_ID = "AzureWebAppFactory"
         private const val FACTORY_NAME = "Azure Web App"
     }
+
+    override fun getId() = FACTORY_ID
 
     override fun getName() = FACTORY_NAME
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsConfigurationProducer.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsConfigurationProducer.kt
@@ -40,11 +40,13 @@ class AzureFunctionsConfigurationProducer
     : LazyRunConfigurationProducer<AzureFunctionsHostConfiguration>() {
 
     override fun getConfigurationFactory(): ConfigurationFactory =
-            AzureFunctionsHostConfigurationFactory(AzureFunctionsHostConfigurationType())
+            AzureFunctionsHostConfigurationType.instance.configurationFactories.first()
 
-    override fun setupConfigurationFromContext(configuration: AzureFunctionsHostConfiguration,
-                                               context: ConfigurationContext, sourceElement: Ref<PsiElement>): Boolean {
-
+    override fun setupConfigurationFromContext(
+            configuration: AzureFunctionsHostConfiguration,
+            context: ConfigurationContext,
+            sourceElement: Ref<PsiElement>
+    ): Boolean {
         val selectedProject = context.getSelectedProject()
         val selectedElement = context.location?.psiElement
         if (selectedProject == null && selectedElement == null) return false
@@ -87,8 +89,10 @@ class AzureFunctionsConfigurationProducer
 
     override fun isPreferredConfiguration(self: ConfigurationFromContext?, other: ConfigurationFromContext?) = true
 
-    override fun isConfigurationFromContext(configurationConfiguration: AzureFunctionsHostConfiguration,
-                                            context: ConfigurationContext): Boolean {
+    override fun isConfigurationFromContext(
+            configurationConfiguration: AzureFunctionsHostConfiguration,
+            context: ConfigurationContext
+    ): Boolean {
         val item = context.getSelectedProject() ?: return false
         return FileUtil.toSystemIndependentName(item.getFile()?.path ?: "") ==
                 configurationConfiguration.parameters.projectFilePath

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationFactory.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationFactory.kt
@@ -37,6 +37,15 @@ import org.jetbrains.plugins.azure.functions.buildTasks.BuildFunctionsProjectBef
 class AzureFunctionsHostConfigurationFactory(type: ConfigurationType)
     : DotNetConfigurationFactoryBase<AzureFunctionsHostConfiguration>(type) {
 
+    companion object {
+        private const val FACTORY_ID = "AzureFunctionsHostFactory"
+        private const val FACTORY_NAME = "Azure functions host factory"
+    }
+
+    override fun getId(): String = FACTORY_ID
+
+    override fun getName(): String = FACTORY_NAME
+
     override fun configureBeforeRunTaskDefaults(providerID: Key<out BeforeRunTask<BeforeRunTask<*>>>?,
                                                 task: BeforeRunTask<out BeforeRunTask<*>>?) {
         if (providerID == BuildFunctionsProjectBeforeRunTaskProvider.providerId && task is BuildProjectBeforeRunTask) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationType.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationType.kt
@@ -25,6 +25,8 @@ package org.jetbrains.plugins.azure.functions.run
 import com.intellij.execution.RunManager
 import com.intellij.execution.RunnerAndConfigurationSettings
 import com.intellij.execution.configurations.ConfigurationTypeBase
+import com.intellij.execution.configurations.ConfigurationTypeUtil
+import com.intellij.execution.configurations.runConfigurationType
 import com.intellij.openapi.project.Project
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rider.model.RunnableProject
@@ -38,11 +40,17 @@ import com.microsoft.icons.CommonIcons
 import org.jetbrains.concurrency.Promise
 import org.jetbrains.concurrency.resolvedPromise
 
-class AzureFunctionsHostConfigurationType : ConfigurationTypeBase("AzureFunctionsHost", "Azure Functions host",
-        "Azure Functions host", CommonIcons.AzureFunctions.FunctionAppRunConfiguration), IRunnableProjectConfigurationType, IRunConfigurationWithDefault {
+class AzureFunctionsHostConfigurationType : ConfigurationTypeBase(
+        id = "AzureFunctionsHost",
+        displayName = "Azure Functions host",
+        description = "Azure Function Applications runner",
+        icon = CommonIcons.AzureFunctions.FunctionAppRunConfiguration
+), IRunnableProjectConfigurationType, IRunConfigurationWithDefault {
 
     companion object {
-        fun isTypeApplicable(kind: RunnableProjectKind) =
+        val instance get() = runConfigurationType<AzureFunctionsHostConfigurationType>()
+
+        fun isTypeApplicable(kind: RunnableProjectKind): Boolean =
                 kind == RunnableProjectKind.AzureFunctions
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostExecutorFactory.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostExecutorFactory.kt
@@ -32,9 +32,7 @@ import com.jetbrains.rider.util.idea.getLogger
 import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsInfo
 import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsInfoProvider
 
-class AzureFunctionsHostExecutorFactory(
-        private val parameters: AzureFunctionsHostConfigurationParameters
-) : IExecutorFactory {
+class AzureFunctionsHostExecutorFactory(private val parameters: AzureFunctionsHostConfigurationParameters) : IExecutorFactory {
 
     private val logger = getLogger<AzureFunctionsHostExecutorFactory>()
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/HostJsonPatcher.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/HostJsonPatcher.kt
@@ -26,7 +26,6 @@ import com.google.gson.*
 import com.jetbrains.rider.util.idea.getLogger
 import java.io.File
 
-
 object HostJsonPatcher {
     private val logger = getLogger<HostJsonPatcher>()
     private val functionsPropertyName = "functions"


### PR DESCRIPTION
Avoid duplicating Azure Functions host configuration groups when launching an Azure functions

- Try to find an existing configuration type group before creating a new one when launching an Azure function from gutter mark
- Add IDs for run configuration factories to avoid warning notifications when creating a run config
- Minor updates