### PR TITLE
Fix #276. Replace Azure API to collect a lightweight function apps objects

### DIFF
--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/appservice/functionapp/AzureFunctionAppModulePresenter.kt
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/appservice/functionapp/AzureFunctionAppModulePresenter.kt
@@ -22,6 +22,7 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.appservice.functionapp
 
+import com.microsoft.azuretools.authmanage.AuthMethodManager
 import com.microsoft.azuretools.core.mvp.model.functionapp.AzureFunctionAppMvpModel
 import com.microsoft.azuretools.core.mvp.ui.base.MvpPresenter
 
@@ -30,14 +31,15 @@ class AzureFunctionAppModulePresenter : MvpPresenter<AzureFunctionAppModule>() {
     fun onModuleRefresh() {
         mvpView ?: return
 
-        val azureFunctionsList = AzureFunctionAppMvpModel.listAllFunctionApps(true)
+        val subscriptionManager = AuthMethodManager.getInstance().azureManager.subscriptionManager
+        val subscriptionId = subscriptionManager.subscriptionDetails.firstOrNull()?.subscriptionId ?: return
+        val azureFunctionsList = AzureFunctionAppMvpModel.getAzureFunctionAppsInnerBySubscriptionId(subscriptionId)
 
         for (functionApp in azureFunctionsList) {
-            val subscriptionId    = functionApp.subscriptionId
-            val appId             = functionApp.resource.id()
-            val appName           = functionApp.resource.name()
-            val state             = functionApp.resource.state()
-            val hostName          = functionApp.resource.defaultHostName()
+            val appId   = functionApp.id()
+            val appName = functionApp.name()
+            val state   = functionApp.state()
+            val hostName= functionApp.defaultHostName()
 
             mvpView.addChildNode(FunctionAppNode(mvpView, subscriptionId, appId, appName, state, hostName))
         }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/functionapp/AzureFunctionAppMvpModel.kt
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/core/mvp/model/functionapp/AzureFunctionAppMvpModel.kt
@@ -32,22 +32,24 @@ import com.microsoft.azuretools.authmanage.AuthMethodManager
 import com.microsoft.azuretools.core.mvp.model.AzureMvpModel
 import com.microsoft.azuretools.core.mvp.model.ResourceEx
 import com.microsoft.azuretools.core.mvp.model.appserviceplan.AzureAppServicePlanMvpModel
+import com.microsoft.azuretools.core.mvp.model.function.FunctionAppWrapper
 import com.microsoft.azuretools.core.mvp.model.functionapp.functions.Function
 import com.microsoft.azuretools.core.mvp.model.functionapp.functions.FunctionImpl
 import com.microsoft.azuretools.core.mvp.model.functionapp.functions.rest.FunctionAppService
 import com.microsoft.azuretools.core.mvp.model.functionapp.functions.rest.getRetrofitClient
 import com.microsoft.azuretools.core.mvp.model.storage.AzureStorageAccountMvpModel
 import org.apache.commons.io.IOUtils
+import org.jetbrains.annotations.TestOnly
+import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
-import java.util.logging.Logger
 
 object AzureFunctionAppMvpModel {
 
-    private val logger = Logger.getLogger(AzureFunctionAppMvpModel::class.java.name)
+    private val logger = LoggerFactory.getLogger(AzureFunctionAppMvpModel::class.java)
 
     private val subscriptionIdToFunctionAppsMap = ConcurrentHashMap<String, List<FunctionApp>>()
     private val appToConnectionStringsMap = ConcurrentHashMap<FunctionApp, List<ConnectionString>>()
@@ -83,41 +85,51 @@ object AzureFunctionAppMvpModel {
             subscriptionIdToFunctionAppsMap[subscriptionId] = functionApps
             return functionApps
         } catch (e: IOException) {
-            logger.warning("Error getting Azure Function Apps by Subscription Id: $e")
+            logger.error("Error getting Azure Function Apps by Subscription Id: $e")
         }
 
         return listOf()
     }
 
     fun getAzureFunctionAppsBySubscriptionId(subscriptionId: String) =
-            AuthMethodManager.getInstance().getAzureClient(subscriptionId).appServices().functionApps()
-                    .list() ?: emptyList<FunctionApp>()
+            getFunctionAppsClient(subscriptionId).list() ?: emptyList<FunctionApp>()
+
+    /**
+     * This call uses other Azure API that quickly return a list of lightweight Azure Function Apps.
+     *
+     * Note: Please use this with caution since object does not cache part of data.
+     *       Be ready requests for this data will take time comparing with [getAzureFunctionAppsBySubscriptionId] method.
+     */
+    fun getAzureFunctionAppsInnerBySubscriptionId(subscriptionId: String) =
+            getFunctionAppsClient(subscriptionId).inner().list()
+                    .map { inner -> FunctionAppWrapper(subscriptionId, inner) }
 
     fun getAzureFunctionAppsByResourceGroup(subscriptionId: String, resourceGroupName: String) =
-            AuthMethodManager.getInstance().getAzureClient(subscriptionId).appServices().functionApps()
-                    .listByResourceGroup(resourceGroupName)
+            getFunctionAppsClient(subscriptionId).listByResourceGroup(resourceGroupName)
 
     fun getFunctionAppById(subscriptionId: String, appId: String) =
-            AuthMethodManager.getInstance().getAzureClient(subscriptionId).appServices().functionApps().getById(appId)
+            getFunctionAppsClient(subscriptionId).getById(appId)
 
     fun startFunctionApp(subscriptionId: String, functionAppId: String) =
-            AuthMethodManager.getInstance().getAzureClient(subscriptionId)
-                    .appServices().functionApps().getById(functionAppId).start()
+            getFunctionAppsClient(subscriptionId).getById(functionAppId).start()
 
     fun restartFunctionApp(subscriptionId: String, functionAppId: String) =
-            AuthMethodManager.getInstance().getAzureClient(subscriptionId)
-                    .appServices().functionApps().getById(functionAppId).restart()
+            getFunctionAppsClient(subscriptionId).getById(functionAppId).restart()
 
     fun stopFunctionApp(subscriptionId: String, functionAppId: String) =
-            AuthMethodManager.getInstance().getAzureClient(subscriptionId)
-                    .appServices().functionApps().getById(functionAppId).stop()
+            getFunctionAppsClient(subscriptionId).getById(functionAppId).stop()
 
     fun deleteFunctionApp(subscriptionId: String, functionAppId: String) {
         try {
-            val azure = AuthMethodManager.getInstance().getAzureClient(subscriptionId)
-            azure.appServices().functionApps().deleteById(functionAppId)
+            getFunctionAppsClient(subscriptionId).deleteById(functionAppId)
+            if (subscriptionIdToFunctionAppsMap.contains(subscriptionId)) {
+                val filteredFunctionApps = subscriptionIdToFunctionAppsMap.getValue(subscriptionId)
+                        .filter { app -> app.id() != functionAppId }
+
+                subscriptionIdToFunctionAppsMap[subscriptionId] = filteredFunctionApps
+            }
         } catch (t: Throwable) {
-            logger.warning("Error deleting Azure Function App: $t")
+            logger.error("Error deleting Azure Function App: $t")
             throw t
         }
     }
@@ -201,13 +213,17 @@ object AzureFunctionAppMvpModel {
         return connectionStrings
     }
 
+    /**
+     * Check whether connection string with name exists for a specified Azure Function app with provided ID.
+     */
     fun checkConnectionStringNameExists(subscriptionId: String, appId: String, connectionStringName: String, force: Boolean = false): Boolean {
-        if (!force && subscriptionIdToFunctionAppsMap.containsKey(subscriptionId)) {
-            val app = subscriptionIdToFunctionAppsMap[subscriptionId]!!.find { it.id() == appId } ?: return false
+        if (!force) {
+            val existingFunctionApps = subscriptionIdToFunctionAppsMap[subscriptionId] ?: return false
+            val app = existingFunctionApps.find { it.id() == appId } ?: return false
             return checkConnectionStringNameExists(app, connectionStringName, force)
         }
 
-        val app = AzureFunctionAppMvpModel.getFunctionAppById(subscriptionId, appId)
+        val app = getFunctionAppById(subscriptionId, appId)
         return checkConnectionStringNameExists(app, connectionStringName, force)
     }
 
@@ -225,6 +241,7 @@ object AzureFunctionAppMvpModel {
         listAllFunctionApps(true)
     }
 
+    @TestOnly
     fun clearSubscriptionIdToFunctionMap() {
         subscriptionIdToFunctionAppsMap.clear()
     }
@@ -314,7 +331,7 @@ object AzureFunctionAppMvpModel {
     }
 
     private fun createFunctionAppDefinition(subscriptionId: String, name: String) =
-            AuthMethodManager.getInstance().getAzureClient(subscriptionId).appServices().functionApps().define(name)
+            getFunctionAppsClient(subscriptionId).define(name)
 
     private fun withStorageAccount(definition: FunctionApp.DefinitionStages.WithCreate,
                                    isCreateNew: Boolean,
@@ -336,4 +353,7 @@ object AzureFunctionAppMvpModel {
     private fun clearTags(app: WebAppBase) {
         app.inner().withTags(null)
     }
+
+    private fun getFunctionAppsClient(subscriptionId: String) =
+            AuthMethodManager.getInstance().getAzureClient(subscriptionId).appServices().functionApps()
 }


### PR DESCRIPTION
- Replace logic that displays Functions inside Azure Explorer to use an inner API call that is executed faster
- Minor updates in defining whether connection string with a specified name exists for a Function App. Logic does not do any API calls when using "force" = false flag since this method is used for run configuration validation that is executed synchronously on UI thread.