### PR TITLE
Replace all logger instance with static Logger.getInstance() calls

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -171,6 +171,8 @@
 
     <projectTemplateProvider implementation="org.jetbrains.plugins.azure.functions.projectTemplating.FunctionsCoreToolsTemplatesProvider" order="first"/>
 
+    <projectService serviceImplementation="org.jetbrains.plugins.azure.cloudshell.CloudShellService" />
+
     <rider.projectView.actions.projectTemplating.backend.reSharperProjectTemplateCustomizer implementation="org.jetbrains.plugins.azure.functions.projectTemplating.FunctionsCoreToolsV1TemplateCustomizer" />
     <rider.projectView.actions.projectTemplating.backend.reSharperProjectTemplateCustomizer implementation="org.jetbrains.plugins.azure.functions.projectTemplating.FunctionsCoreToolsV2TemplateCustomizer" />
 
@@ -209,10 +211,6 @@
     <component>
       <implementation-class>com.microsoft.intellij.AzureRiderPlugin</implementation-class>
       <loadForDefaultProject/>
-    </component>
-
-    <component>
-      <implementation-class>org.jetbrains.plugins.azure.cloudshell.CloudShellComponent</implementation-class>
     </component>
   </project-components>
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/helpers/base/AzureMvpPresenter.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/helpers/base/AzureMvpPresenter.kt
@@ -22,11 +22,11 @@
 
 package com.microsoft.intellij.helpers.base
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.jetbrains.rd.platform.util.application
-import com.jetbrains.rider.util.idea.getLogger
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.lifetime.isAlive
 import com.jetbrains.rd.util.reactive.Signal
@@ -38,7 +38,7 @@ import com.microsoft.tooling.msservices.components.DefaultLoader
 open class AzureMvpPresenter<V : MvpView> : MvpPresenter<V>() {
 
     companion object {
-        private val logger = getLogger(this)
+        private val logger = Logger.getInstance(AzureMvpPresenter::class.java)
     }
 
     fun <T>subscribe(lifetime: Lifetime,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/helpers/deploy/KuduClient.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/helpers/deploy/KuduClient.kt
@@ -22,7 +22,7 @@
 
 package com.microsoft.intellij.helpers.deploy
 
-import com.jetbrains.rider.util.idea.getLogger
+import com.intellij.openapi.diagnostic.Logger
 import com.microsoft.azure.management.appservice.PublishingProfile
 import com.microsoft.azure.management.appservice.WebAppBase
 import com.microsoft.intellij.runner.RunProcessHandler
@@ -34,7 +34,7 @@ import java.io.File
 
 object KuduClient {
 
-    private val logger = getLogger<WebAppDeployStateUtil>()
+    private val logger = Logger.getInstance(WebAppDeployStateUtil::class.java)
 
     private const val URL_KUDU_ZIP_DEPLOY_SUFFIX = "/api/zipdeploy"
     private const val URL_AZURE_BASE = ".azurewebsites.net"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/appbase/config/runstate/AppDeployStateUtil.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/appbase/config/runstate/AppDeployStateUtil.kt
@@ -23,6 +23,7 @@
 package com.microsoft.intellij.runner.appbase.config.runstate
 
 import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.wm.ToolWindowId
@@ -35,7 +36,6 @@ import com.jetbrains.rdclient.util.idea.toIOFile
 import com.jetbrains.rider.model.BuildResultKind
 import com.jetbrains.rider.model.PublishableProjectModel
 import com.jetbrains.rider.run.configurations.publishing.base.MsBuildPublishingService
-import com.jetbrains.rider.util.idea.getLogger
 import com.microsoft.azure.management.appservice.WebAppBase
 import com.microsoft.azure.management.sql.SqlDatabase
 import com.microsoft.azuretools.utils.AzureUIRefreshCore
@@ -55,7 +55,7 @@ import java.util.zip.ZipOutputStream
 
 object AppDeployStateUtil {
 
-    private val logger = getLogger<AppDeployStateUtil>()
+    private val logger = Logger.getInstance(AppDeployStateUtil::class.java)
 
     private const val COLLECT_ARTIFACTS_TIMEOUT_MS = 180000L
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/config/runstate/FunctionAppDeployStateUtil.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/config/runstate/FunctionAppDeployStateUtil.kt
@@ -22,10 +22,10 @@
 
 package com.microsoft.intellij.runner.functionapp.config.runstate
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.FileUtil
 import com.jetbrains.rider.model.PublishableProjectModel
-import com.jetbrains.rider.util.idea.getLogger
 import com.microsoft.azure.management.appservice.ConnectionStringType
 import com.microsoft.azure.management.appservice.FunctionApp
 import com.microsoft.azure.management.sql.SqlDatabase
@@ -47,7 +47,7 @@ import java.util.*
 
 object FunctionAppDeployStateUtil {
 
-    private val logger = getLogger<FunctionAppDeployStateUtil>()
+    private val logger = Logger.getInstance(FunctionAppDeployStateUtil::class.java)
 
     private val activityNotifier = AzureDeploymentProgressNotification(null)
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/AzureDotNetWebAppMvpModel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/AzureDotNetWebAppMvpModel.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 JetBrains s.r.o.
+ * Copyright (c) 2018-2020 JetBrains s.r.o.
  * <p/>
  * All rights reserved.
  * <p/>
@@ -22,9 +22,8 @@
 
 package com.microsoft.intellij.runner.webapp
 
+import com.intellij.openapi.diagnostic.Logger
 import com.jetbrains.rd.util.concurrentMapOf
-import com.jetbrains.rd.util.error
-import com.jetbrains.rd.util.getLogger
 import com.microsoft.azure.management.Azure
 import com.microsoft.azure.management.appservice.*
 import com.microsoft.azure.management.resources.fluentcore.arm.Region
@@ -34,7 +33,7 @@ import com.microsoft.azuretools.core.mvp.model.ResourceEx
 
 object AzureDotNetWebAppMvpModel {
 
-    private val LOG = getLogger<AzureDotNetWebAppMvpModel>()
+    private val logger = Logger.getInstance(AzureDotNetWebAppMvpModel::class.java)
 
     class WebAppDefinition(val name: String,
                            val isCreatingResourceGroup: Boolean,
@@ -81,7 +80,7 @@ object AzureDotNetWebAppMvpModel {
             subscriptionIdToWebAppsMap[subscriptionId] = webAppList
             return webAppList
         } catch (e: Throwable) {
-            LOG.error(e)
+            logger.error(e)
         }
 
         return listOf()

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/runstate/WebAppDeployStateUtil.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/runstate/WebAppDeployStateUtil.kt
@@ -22,10 +22,10 @@
 
 package com.microsoft.intellij.runner.webapp.config.runstate
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.FileUtil
 import com.jetbrains.rider.model.PublishableProjectModel
-import com.jetbrains.rider.util.idea.getLogger
 import com.microsoft.azure.management.appservice.ConnectionStringType
 import com.microsoft.azure.management.appservice.OperatingSystem
 import com.microsoft.azure.management.appservice.RuntimeStack
@@ -51,7 +51,7 @@ import java.util.*
 
 object WebAppDeployStateUtil {
 
-    private val logger = getLogger<WebAppDeployStateUtil>()
+    private val logger = Logger.getInstance(WebAppDeployStateUtil::class.java)
 
     private val activityNotifier = AzureDeploymentProgressNotification(null)
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/CloudShellService.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/CloudShellService.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 JetBrains s.r.o.
+ * Copyright (c) 2018-2020 JetBrains s.r.o.
  * <p/>
  * All rights reserved.
  * <p/>
@@ -19,12 +19,19 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package org.jetbrains.plugins.azure.cloudshell
 
-import com.intellij.openapi.components.ProjectComponent
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.project.Project
 import org.jetbrains.plugins.azure.cloudshell.terminal.AzureCloudProcessTtyConnector
 
-class CloudShellComponent : ProjectComponent {
+class CloudShellService {
+
+    companion object {
+        fun getInstance(project: Project): CloudShellService = ServiceManager.getService(project, CloudShellService::class.java)
+    }
+
     private val connectors = mutableListOf<AzureCloudProcessTtyConnector>()
 
     fun registerConnector(connector: AzureCloudProcessTtyConnector) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/CloseCloudShellPortActionGroup.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/CloseCloudShellPortActionGroup.kt
@@ -34,7 +34,9 @@ import org.jetbrains.plugins.azure.cloudshell.CloudShellComponent
 
 class CloseCloudShellPortActionGroup : ActionGroup() {
 
-    private val logger = Logger.getInstance(OpenCloudShellPortAction::class.java)
+    companion object {
+        private val logger = Logger.getInstance(OpenCloudShellPortAction::class.java)
+    }
 
     override fun update(e: AnActionEvent) {
         val project = CommonDataKeys.PROJECT.getData(e.dataContext)
@@ -71,7 +73,9 @@ class CloseCloudShellPortActionGroup : ActionGroup() {
 }
 
 private class CloseCloudShellPortAction(val port: Int) : AnAction(port.toString()) {
-    private val logger = Logger.getInstance(CloseCloudShellPortAction::class.java)
+    companion object {
+        private val logger= Logger.getInstance(CloseCloudShellPortAction::class.java)
+    }
 
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabled = true
@@ -98,7 +102,7 @@ private class CloseCloudShellPortAction(val port: Int) : AnAction(port.toString(
 }
 
 private object CloseAllCloudShellPortsAction : AnAction("Close all") {
-    private val logger = Logger.getInstance(CloseCloudShellPortAction::class.java)
+    private val logger= Logger.getInstance(CloseCloudShellPortAction::class.java)
 
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabled = true

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/OpenCloudShellPortAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/OpenCloudShellPortAction.kt
@@ -32,9 +32,8 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.ui.InputValidator
 import com.intellij.openapi.ui.Messages
-import com.jetbrains.rider.util.idea.getComponent
 import org.jetbrains.plugins.azure.RiderAzureBundle
-import org.jetbrains.plugins.azure.cloudshell.CloudShellComponent
+import org.jetbrains.plugins.azure.cloudshell.CloudShellService
 
 class OpenCloudShellPortAction : AnAction() {
     companion object {
@@ -43,15 +42,19 @@ class OpenCloudShellPortAction : AnAction() {
 
     override fun update(e: AnActionEvent) {
         val project = CommonDataKeys.PROJECT.getData(e.dataContext)
-        val cloudShellComponent = project?.getComponent<CloudShellComponent>()
+                ?: let {
+                    e.presentation.isEnabled = false
+                    return
+                }
 
-        e.presentation.isEnabled = project != null
-                && cloudShellComponent?.activeConnector() != null
+        val cloudShellComponent = CloudShellService.getInstance(project)
+
+        e.presentation.isEnabled = cloudShellComponent.activeConnector() != null
     }
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = CommonDataKeys.PROJECT.getData(e.dataContext) ?: return
-        val activeConnector = project.getComponent<CloudShellComponent>().activeConnector() ?: return
+        val activeConnector = CloudShellService.getInstance(project).activeConnector() ?: return
 
         val port = Messages.showInputDialog(project,
                 RiderAzureBundle.message("dialog.cloud_shell.open_port.message"),

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/OpenCloudShellPortAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/OpenCloudShellPortAction.kt
@@ -37,7 +37,9 @@ import org.jetbrains.plugins.azure.RiderAzureBundle
 import org.jetbrains.plugins.azure.cloudshell.CloudShellComponent
 
 class OpenCloudShellPortAction : AnAction() {
-    private val logger = Logger.getInstance(OpenCloudShellPortAction::class.java)
+    companion object {
+        private val logger = Logger.getInstance(OpenCloudShellPortAction::class.java)
+    }
 
     override fun update(e: AnActionEvent) {
         val project = CommonDataKeys.PROJECT.getData(e.dataContext)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/StartAzureCloudShellAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/StartAzureCloudShellAction.kt
@@ -19,6 +19,7 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package org.jetbrains.plugins.azure.cloudshell.actions
 
 import com.intellij.ide.BrowserUtil
@@ -59,7 +60,9 @@ import java.net.URI
 import javax.swing.event.HyperlinkEvent
 
 class StartAzureCloudShellAction : AnAction() {
-    private val logger = Logger.getInstance(StartAzureCloudShellAction::class.java)
+    companion object {
+        private val logger = Logger.getInstance(StartAzureCloudShellAction::class.java)
+    }
 
     private val defaultTerminalColumns = 100
     private val defaultTerminalRows = 30

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/UploadToAzureCloudShellAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/UploadToAzureCloudShellAction.kt
@@ -33,9 +33,8 @@ import com.intellij.openapi.progress.PerformInBackgroundOption
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.vfs.VirtualFile
-import com.jetbrains.rider.util.idea.getComponent
 import org.jetbrains.plugins.azure.RiderAzureBundle
-import org.jetbrains.plugins.azure.cloudshell.CloudShellComponent
+import org.jetbrains.plugins.azure.cloudshell.CloudShellService
 
 class UploadToAzureCloudShellAction : AnAction() {
     companion object {
@@ -44,16 +43,19 @@ class UploadToAzureCloudShellAction : AnAction() {
 
     override fun update(e: AnActionEvent) {
         val project = CommonDataKeys.PROJECT.getData(e.dataContext)
-        val cloudShellComponent = project?.getComponent<CloudShellComponent>()
+                ?: let {
+                    e.presentation.isEnabled = false
+                    return
+                }
 
-        e.presentation.isEnabled = CommonDataKeys.PROJECT.getData(e.dataContext) != null
-                && cloudShellComponent != null
-                && cloudShellComponent.activeConnector() != null
+        val cloudShellComponent = CloudShellService.getInstance(project)
+
+        e.presentation.isEnabled = cloudShellComponent.activeConnector() != null
     }
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = CommonDataKeys.PROJECT.getData(e.dataContext) ?: return
-        val activeConnector = project.getComponent<CloudShellComponent>().activeConnector() ?: return
+        val activeConnector = CloudShellService.getInstance(project).activeConnector() ?: return
 
         ApplicationManager.getApplication().invokeLater {
             val descriptor = FileChooserDescriptor(true, false, false, true, false, true)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/UploadToAzureCloudShellAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/UploadToAzureCloudShellAction.kt
@@ -19,6 +19,7 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package org.jetbrains.plugins.azure.cloudshell.actions
 
 import com.intellij.openapi.actionSystem.AnAction
@@ -37,7 +38,9 @@ import org.jetbrains.plugins.azure.RiderAzureBundle
 import org.jetbrains.plugins.azure.cloudshell.CloudShellComponent
 
 class UploadToAzureCloudShellAction : AnAction() {
-    private val logger = Logger.getInstance(UploadToAzureCloudShellAction::class.java)
+    companion object {
+        private val logger = Logger.getInstance(UploadToAzureCloudShellAction::class.java)
+    }
 
     override fun update(e: AnActionEvent) {
         val project = CommonDataKeys.PROJECT.getData(e.dataContext)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/controlchannel/CloudConsoleControlChannelWebSocket.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/controlchannel/CloudConsoleControlChannelWebSocket.kt
@@ -24,6 +24,7 @@ package org.jetbrains.plugins.azure.cloudshell.controlchannel
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
 import com.google.gson.annotations.SerializedName
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import org.java_websocket.client.WebSocketClient
 import org.java_websocket.handshake.ServerHandshake
@@ -35,6 +36,10 @@ class CloudConsoleControlChannelWebSocket(private val project: Project,
                                           private val cloudConsoleService: CloudConsoleService,
                                           private val cloudConsoleBaseUrl: String)
     : WebSocketClient(serverURI) {
+
+    companion object {
+        private val logger = Logger.getInstance(CloudConsoleControlChannelWebSocket::class.java)
+    }
 
     private val gson = Gson()
 
@@ -53,7 +58,7 @@ class CloudConsoleControlChannelWebSocket(private val project: Project,
                             .handle(message)
                 }
             } catch (e: JsonSyntaxException) {
-                // TODO
+                logger.error("Error on receiving message from cloud shell terminal: $e")
             }
         }
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/terminal/AzureCloudTerminalRunner.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/terminal/AzureCloudTerminalRunner.kt
@@ -46,7 +46,10 @@ class AzureCloudTerminalRunner(project: Project,
                                process: AzureCloudTerminalProcess)
     : CloudTerminalRunner(project, message("terminal.cloud_shell.runner.pipe_name"), process) {
 
-    private val logger = Logger.getInstance(AzureCloudTerminalRunner::class.java)
+    companion object {
+        private val logger = Logger.getInstance(AzureCloudTerminalRunner::class.java)
+    }
+
     private val resizeTerminalUrl: String
     private val uploadFileToTerminalUrl: String
     private val previewPortBaseUrl: String

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/terminal/AzureCloudTerminalRunner.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/terminal/AzureCloudTerminalRunner.kt
@@ -32,7 +32,7 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import org.apache.http.client.utils.URIBuilder
 import org.jetbrains.plugins.azure.RiderAzureBundle.message
-import org.jetbrains.plugins.azure.cloudshell.CloudShellComponent
+import org.jetbrains.plugins.azure.cloudshell.CloudShellService
 import org.jetbrains.plugins.azure.cloudshell.controlchannel.CloudConsoleControlChannelWebSocket
 import org.jetbrains.plugins.azure.cloudshell.rest.CloudConsoleService
 import org.jetbrains.plugins.terminal.cloud.CloudTerminalProcess
@@ -69,7 +69,7 @@ class AzureCloudTerminalRunner(project: Project,
     }
 
     override fun createTtyConnector(process: CloudTerminalProcess): TtyConnector {
-        val cloudShellComponent = project.getComponent<CloudShellComponent>()
+        val cloudShellComponent = CloudShellService.getInstance(project)
 
         // Connect control socket
         // TODO: for now, this does not yet need any other wiring, it's just a convenience for e.g. downloading files

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/AzureCoreToolsDetector.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/AzureCoreToolsDetector.kt
@@ -23,10 +23,9 @@
 package org.jetbrains.plugins.azure.functions
 
 import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
-import com.jetbrains.rd.util.getLogger
-import com.jetbrains.rd.util.info
 import com.microsoft.intellij.configuration.AzureRiderSettings
 import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsInfoProvider
 import java.io.File
@@ -37,7 +36,7 @@ import java.io.File
 class AzureCoreToolsDetector : StartupActivity {
 
     companion object {
-        private val logger = getLogger<AzureCoreToolsDetector>()
+        private val logger = Logger.getInstance(AzureCoreToolsDetector::class.java)
     }
 
     override fun runActivity(project: Project) {
@@ -45,15 +44,15 @@ class AzureCoreToolsDetector : StartupActivity {
 
         val existingCoreToolPath = properties.getValue(AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH, "")
         if (existingCoreToolPath.isNotEmpty() && File(existingCoreToolPath).exists()) {
-            logger.info { "Azure Function Core Tool is setup: '$existingCoreToolPath'" }
+            logger.info("Azure Function Core Tool is setup: '$existingCoreToolPath'")
             return
         }
 
-        logger.info { "Detecting Azure Function Core Tool..." }
+        logger.info("Detecting Azure Function Core Tool...")
         val functionCoreToolPath = FunctionsCoreToolsInfoProvider.detectFunctionCoreToolsPath()
 
         if (functionCoreToolPath == null) {
-            logger.info { "Unable to detect Azure Core Tool path" }
+            logger.info("Unable to detect Azure Core Tool path")
             return
         }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/actions/TriggerAzureFunctionAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/actions/TriggerAzureFunctionAction.kt
@@ -22,12 +22,12 @@
 
 package org.jetbrains.plugins.azure.functions.actions
 
-import com.jetbrains.rider.util.idea.getLogger
 import com.intellij.ide.fileTemplates.FileTemplateManager
 import com.intellij.ide.scratch.ScratchFileService
 import com.intellij.ide.scratch.ScratchRootType
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.ws.http.request.HttpRequestLanguage
@@ -42,7 +42,7 @@ class TriggerAzureFunctionAction(private val functionName: String)
         RestClientIcons.Http_requests_filetype) {
 
     companion object {
-        private val logger by lazy { getLogger<TriggerAzureFunctionAction>() }
+        private val logger by lazy { Logger.getInstance(TriggerAzureFunctionAction::class.java) }
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/completion/csharp/AzureFunctionsTimerTriggerCompletionContributor.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/completion/csharp/AzureFunctionsTimerTriggerCompletionContributor.kt
@@ -37,7 +37,9 @@ import java.util.*
 
 class AzureFunctionsTimerTriggerCompletionContributor : CompletionContributor() {
 
-    private val logger = Logger.getInstance(AzureFunctionsTimerTriggerCompletionContributor::class.java)
+    companion object {
+        private val logger = Logger.getInstance(AzureFunctionsTimerTriggerCompletionContributor::class.java)
+    }
 
     private val cronParser = CronParser(NCrontabCronDefinition)
     private val cronDescriptor = CronDescriptor.instance(Locale.getDefault())

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsInfoProvider.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsInfoProvider.kt
@@ -23,11 +23,8 @@
 package org.jetbrains.plugins.azure.functions.coreTools
 
 import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.SystemInfo
-import com.jetbrains.rd.util.error
-import com.jetbrains.rd.util.getLogger
-import com.jetbrains.rd.util.info
-import com.jetbrains.rd.util.warn
 import com.microsoft.intellij.configuration.AzureRiderSettings
 import com.microsoft.intellij.runner.functions.core.FunctionCliResolver
 import java.io.File
@@ -35,7 +32,7 @@ import java.io.File
 data class FunctionsCoreToolsInfo(val coreToolsPath: String, var coreToolsExecutable: String)
 
 object FunctionsCoreToolsInfoProvider {
-    private val logger = getLogger<FunctionsCoreToolsInfoProvider>()
+    private val logger = Logger.getInstance(FunctionsCoreToolsInfoProvider::class.java)
 
     fun retrieve(): FunctionsCoreToolsInfo? {
         val funcCoreToolsPath = PropertiesComponent.getInstance().getValue(AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH)
@@ -54,7 +51,7 @@ object FunctionsCoreToolsInfoProvider {
         }
 
         if (!coreToolsExecutablePath.canExecute()) {
-            logger.warn { "Updating executable flag for $coreToolsExecutablePath..." }
+            logger.warn("Updating executable flag for $coreToolsExecutablePath...")
             try {
                 coreToolsExecutablePath.setExecutable(true)
             } catch (s: SecurityException) {
@@ -93,13 +90,13 @@ object FunctionsCoreToolsInfoProvider {
         // Plugin tool downloads has higher priority then manual downloads.
         val pluginCoreToolsExecutable = detectPluginDownloads()
         if (pluginCoreToolsExecutable != null) {
-            logger.info { "Found an existing download from the plugin for function core tool: '${pluginCoreToolsExecutable.canonicalPath}'" }
+            logger.info("Found an existing download from the plugin for function core tool: '${pluginCoreToolsExecutable.canonicalPath}'")
             return pluginCoreToolsExecutable.parentFile.canonicalPath
         }
 
         val manualCoreToolsExecutable = detectManualDownloads()
         if (manualCoreToolsExecutable != null) {
-            logger.info { "Found an existing manual setup for function core tool: '${manualCoreToolsExecutable.canonicalPath}'" }
+            logger.info("Found an existing manual setup for function core tool: '${manualCoreToolsExecutable.canonicalPath}'")
             return manualCoreToolsExecutable.parentFile.canonicalPath
         }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsManager.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsManager.kt
@@ -26,6 +26,7 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
@@ -36,10 +37,7 @@ import com.intellij.openapi.util.text.StringUtil
 import com.intellij.util.io.HttpRequests
 import com.intellij.util.io.ZipUtil
 import com.intellij.util.text.VersionComparatorUtil
-import com.jetbrains.rd.util.error
-import com.jetbrains.rd.util.getLogger
 import com.jetbrains.rd.util.string.printToString
-import com.jetbrains.rd.util.warn
 import org.jetbrains.plugins.azure.RiderAzureBundle.message
 import org.jetbrains.plugins.azure.functions.GitHubReleasesService
 import java.io.File
@@ -52,7 +50,7 @@ object FunctionsCoreToolsManager {
 
     private val downloadPath: String = PathManager.getConfigPath() + File.separator + CORE_TOOLS_DIR
 
-    private val logger = getLogger<FunctionsCoreToolsManager>()
+    private val logger = Logger.getInstance(FunctionsCoreToolsManager::class.java)
 
     fun downloadLatestRelease(allowPrerelease: Boolean, indicator: ProgressIndicator, onComplete: (String) -> Unit) {
         object : Task.Backgroundable(null, message("progress.function_app.core_tools.downloading_latest"), true) {
@@ -176,7 +174,7 @@ object FunctionsCoreToolsManager {
 
         try {
             if (!coreToolsExecutable.canExecute()) {
-                logger.warn { "Updating executable flag for $coreToolsPath..." }
+                logger.warn("Updating executable flag for $coreToolsPath...")
                 try {
                     coreToolsExecutable.setExecutable(true)
                 } catch (s: SecurityException) {
@@ -255,9 +253,9 @@ object FunctionsCoreToolsManager {
                 }
             }
         } catch (e: UnknownHostException) {
-            logger.warn { "Could not determine latest remote: " + e.printToString() }
+            logger.warn("Could not determine latest remote: " + e.printToString())
         } catch (e: IOException) {
-            logger.warn { "Could not determine latest remote: " + e.printToString() }
+            logger.warn("Could not determine latest remote: " + e.printToString())
         }
 
         return null

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/FunctionsCoreToolsTemplateManager.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/FunctionsCoreToolsTemplateManager.kt
@@ -22,15 +22,13 @@
 
 package org.jetbrains.plugins.azure.functions.projectTemplating
 
-import com.jetbrains.rd.util.error
-import com.jetbrains.rd.util.getLogger
-import com.jetbrains.rd.util.info
+import com.intellij.openapi.diagnostic.Logger
 import com.jetbrains.rider.projectView.actions.projectTemplating.backend.ReSharperProjectTemplateProvider
 import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsInfoProvider
 import java.io.File
 
 object FunctionsCoreToolsTemplateManager {
-    private val logger = getLogger<FunctionsCoreToolsTemplateManager>()
+    private val logger = Logger.getInstance(FunctionsCoreToolsTemplateManager::class.java)
 
     private fun isFunctionsProjectTemplate(file: File?): Boolean =
             file != null && file.isFile && file.name.startsWith("projectTemplates.", true) && file.name.endsWith(".nupkg", true)
@@ -55,7 +53,7 @@ object FunctionsCoreToolsTemplateManager {
                 val templateFiles = templatesToBeRegisteredFolder.listFiles { f: File? -> isFunctionsProjectTemplate(f) }
                         ?: emptyArray<File>()
 
-                logger.info { "Found ${templateFiles.size} function template(s)" }
+                logger.info("Found ${templateFiles.size} function template(s)")
 
                 templateFiles.forEach { file ->
                     ReSharperProjectTemplateProvider.addUserTemplateSource(file)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationParameters.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationParameters.kt
@@ -29,6 +29,7 @@ import com.intellij.execution.configurations.RuntimeConfigurationError
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.ide.browsers.BrowserStarter
 import com.intellij.ide.browsers.StartBrowserSettings
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.JDOMExternalizerUtil
 import com.intellij.util.execution.ParametersListUtil
@@ -44,7 +45,6 @@ import com.jetbrains.rider.run.configurations.project.DotNetStartBrowserParamete
 import com.jetbrains.rider.runtime.DotNetExecutable
 import com.jetbrains.rider.runtime.RiderDotNetActiveRuntimeHost
 import com.jetbrains.rider.util.idea.getComponent
-import com.jetbrains.rider.util.idea.getLogger
 import org.jdom.Element
 import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsInfo
 import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsInfoProvider
@@ -91,7 +91,7 @@ open class AzureFunctionsHostConfigurationParameters(
         const val PROJECT_NOT_SPECIFIED = "Project is not specified"
         const val SOLUTION_IS_LOADING = "Solution is loading, please wait for a few seconds"
 
-        private val logger = getLogger<AzureFunctionsHostConfigurationParameters>()
+        private val logger = Logger.getInstance(AzureFunctionsHostConfigurationParameters::class.java)
     }
 
     val isUnloadedProject: Boolean

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostExecutorFactory.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostExecutorFactory.kt
@@ -27,14 +27,16 @@ import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.executors.DefaultDebugExecutor
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.diagnostic.Logger
 import com.jetbrains.rider.run.configurations.IExecutorFactory
-import com.jetbrains.rider.util.idea.getLogger
 import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsInfo
 import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsInfoProvider
 
 class AzureFunctionsHostExecutorFactory(private val parameters: AzureFunctionsHostConfigurationParameters) : IExecutorFactory {
 
-    private val logger = getLogger<AzureFunctionsHostExecutorFactory>()
+    companion object {
+        private val logger = Logger.getInstance(AzureFunctionsHostExecutorFactory::class.java)
+    }
 
     override fun create(executorId: String, environment: ExecutionEnvironment): RunProfileState {
         val coreToolsInfo: FunctionsCoreToolsInfo? = FunctionsCoreToolsInfoProvider.retrieve()

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/HostJsonPatcher.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/HostJsonPatcher.kt
@@ -23,11 +23,11 @@
 package org.jetbrains.plugins.azure.functions.run
 
 import com.google.gson.*
-import com.jetbrains.rider.util.idea.getLogger
+import com.intellij.openapi.diagnostic.Logger
 import java.io.File
 
 object HostJsonPatcher {
-    private val logger = getLogger<HostJsonPatcher>()
+    private val logger = Logger.getInstance(HostJsonPatcher::class.java)
     private val functionsPropertyName = "functions"
 
     private fun determineHostJsonFile(workingDirectory: String): File? {


### PR DESCRIPTION
- Unify all logger instance with static Logger.getInstance() calls
- Replace project component with project service