### PR TITLE
Fixed RIDER-45405. Persists user's browser settings in Function App config

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfiguration.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 JetBrains s.r.o.
+ * Copyright (c) 2019-2020 JetBrains s.r.o.
  * <p/>
  * All rights reserved.
  * <p/>
@@ -40,9 +40,7 @@ class AzureFunctionsHostConfiguration(
         project,
         factory,
         { AzureFunctionsHostSettingsEditorGroup(it) },
-        AzureFunctionsHostExecutorFactory(
-                parameters
-        )
+        AzureFunctionsHostExecutorFactory(parameters)
 ), IRiderDebuggable {
 
     private val riderDotNetActiveRuntimeHost = project.getComponent<RiderDotNetActiveRuntimeHost>()

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationViewModel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationViewModel.kt
@@ -25,12 +25,18 @@ package org.jetbrains.plugins.azure.functions.run
 import com.intellij.util.execution.ParametersListUtil
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.reactive.adviseOnce
-import com.jetbrains.rider.model.*
+import com.jetbrains.rider.model.EnvironmentVariable
+import com.jetbrains.rider.model.Key
+import com.jetbrains.rider.model.ProjectOutput
+import com.jetbrains.rider.model.RunnableProjectsModel
+import com.jetbrains.rider.model.RunnableProjectKind
+import com.jetbrains.rider.model.RunnableProject
 import com.jetbrains.rider.run.configurations.controls.*
 import com.jetbrains.rider.run.configurations.controls.startBrowser.BrowserSettings
 import com.jetbrains.rider.run.configurations.controls.startBrowser.BrowserSettingsEditor
 import com.jetbrains.rider.run.configurations.dotNetExe.DotNetExeConfigurationViewModel
 import com.jetbrains.rider.run.configurations.project.DotNetStartBrowserParameters
+import org.apache.http.client.utils.URIBuilder
 import java.io.File
 
 class AzureFunctionsHostConfigurationViewModel(
@@ -43,7 +49,7 @@ class AzureFunctionsHostConfigurationViewModel(
         val functionNamesEditor: TextEditor,
         environmentVariablesEditor: EnvironmentVariablesEditor,
         useExternalConsoleEditor: FlagEditor,
-        val separator: ViewSeparator,
+        separator: ViewSeparator,
         val urlEditor: TextEditor,
         val dotNetBrowserSettingsEditor: BrowserSettingsEditor
 ) : DotNetExeConfigurationViewModel(
@@ -76,7 +82,8 @@ class AzureFunctionsHostConfigurationViewModel(
     var trackProjectExePath = true
     var trackProjectArguments = true
     var trackProjectWorkingDirectory = true
-    private val portRegex = Regex("--port (\\d+)", RegexOption.IGNORE_CASE)
+
+    private val portRegex = Regex("(--port|-p) (\\d+)", RegexOption.IGNORE_CASE)
 
     init {
         disable()
@@ -87,6 +94,15 @@ class AzureFunctionsHostConfigurationViewModel(
         exePathSelector.path.advise(lifetime) { recalculateTrackProjectOutput() }
         programParametersEditor.parametersString.advise(lifetime) { recalculateTrackProjectOutput() }
         workingDirectorySelector.path.advise(lifetime) { recalculateTrackProjectOutput() }
+
+        functionNamesEditor.text.change.advise(lifetime) { text -> handleFunctionNameChange(text) }
+
+        // Please make sure it is executed after you enable controls through [RunConfigurationViewModelBase::enable]
+        disableBrowserUrl()
+    }
+
+    private fun disableBrowserUrl() {
+        urlEditor.isEnabled.set(false)
     }
 
     private fun handleChangeTfmSelection() {
@@ -107,7 +123,7 @@ class AzureFunctionsHostConfigurationViewModel(
                     val patchedProjectOutput = AzureFunctionsRunnableProjectUtil.patchProjectOutput(projectOutput)
 
                     // ...but keep the previous value if it's not empty
-                    if (programParametersEditor.parametersString.value.isNullOrEmpty()) {
+                    if (programParametersEditor.parametersString.value.isEmpty()) {
                         if (patchedProjectOutput.defaultArguments.isNotEmpty()) {
                             programParametersEditor.parametersString.set(ParametersListUtil.join(patchedProjectOutput.defaultArguments))
                             programParametersEditor.defaultValue.set(ParametersListUtil.join(patchedProjectOutput.defaultArguments))
@@ -120,51 +136,79 @@ class AzureFunctionsHostConfigurationViewModel(
                 }
     }
 
+    // TODO: FIX_WHEN. Add integration tests when enabled in the plugin.
     private fun recalculateTrackProjectOutput() {
-        val selectedProject = projectSelector.project.valueOrNull
-        val selectedTfm = tfmSelector.string.valueOrNull
-        if (selectedProject != null && selectedTfm != null) {
-            selectedProject.projectOutputs.singleOrNull { it.tfm == selectedTfm }?.let {
-                trackProjectExePath = exePathSelector.path.value == it.exePath
-                trackProjectArguments = (it.defaultArguments.isEmpty()
-                        || programParametersEditor.parametersString.value ==
-                        ParametersListUtil.join(it.defaultArguments))
-                trackProjectWorkingDirectory = workingDirectorySelector.path.value == it.workingDirectory
-            }
+        val selectedProject = projectSelector.project.valueOrNull ?: return
+        val selectedTfm = tfmSelector.string.valueOrNull ?: return
 
-            val result = portRegex.find(programParametersEditor.parametersString.value)
-            if (result != null && result.groups.count() == 2) {
-                urlEditor.defaultValue.value = "http://localhost:${result.groupValues[1]}"
-                urlEditor.text.value = "http://localhost:${result.groupValues[1]}"
-                dotNetBrowserSettingsEditor.settings.value = BrowserSettings(false, false, null)
-            }
+        val programParameters = programParametersEditor.parametersString.value
+
+        selectedProject.projectOutputs.singleOrNull { it.tfm == selectedTfm }?.let { projectOutput ->
+            trackProjectExePath = exePathSelector.path.value == projectOutput.exePath
+
+            val defaultArguments = projectOutput.defaultArguments
+            trackProjectArguments = (defaultArguments.isEmpty() || ParametersListUtil.parse(programParameters).containsAll(defaultArguments))
+
+            trackProjectWorkingDirectory = workingDirectorySelector.path.value == projectOutput.workingDirectory
         }
+
+        val parametersPortMatch = portRegex.find(programParameters)
+        val parametersPortValue = parametersPortMatch?.groupValues?.getOrNull(2)?.toIntOrNull() ?: -1
+        composeUrlString(port = parametersPortValue, functionName = functionNamesEditor.text.value)
     }
 
-    private fun handleProjectSelection(project: RunnableProject) {
+    private fun handleProjectSelection(runnableProject: RunnableProject) {
         if (!isLoaded) return
-        reloadTfmSelector(project)
+        reloadTfmSelector(runnableProject)
 
-        val startBrowserUrl = project.customAttributes.singleOrNull { it.key == Key.StartBrowserUrl }?.value ?: ""
-        val launchBrowser = project.customAttributes.singleOrNull { it.key == Key.LaunchBrowser }?.value?.toBoolean() ?: false
+        val startBrowserUrl = runnableProject.customAttributes.singleOrNull { it.key == Key.StartBrowserUrl }?.value ?: ""
+        val launchBrowser = runnableProject.customAttributes.singleOrNull { it.key == Key.LaunchBrowser }?.value?.toBoolean() ?: false
         if (startBrowserUrl.isNotEmpty()) {
-            urlEditor.defaultValue.value = startBrowserUrl
-            urlEditor.text.value = startBrowserUrl
-            dotNetBrowserSettingsEditor.settings.value = BrowserSettings(launchBrowser, false, null)
+            urlEditor.defaultValue.set(startBrowserUrl)
+            urlEditor.text.set(startBrowserUrl)
+            dotNetBrowserSettingsEditor.settings.set(
+                    BrowserSettings(
+                            startAfterLaunch = launchBrowser,
+                            withJavaScriptDebugger = dotNetBrowserSettingsEditor.settings.value.withJavaScriptDebugger,
+                            myBrowser = dotNetBrowserSettingsEditor.settings.value.myBrowser))
         }
 
-        environmentVariablesEditor.envs.set(project.environmentVariables.map { it.key to it.value }.toMap())
+        environmentVariablesEditor.envs.set(runnableProject.environmentVariables.map { it.key to it.value }.toMap())
     }
 
-    private fun reloadTfmSelector(project: RunnableProject) {
+    private fun reloadTfmSelector(runnableProject: RunnableProject) {
         tfmSelector.stringList.clear()
-        project.projectOutputs.map { it.tfm }.sorted().forEach {
+        runnableProject.projectOutputs.map { it.tfm }.sorted().forEach {
             tfmSelector.stringList.add(it)
         }
         if (tfmSelector.stringList.isNotEmpty()) {
             tfmSelector.string.set(tfmSelector.stringList.first())
         }
         handleChangeTfmSelection()
+    }
+
+    private fun handleFunctionNameChange(functionName: String) {
+        composeUrlString(port = null, functionName = functionName)
+    }
+
+    private fun composeUrlString(port: Int? = null, functionName: String? = null) {
+        if (port == null && functionName == null)
+            throw IllegalStateException("Missing all parameters (port, functionName). Please provide at least one.")
+
+        val currentUrl = urlEditor.text.value
+        val originalUrl = if (currentUrl.isNotEmpty()) currentUrl else "http://localhost"
+        val url = URIBuilder(originalUrl)
+
+        if (port != null)
+            url.port = port
+
+        if (functionName != null)
+            url.path = if (functionName.isEmpty()) "" else "/api/${functionName.trim()}"
+
+        val updatedUrl = url.build().toString()
+
+        urlEditor.text.set(updatedUrl)
+        urlEditor.defaultValue.set(updatedUrl)
     }
 
     fun reset(projectFilePath: String,
@@ -195,6 +239,7 @@ class AzureFunctionsHostConfigurationViewModel(
         }
 
         isLoaded = false
+
         this.trackProjectExePath = trackProjectExePath
         this.trackProjectArguments = trackProjectArguments
         this.trackProjectWorkingDirectory = trackProjectWorkingDirectory
@@ -202,13 +247,15 @@ class AzureFunctionsHostConfigurationViewModel(
         this.functionNamesEditor.defaultValue.value = ""
         this.functionNamesEditor.text.value = functionNames
 
+        this.dotNetBrowserSettingsEditor.settings.set(BrowserSettings(
+                startAfterLaunch = dotNetStartBrowserParameters.startAfterLaunch,
+                withJavaScriptDebugger = dotNetStartBrowserParameters.withJavaScriptDebugger,
+                myBrowser = dotNetStartBrowserParameters.browser))
+
+        this.urlEditor.defaultValue.value = dotNetStartBrowserParameters.url
+        this.urlEditor.text.value = dotNetStartBrowserParameters.url
+
         runnableProjectsModel.projects.adviseOnce(lifetime) { projectList ->
-            urlEditor.defaultValue.value = dotNetStartBrowserParameters.url
-            urlEditor.text.value = dotNetStartBrowserParameters.url
-            dotNetBrowserSettingsEditor.settings.set(BrowserSettings(
-                    dotNetStartBrowserParameters.startAfterLaunch,
-                    dotNetStartBrowserParameters.withJavaScriptDebugger,
-                    dotNetStartBrowserParameters.browser))
 
             if (projectFilePath.isEmpty() || projectList.none {
                         it.projectFilePath == projectFilePath && AzureFunctionsHostConfigurationType.isTypeApplicable(it.kind)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationViewModel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationViewModel.kt
@@ -154,7 +154,7 @@ class AzureFunctionsHostConfigurationViewModel(
 
         val parametersPortMatch = portRegex.find(programParameters)
         val parametersPortValue = parametersPortMatch?.groupValues?.getOrNull(2)?.toIntOrNull() ?: -1
-        composeUrlString(port = parametersPortValue, functionName = functionNamesEditor.text.value)
+        composeUrlString(port = parametersPortValue, functionNamesString = functionNamesEditor.text.value)
     }
 
     private fun handleProjectSelection(runnableProject: RunnableProject) {
@@ -188,11 +188,11 @@ class AzureFunctionsHostConfigurationViewModel(
     }
 
     private fun handleFunctionNameChange(functionName: String) {
-        composeUrlString(port = null, functionName = functionName)
+        composeUrlString(port = null, functionNamesString = functionName)
     }
 
-    private fun composeUrlString(port: Int? = null, functionName: String? = null) {
-        if (port == null && functionName == null)
+    private fun composeUrlString(port: Int? = null, functionNamesString: String? = null) {
+        if (port == null && functionNamesString == null)
             throw IllegalStateException("Missing all parameters (port, functionName). Please provide at least one.")
 
         val currentUrl = urlEditor.text.value
@@ -202,8 +202,15 @@ class AzureFunctionsHostConfigurationViewModel(
         if (port != null)
             url.port = port
 
-        if (functionName != null)
-            url.path = if (functionName.isEmpty()) "" else "/api/${functionName.trim()}"
+        if (functionNamesString != null) {
+            val functionNames =
+                    functionNamesString.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+
+            url.path = when (functionNames.size) {
+                1 -> "/api/${functionNames.first()}"
+                else -> ""
+            }
+        }
 
         val updatedUrl = url.build().toString()
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/HostJsonPatcher.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/HostJsonPatcher.kt
@@ -39,7 +39,7 @@ object HostJsonPatcher {
                 File(workingDirectory, "../../host.json")
         )
 
-        return candidates.firstOrNull { it.exists() }
+        return candidates.firstOrNull { it.exists() }?.canonicalFile
     }
 
     fun tryPatchHostJsonFile(workingDirectory: String, functionNames: String) {


### PR DESCRIPTION
- Update configuration view model to not reset browser settings on project output change
- Disable ability to change URL string
- Update logic to track port value in function app arguments
- Add Function Name into generated URL string if known