### PR TITLE
Fix #287. Replace registration actions in code with setting groups in XML

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzureActionsComponent.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzureActionsComponent.java
@@ -115,9 +115,9 @@ public abstract class AzureActionsComponent implements ApplicationComponent, Plu
     }
 
     public void initComponent() {
-        // TODO: This should all become a Service instead of a component
-        // similar to https://github.com/krasa/StringManipulation/issues/92
-        ApplicationManager.getApplication().invokeLater(() -> {
+        // TODO: ApplicationComponent should be fixed in the next release -
+        //  https://github.com/microsoft/azure-tools-for-java/commit/c21a66a4074eb70021b04f33eefcd49065211fd6
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
             try {
                 if (!AzurePlugin.IS_ANDROID_STUDIO) {
                     ServiceManager.setServiceProvider(SecureStore.class, IdeaSecureStore.getInstance());

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/IDEHelperImpl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/IDEHelperImpl.java
@@ -24,8 +24,6 @@ package com.microsoft.intellij.helpers;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.SettableFuture;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
@@ -48,8 +46,6 @@ import com.microsoft.intellij.util.PluginUtil;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.helpers.IDEHelper;
 
-import java.awt.*;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Semaphore;
@@ -260,42 +256,6 @@ public class IDEHelperImpl implements IDEHelper {
                                                   @NotNull ArtifactDescriptor artifactDescriptor) {
 
         return Futures.immediateFuture(null);
-
-        // TODO: SD -- check this change from upstream (start)
-//        try {
-//            Project project = findOpenProject(projectDescriptor);
-//
-//            final Artifact artifact = findProjectArtifact(project, artifactDescriptor);
-//
-//            final SettableFuture<String> future = SettableFuture.create();
-//
-//            Futures.addCallback(buildArtifact(project, artifact, false), new FutureCallback<Boolean>() {
-//                @Override
-//                public void onSuccess(@Nullable Boolean succeded) {
-//                    if (succeded != null && succeded) {
-//                        future.set(artifact.getOutputFilePath());
-//                    } else {
-//                        future.setException(new AzureCmdException("An error occurred while building the artifact"));
-//                    }
-//                }
-//
-//                @Override
-//                public void onFailure(Throwable throwable) {
-//                    if (throwable instanceof ExecutionException) {
-//                        future.setException(new AzureCmdException("An error occurred while building the artifact",
-//                                throwable.getCause()));
-//                    } else {
-//                        future.setException(new AzureCmdException("An error occurred while building the artifact",
-//                                throwable));
-//                    }
-//                }
-//            }, MoreExecutors.directExecutor());
-//
-//            return future;
-//        } catch (AzureCmdException e) {
-//            return Futures.immediateFailedFuture(e);
-//        }
-        // TODO: SD -- check this change from upstream (end)
     }
 
     @Override


### PR DESCRIPTION
The exception is through since an action group is registered programmatically on UI thread when initialising an application component. Replace it with XML configuration for action registration.

Fixes #287