### PR TITLE
Fixed RIDER-46055. Swap test and buildPlugin gradle tasks

### DIFF
--- a/BuildDevint
+++ b/BuildDevint
@@ -115,8 +115,8 @@ BUILD_NUMBER="3.35.0.$BUILD_COUNTER-2020.2"
 # Build JetBrains Rider 2020.1 plugin
 tc_open "Building Rider plugin"
 {
+    (cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info :rider:test -s -Pbuild_common_code_with=rider -PBuildNumber=$BUILD_NUMBER --console=plain)
     (cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info :rider:buildPlugin -s -Pbuild_common_code_with=rider -PBuildNumber=$BUILD_NUMBER --console=plain)
-    (cd PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info :rider:test)
     cp ./PluginsAndFeatures/azure-toolkit-for-intellij/rider/build/distributions/azure-toolkit-for-rider-$BUILD_NUMBER.zip ./$ARTIFACTS_DIR/azure-toolkit-for-rider-$BUILD_NUMBER.zip
     df -h
 }


### PR DESCRIPTION
`./gradlew :rider:test` task executes `:rider:buildPlugin`. Since call did not pass parameters to the task we got default build number `9999` when running tests. Test task runs latest so, final build was compiled with corrupted build number. Swap build and test tasks and add parameters for tests. Need to re-think the approach and maybe run tests without rebuilding in future (that was the original intension).