### PR TITLE
Fixed RIDER-44654. Base setup for integration tests

### DIFF
--- a/BuildPlugin
+++ b/BuildPlugin
@@ -155,20 +155,8 @@ fi
 
 BUILD_NUMBER="3.35.0.$BUILD_COUNTER-2020.2"
 
-tc_open "Run Rider tests"
-{
-    (cd "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info :rider:test -s --console=plain)
-    (cd "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info :rider:clean -s --console=plain)
-    rm -rf "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij/rider/build/
-    df -h
-}
-tc_close "Run Rider tests"
-
 tc_open "Building Rider plugin"
 {
-    # :rider:test task depends on :buildPlugin that prepare the plugin package.
-    # When we run then :rider:buildPlugin Gradle task, some tasks (including a task that get outputs from backend compilation) are skipped.
-    # TODO: Fix --rerun-tasks: split tests execution step from the build process.
     (cd "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info --rerun-tasks :rider:buildPlugin -s -Pbuild_common_code_with=rider -PBuildNumber=$BUILD_NUMBER --console=plain)
     cp "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij/rider/build/distributions/azure-toolkit-for-rider-"$BUILD_NUMBER".zip "$ARTIFACTS_DIR"/azure-toolkit-for-rider-"$BUILD_NUMBER".zip
     df -h

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/.idea/gradle.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/.idea/gradle.xml
@@ -8,7 +8,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="1.8" />
+        <option name="gradleJvm" value="11.0.6" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -14,7 +14,6 @@ rider_backend_build_configuration=Debug
 
 # TODO: Bump scala plugin version when they fix the issue with final ScalaConsoleRunConfiguration class in 202 version
 dep_plugins=org.intellij.scala:2020.1.10
-dep_plugins_rider=DatabaseTools
 applicationinsights.key=57cc111a-36a8-44b3-b044-25d293b8b77c
 
 updateVersionRange=false
@@ -22,9 +21,11 @@ patchPluginXmlSinceBuild=202
 
 gradle_plugin_version=0.4.21
 kotlin_version=1.3.72
-rd_version=0.202.99
-rider_nuget_sdk_version=2020.2.0-eap06
+rd_version=0.202.118
+rider_nuget_sdk_version=2020.2.0-eap07
 web_socket_version=1.3.9
 retrofit_version=2.8.1
 
 assertj_version=3.15.0
+
+rider_test_local_env_run=true

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/build.gradle
@@ -1,9 +1,26 @@
+import org.jetbrains.intellij.tasks.PrepareSandboxTask
+
+sourceSets {
+    integrationTest {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+
+        kotlin.srcDirs = ['test-integration']
+        resources.srcDirs = ['test-integration/resources']
+    }
+}
+
 dependencies {
     compile rootProject
     compile "org.java-websocket:Java-WebSocket:$web_socket_version"
     compile "com.squareup.retrofit2:converter-gson:$retrofit_version"
 
-    testCompile rootProject
+    testImplementation rootProject
+}
+
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
 }
 
 ext.resharperPluginPath = new File(projectDir, 'ReSharper.Azure')
@@ -24,10 +41,14 @@ intellij {
     pluginName = 'azure-toolkit-for-rider'
     version = rider_version
 
-    plugins 'JavaScriptLanguage', 'terminal', 'restClient', dep_plugins_rider
+    // Workaround for https://youtrack.jetbrains.com/issue/IDEA-179607
+    def extraPlugins = [ "rider-plugins-appender" ]
+    plugins = ['DatabaseTools', 'JavaScriptLanguage', 'terminal', 'restClient'] + extraPlugins
+
+    downloadSources = Boolean.valueOf(sources)
 }
 
-tasks.withType(prepareSandbox.class).configureEach {
+tasks.withType(PrepareSandboxTask).configureEach {
     dependsOn buildReSharperPlugin
 
     from(extensionsFrom, { into "${intellij.pluginName}/dotnet" })
@@ -41,8 +62,32 @@ patchPluginXml {
 }
 
 test {
+    description = "Rider unit tests."
     dependsOn ':rider:buildPlugin'
+
     useTestNG()
+}
+
+task integrationTest(type: Test) {
+    description = "Rider Azure integration tests based on Rider Test Framework."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    dependsOn ':rider:buildPlugin'
+
+    environment("LOCAL_ENV_RUN", rider_test_local_env_run)
+    environment("NO_FS_ROOTS_ACCESS_CHECK", true)
+    useTestNG()
+
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+
+    testLogging {
+        showStandardStreams = true
+        exceptionFormat "full"
+    }
+
+    doFirst {
+        println "LOCAL_ENV_RUN = $rider_test_local_env_run"
+    }
 }
 
 clean {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/protocol/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/protocol/build.gradle
@@ -38,6 +38,9 @@ ext.csDaemonGeneratedOutput = new File(resharperPluginPath, 'src/Azure.Daemon/Pr
 ext.ktGeneratedOutput = new File(projectDir, '../src/org/jetbrains/protocol')
 ext.modelDir = new File(projectDir, 'src/model')
 
+ext.rdgenDir = file("${project.buildDir}/rdgen/")
+rdgenDir.mkdirs()
+
 task generateModel(type: tasks.getByName('rdgen').class) {
     group = protocolGroup
     description = 'Generates protocol models'
@@ -46,7 +49,7 @@ task generateModel(type: tasks.getByName('rdgen').class) {
     // intellij SDK, which is extracted in afterEvaluate
     params {
         verbose = true
-        hashFolder = 'build/rdgen'
+        hashFolder = rdgenDir
 
         logger.info('Configuring rdgen params')
         classpath {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/helpers/validator/IpAddressValidator.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/helpers/validator/IpAddressValidator.kt
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2020 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.intellij.helpers.validator
+
+import com.intellij.openapi.ui.InputValidator
+
+class IpAddressInputValidator : InputValidator {
+    companion object {
+        val instance = IpAddressInputValidator()
+    }
+
+    override fun checkInput(input: String?): Boolean {
+        return !input.isNullOrEmpty() && validateIpV4Address(input)
+    }
+
+    override fun canClose(input: String?): Boolean {
+        return checkInput(input)
+    }
+
+    fun validateIpV4Address(address: String): Boolean {
+        val regex = Regex("^(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})$")
+        val match = regex.matchEntire(address) ?: return false
+
+        return match.groupValues.drop(1).all { value ->
+            val intValue = value.toIntOrNull()
+                    ?: return@all false
+
+            if (value.length > 1 && value.startsWith('0'))
+                return@all false
+
+            intValue in 0..255
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/AddCurrentIpAddressToFirewallAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/AddCurrentIpAddressToFirewallAction.kt
@@ -35,6 +35,7 @@ import com.microsoft.azuretools.authmanage.AuthMethodManager
 import com.microsoft.azuretools.core.mvp.model.database.AzureSqlServerMvpModel
 import com.microsoft.azuretools.ijidea.actions.AzureSignInAction
 import com.microsoft.icons.CommonIcons
+import com.microsoft.intellij.helpers.validator.IpAddressInputValidator
 import com.microsoft.tooling.msservices.serviceexplorer.Node
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener
@@ -43,7 +44,6 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqlserver
 import org.jetbrains.plugins.azure.RiderAzureBundle.message
 import org.jetbrains.plugins.azure.cloudshell.AzureCloudShellNotifications
 import org.jetbrains.plugins.azure.util.PublicIpAddressProvider
-import sun.net.util.IPAddressUtil
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -93,7 +93,7 @@ abstract class AddCurrentIpAddressToFirewallAction(private val node: Node) : Nod
                 message("dialog.cloud_shell.app_firewall_rule.title"),
                 firewallIcon,
                 publicIpAddressResult.ipv4address,
-                IpAddressInputValidator.INSTANCE)
+                IpAddressInputValidator.instance)
 
         if (ipAddressInput.isNullOrEmpty()) return
 
@@ -124,19 +124,5 @@ abstract class AddCurrentIpAddressToFirewallAction(private val node: Node) : Nod
                         NotificationType.INFORMATION)
             }
         })
-    }
-
-    private class IpAddressInputValidator : InputValidator {
-        companion object {
-            val INSTANCE = IpAddressInputValidator()
-        }
-
-        override fun checkInput(input: String?): Boolean {
-            return !input.isNullOrEmpty() && IPAddressUtil.isIPv4LiteralAddress(input)
-        }
-
-        override fun canClose(input: String?): Boolean {
-            return checkInput(input)
-        }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/daemon/FunctionAppDaemonHost.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/daemon/FunctionAppDaemonHost.kt
@@ -34,7 +34,7 @@ import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.openapi.actionSystem.impl.SimpleDataContext
 import com.intellij.openapi.project.Project
 import com.intellij.util.execution.ParametersListUtil
-import com.jetbrains.rdclient.ui.bindableUi.extensions.valueOrEmpty
+import com.jetbrains.rd.platform.ui.bedsl.extensions.valueOrEmpty
 import com.jetbrains.rdclient.util.idea.LifetimedProjectComponent
 import com.jetbrains.rider.model.RunnableProject
 import com.jetbrains.rider.model.functionAppDaemonModel

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/storage/azurite/AzuriteConfigurationPanel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/storage/azurite/AzuriteConfigurationPanel.kt
@@ -42,9 +42,9 @@ import com.intellij.util.ui.SwingHelper
 import com.intellij.webcore.ui.PathShortener
 import com.microsoft.intellij.configuration.AzureRiderSettings
 import com.microsoft.intellij.configuration.ui.AzureRiderAbstractConfigurablePanel
+import com.microsoft.intellij.helpers.validator.IpAddressInputValidator
 import org.jetbrains.plugins.azure.RiderAzureBundle
 import org.jetbrains.plugins.azure.orWhenNullOrEmpty
-import sun.net.util.IPAddressUtil
 import java.io.File
 import javax.swing.*
 
@@ -239,7 +239,7 @@ class AzuriteConfigurationPanel(private val project: Project) : AzureRiderAbstra
             }
 
     private fun validationForIpAddress(textField: JBTextField) =
-            if (textField.text.isNullOrEmpty() || !IPAddressUtil.isIPv4LiteralAddress(textField.text)) {
+            if (textField.text.isNullOrEmpty() || !IpAddressInputValidator.instance.validateIpV4Address(textField.text)) {
                 ValidationInfo(RiderAzureBundle.message("settings.azurite.validation.invalid.ip"), textField)
             } else {
                 null

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest.kt
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2020 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.cases.documentmodel.completion.csharp
+
+import com.jetbrains.rider.test.annotations.TestEnvironment
+import com.jetbrains.rider.test.base.CompletionTestBase
+import com.jetbrains.rider.test.enums.CoreVersion
+import com.jetbrains.rider.test.scriptingApi.*
+import org.testng.annotations.DataProvider
+import org.testng.annotations.Test
+
+@TestEnvironment(coreVersion = CoreVersion.DEFAULT)
+class AzureFunctionsTimerTriggerCompletionTest : CompletionTestBase() {
+
+    override fun getSolutionDirectoryName(): String = "FunctionApp"
+
+    override val restoreNuGetPackages: Boolean? = true
+
+    override val checkTextControls: Boolean = false
+
+    private val defaultCronCompletionList = arrayOf(
+            "*/15 * * * * *",
+            "* * * * * *",
+            "0 */5 * * * *",
+            "0 * * * * *",
+            "0 0 */6 * * *",
+            "0 0 * * * *",
+            "0 0 * * * Sun",
+            "0 0 * * * 1-5",
+            "0 0 0 * * *",
+            "0 0 0 * * Sat,Sun",
+            "0 0 0 * * 0",
+            "0 0 0 * * 6,0",
+            "0 0 0 1-7 * Sun",
+            "0 0 0 1 * *",
+            "0 0 0 1 1 *",
+            "0 0 8-18 * * *",
+            "0 0 9 * * Mon",
+            "0 0 10 * * *",
+            "0 30 9 * Jan Mon",
+            "11 5 23 * * *"
+    )
+
+    @Test(description = "Check the full list of completion variants on opening double quote.")
+    fun testPopup_CompletionList_FullListOnQuote() {
+        withOpenedEditor("Function.cs", "Function.cs") {
+            typeWithLatency("\"")
+            assertLookupContainsExact(*defaultCronCompletionList)
+        }
+    }
+
+    @Test(description = "Check the full list of completion variants when calling a basic completion.")
+    fun testPopup_CompletionList_FullListOnBasicCompletion() {
+        dumpOpenedEditor("Function.cs", "Function.cs") {
+            callBasicCompletion()
+            assertLookupContainsExact(*defaultCronCompletionList)
+            completeWithEnter()
+        }
+    }
+
+    @Test(description = "Check completion variants are filtered by a digit prefix.")
+    fun testPopup_CompletionList_DigitPrefix() {
+        withOpenedEditor("Function.cs", "Function.cs") {
+            typeWithLatency("0")
+            val expectedCompletionList = defaultCronCompletionList.filter { it.contains("0") }.toTypedArray()
+            assertLookupContainsExact(*expectedCompletionList)
+        }
+    }
+
+    @Test(description = "Check completion variants are filtered by a literal prefix.")
+    fun testPopup_CompletionList_LiteralPrefix() {
+        withOpenedEditor("Function.cs", "Function.cs") {
+            typeWithLatency("Sun")
+            val expectedCompletionList = defaultCronCompletionList.filter { it.contains("Sun") }.toTypedArray()
+            assertLookupContainsExact(*expectedCompletionList)
+        }
+    }
+
+    @DataProvider(name = "completionSymbolPrefixData")
+    fun completionSymbolPrefixData() = arrayOf(
+            arrayOf("Star", "*"),
+            arrayOf("Slash", "/"),
+            arrayOf("Comma", ","),
+            arrayOf("Space", " ")
+    )
+
+    // TODO: We might think about re-working this to allow these symbols in completion porefix if it does not break default behavior.
+    @Test(description = "Check completion list is not show on termination symbols.",
+            dataProvider = "completionSymbolPrefixData")
+    fun testPopup_CompletionList_SymbolPrefix(name: String, toType: String) {
+        withOpenedEditor("Function.cs", "Function.cs") {
+            typeWithLatency(toType)
+            ensureThereIsNoLookup()
+        }
+    }
+
+    @Test(description = "Check completion variants are filtered by full match when type different prefix.")
+    fun testPopup_CompletionList_MixedPrefix() {
+        withOpenedEditor("Function.cs", "Function.cs") {
+            typeWithLatency("0")
+            assertLookupContainsExact(*defaultCronCompletionList.filter { it.startsWith("0") }.toTypedArray())
+
+            typeWithLatency(" ")
+            assertLookupContainsExact(*defaultCronCompletionList.filter { it.startsWith("0 ") }.toTypedArray())
+
+            typeWithLatency("0")
+            assertLookupContainsExact(*defaultCronCompletionList.filter { it.contains("0.+0".toRegex()) }.toTypedArray())
+
+            typeWithLatency(" 0")
+            assertLookupContainsExact(*defaultCronCompletionList.filter { it.contains("0.+0.+0".toRegex()) }.toTypedArray())
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest.kt
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2020 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.cases.markup.functionapp.csharp
+
+import com.jetbrains.rdclient.daemon.util.attributeId
+import com.jetbrains.rdclient.testFramework.waitForDaemon
+import com.jetbrains.rider.test.annotations.TestEnvironment
+import com.jetbrains.rider.test.base.BaseTestWithMarkup
+import com.jetbrains.rider.test.enums.CoreVersion
+import org.testng.annotations.Test
+
+@TestEnvironment(coreVersion = CoreVersion.DEFAULT)
+class AzureFunctionRunMarkerTest : BaseTestWithMarkup() {
+
+    companion object {
+        private const val FUNCTION_APP_RUN_MARKER_ATTRIBUTE_ID = "Azure Function App Run Method Gutter Mark"
+    }
+
+    override fun getSolutionDirectoryName(): String = "FunctionApp"
+
+    @Test(description = "Check function app gutter mark is shown on a default Http Trigger Function App from item template.")
+    fun testFunctionApp_HttpTriggerFromItemTemplate_Detected() = verifyLambdaGutterMark()
+
+    @Test(description = "Check Http Trigger function app that miss required attribute is not marked with Function App gutter mark.")
+    fun testFunctionApp_HttpTriggerMissingAttribute_NotDetected() = verifyLambdaGutterMark()
+
+    @Test(description = "Check any function having required attribute is shown with Function App gutter mark.")
+    fun testFunctionApp_MethodWithAttribute_Detected() = verifyLambdaGutterMark()
+
+    @Test(description = "Check Timer Trigger function with required attribute is shown with Function App gutter mark.")
+    fun testFunctionApp_TimerTriggerFromItemTemplate_Detected() = verifyLambdaGutterMark()
+
+    @Test(description = "Check Http Trigger function having an attribute, but not a correct one is shown without Function App gutter mark.")
+    fun testFunctionApp_HttpTriggerWithIncorrectAttribute_NotDetected() = verifyLambdaGutterMark()
+
+    @Test(description = "Check Http Trigger function having multiple attribute including required [FunctionName] is shown with Function App gutter mark.")
+    fun testFunctionApp_HttpTriggerWithMultipleAttributes_Detected() = verifyLambdaGutterMark()
+
+    @Test(description = "Check Http Trigger function having a required attribute, but on namespace level is shown without Function App gutter mark.")
+    fun testFunctionApp_HttpTriggerWithNamespaceAttribute_NotDetected() = verifyLambdaGutterMark()
+
+    @Test(description = "Check multipole functions inside one class with [FunctionName] required attribute are shown with gutter mark.")
+    fun testFunctionApp_MultipleFunctionApps_Detected() = verifyLambdaGutterMark()
+
+    private fun verifyLambdaGutterMark() {
+        doTestWithMarkupModel(
+                testFilePath = "FunctionApp/Function.cs",
+                sourceFileName = "Function.cs",
+                goldFileName = "Function.gold"
+        ) {
+            waitForDaemon()
+            dumpHighlightersTree(
+                    valueFilter = { it.attributeId.contains(FUNCTION_APP_RUN_MARKER_ATTRIBUTE_ID) }
+            )
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationEditorTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationEditorTest.kt
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2020 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.cases.runconfig.functionapp
+
+import com.intellij.openapi.util.Disposer
+import com.jetbrains.rider.model.RunnableProjectKind
+import com.jetbrains.rider.model.runnableProjectsModel
+import com.jetbrains.rider.projectView.solution
+import com.jetbrains.rider.test.annotations.TestEnvironment
+import com.jetbrains.rider.test.asserts.*
+import com.jetbrains.rider.test.base.BaseTestWithSolution
+import com.jetbrains.rider.test.enums.CoreVersion
+import com.jetbrains.rider.test.scriptingApi.createRunConfiguration
+import org.jetbrains.plugins.azure.functions.run.AzureFunctionsHostConfiguration
+import org.jetbrains.plugins.azure.functions.run.AzureFunctionsHostConfigurationEditor
+import org.jetbrains.plugins.azure.functions.run.AzureFunctionsHostConfigurationType
+import org.testng.annotations.AfterMethod
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+@TestEnvironment(coreVersion = CoreVersion.DEFAULT)
+class FunctionHostConfigurationEditorTest : BaseTestWithSolution() {
+
+    override fun getSolutionDirectoryName(): String = "FunctionApp"
+
+    override val waitForCaches: Boolean = true
+
+    lateinit var editor: AzureFunctionsHostConfigurationEditor
+
+    @BeforeMethod
+    fun setUp() {
+        editor = AzureFunctionsHostConfigurationEditor(project)
+    }
+
+    @AfterMethod
+    fun tearDown() {
+        Disposer.dispose(editor)
+    }
+
+    private val type = AzureFunctionsHostConfigurationType()
+
+    @Test
+    fun testFunctionHost_DefaultParameters() {
+        val configuration = createRunConfiguration(
+                name = "Run FunctionApp",
+                configurationType = AzureFunctionsHostConfigurationType::class.java
+        ) as AzureFunctionsHostConfiguration
+
+        editor.component // to initialize viewModel
+        editor.resetFrom(configuration)
+        editor.applyTo(configuration)
+
+        val runnableProject =
+                project.solution.runnableProjectsModel.projects.valueOrNull?.find { it.name == "FunctionApp" }.shouldNotBeNull()
+
+        val parameters = configuration.parameters
+        parameters.project.name.shouldBe("FunctionApp")
+        parameters.projectFilePath.shouldBe(runnableProject.projectFilePath)
+        parameters.functionNames.shouldBeEmpty()
+        parameters.isUnloadedProject.shouldBeFalse()
+        parameters.projectKind.shouldBe(RunnableProjectKind.AzureFunctions)
+        parameters.projectTfm.shouldBe(".NETCoreApp,Version=v3.1")
+
+        val projectOutput = runnableProject.projectOutputs.first()
+        parameters.workingDirectory.shouldBe(projectOutput.workingDirectory)
+        parameters.exePath.shouldBe(projectOutput.exePath)
+
+        parameters.programParameters.shouldBe("host start --port 7071 --pause-on-error")
+        parameters.envs.size.shouldBe(0)
+        parameters.isPassParentEnvs.shouldBeTrue()
+        parameters.useExternalConsole.shouldBeFalse()
+
+        parameters.startBrowserParameters.browser.shouldBeNull()
+        parameters.startBrowserParameters.startAfterLaunch.shouldBeFalse()
+        parameters.startBrowserParameters.url.shouldBe("http://localhost:7071")
+        parameters.startBrowserParameters.withJavaScriptDebugger.shouldBeFalse()
+
+        parameters.trackProjectArguments.shouldBeTrue()
+        parameters.trackProjectExePath.shouldBeTrue()
+        parameters.trackProjectWorkingDirectory.shouldBeTrue()
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationParametersTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationParametersTest.kt
@@ -1,0 +1,412 @@
+/**
+ * Copyright (c) 2020 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.cases.runconfig.functionapp
+
+import com.intellij.execution.configurations.RuntimeConfigurationError
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.project.Project
+import com.jetbrains.rider.model.*
+import com.jetbrains.rider.projectView.solution
+import com.jetbrains.rider.run.configurations.project.DotNetStartBrowserParameters
+import com.jetbrains.rider.runtime.RiderDotNetActiveRuntimeHost
+import com.jetbrains.rider.runtime.mono.MonoRuntime
+import com.jetbrains.rider.test.annotations.TestEnvironment
+import com.jetbrains.rider.test.base.BaseTestWithSolution
+import com.jetbrains.rider.test.enums.CoreVersion
+import com.microsoft.intellij.configuration.AzureRiderSettings
+import org.jetbrains.plugins.azure.functions.run.AzureFunctionsHostConfigurationParameters
+import org.testng.annotations.AfterMethod
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+import java.io.File
+
+@TestEnvironment(coreVersion = CoreVersion.DEFAULT)
+class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
+
+    override fun getSolutionDirectoryName(): String = "FunctionApp"
+
+    override val waitForCaches: Boolean = true
+
+    override val restoreNuGetPackages: Boolean = true
+
+    private var originalCoreToolsProperty: String? = null
+
+    @BeforeMethod(alwaysRun = true)
+    fun collectCoreToolsProperties() {
+        originalCoreToolsProperty =
+                PropertiesComponent.getInstance().getValue(AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH)
+    }
+
+    @AfterMethod(alwaysRun = true)
+    fun restoreCoreToolsProperty() {
+        PropertiesComponent.getInstance().setValue(
+                AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH, originalCoreToolsProperty)
+    }
+
+    //region Invalid
+
+    @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Solution is loading, please wait for a few seconds\\.")
+    fun testValidate_Solution_NotLoaded() {
+        val parameters = createParameters(project = project)
+        project.solution.isLoaded.set(false)
+        parameters.validate(createHost())
+    }
+
+    @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Project is not specified\\.")
+    fun testValidate_RunnableProjects_NoRunnableProjects() {
+        val parameters = createParameters(project = project)
+        project.solution.runnableProjectsModel.projects.set(emptyList())
+        parameters.validate(createHost())
+    }
+
+    @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Project is not specified\\.")
+    fun testValidate_RunnableProjects_NoFunctionProjectType() {
+        val parameters = createParameters(project = project)
+        project.solution.runnableProjectsModel.projects.set(listOf(createRunnableProject(kind = RunnableProjectKind.DotNetCore)))
+        parameters.validate(createHost())
+    }
+
+    @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Project is not specified\\.")
+    fun testValidate_RunnableProjects_MultipleRunnableProjectsMatch() {
+        val projectFilePath = File("project/file/path").path
+        val parameters = createParameters(project = project, projectFilePath = projectFilePath)
+
+        project.solution.runnableProjectsModel.projects.set(listOf(
+                createRunnableProject(kind = RunnableProjectKind.DotNetCore, projectFilePath = projectFilePath),
+                createRunnableProject(kind = RunnableProjectKind.DotNetCore, projectFilePath = projectFilePath)
+        ))
+        parameters.validate(createHost())
+    }
+
+    @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Function App is not loaded properly\\.")
+    fun testValidate_RunnableProjects_ProjectWithProblems() {
+        val projectFilePath = File("project/file/path").path
+        val parameters = createParameters(project = project, projectFilePath = projectFilePath)
+        project.solution.runnableProjectsModel.projects.set(listOf(
+                createRunnableProject(
+                        kind = RunnableProjectKind.AzureFunctions,
+                        projectFilePath = projectFilePath,
+                        problems = "Function App is not loaded properly."
+                )
+        ))
+        parameters.validate(createHost())
+    }
+
+    @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Invalid exe path: '/not/existing/path'\\.")
+    fun testValidate_TrackProjectExePath_NotExists() {
+        val projectFilePath = File("project/file/path").path
+
+        val parameters =
+                createParameters(project = project, projectFilePath = projectFilePath, trackProjectExePath = false, exePath = "/not/existing/path")
+
+        project.solution.runnableProjectsModel.projects.set(listOf(
+                createRunnableProject(
+                        kind = RunnableProjectKind.AzureFunctions,
+                        projectFilePath = projectFilePath,
+                        problems = null
+                )
+        ))
+        parameters.validate(createHost())
+    }
+
+    @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Invalid exe path: '<empty>'\\.")
+    fun testValidate_TrackProjectExePath_EmptyExePath() {
+        val projectFilePath = File("project/file/path").path
+
+        val parameters =
+                createParameters(project = project, projectFilePath = projectFilePath, trackProjectExePath = false, exePath = "")
+
+        project.solution.runnableProjectsModel.projects.set(listOf(
+                createRunnableProject(
+                        kind = RunnableProjectKind.AzureFunctions,
+                        projectFilePath = projectFilePath,
+                        problems = null
+                )
+        ))
+        parameters.validate(createHost())
+    }
+
+    @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Invalid exe path:\\s.+\\.")
+    fun testValidate_TrackProjectExePath_NotAFile() {
+        val projectFilePath = File("project/file/path").path
+
+        val parameters = createParameters(
+                project = project,
+                projectFilePath = projectFilePath,
+                trackProjectExePath = false,
+                exePath = tempTestDirectory.path
+        )
+
+        project.solution.runnableProjectsModel.projects.set(listOf(
+                createRunnableProject(
+                        kind = RunnableProjectKind.AzureFunctions,
+                        projectFilePath = projectFilePath,
+                        problems = null
+                )
+        ))
+        parameters.validate(createHost())
+    }
+
+    @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Invalid working directory: '/not/existing/path'\\.")
+    fun testValidate_TrackProjectWorkingDirectory_NotExists() {
+        val projectFilePath = File("project/file/path").path
+
+        val parameters = createParameters(
+                project = project,
+                projectFilePath = projectFilePath,
+                trackProjectExePath = true,
+                trackProjectWorkingDirectory = false,
+                workingDirectory = "/not/existing/path"
+        )
+
+        project.solution.runnableProjectsModel.projects.set(listOf(
+                createRunnableProject(
+                        kind = RunnableProjectKind.AzureFunctions,
+                        projectFilePath = projectFilePath,
+                        problems = null
+                )
+        ))
+        parameters.validate(createHost())
+    }
+
+    @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Invalid working directory: '<empty>'\\.")
+    fun testValidate_TrackProjectWorkingDirectory_EmptyDirectory() {
+        val projectFilePath = File("project/file/path").path
+
+        val parameters = createParameters(
+                project = project,
+                projectFilePath = projectFilePath,
+                trackProjectExePath = true,
+                trackProjectWorkingDirectory = false,
+                workingDirectory = ""
+        )
+
+        project.solution.runnableProjectsModel.projects.set(listOf(
+                createRunnableProject(
+                        kind = RunnableProjectKind.AzureFunctions,
+                        projectFilePath = projectFilePath,
+                        problems = null
+                )
+        ))
+        parameters.validate(createHost())
+    }
+
+    @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Invalid working directory:\\s.+\\.")
+    fun testValidate_TrackProjectWorkingDirectory_NotADirectory() {
+        val projectFilePath = File("project/file/path").path
+
+        val workingDirectoryFile = tempTestDirectory.resolve("FunctionApp.dll")
+        workingDirectoryFile.createNewFile()
+
+        val parameters = createParameters(
+                project = project,
+                projectFilePath = projectFilePath,
+                trackProjectExePath = true,
+                trackProjectWorkingDirectory = false,
+                workingDirectory = workingDirectoryFile.path
+        )
+
+        project.solution.runnableProjectsModel.projects.set(listOf(
+                createRunnableProject(
+                        kind = RunnableProjectKind.AzureFunctions,
+                        projectFilePath = projectFilePath,
+                        problems = null
+                )
+        ))
+        parameters.validate(createHost())
+    }
+
+    @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Path to Azure Functions core tools has not been configured\\. This can be done in the settings under Tools \\| Azure \\| Functions\\.")
+    fun testValidate_FunctionCoreTools_NotInstalled() {
+        val projectFilePath = File("project/file/path").path
+
+        val parameters = createParameters(
+                project = project,
+                projectFilePath = projectFilePath,
+                trackProjectExePath = true,
+                trackProjectWorkingDirectory = true
+        )
+
+        project.solution.runnableProjectsModel.projects.set(listOf(
+                createRunnableProject(
+                        kind = RunnableProjectKind.AzureFunctions,
+                        projectFilePath = projectFilePath,
+                        problems = null
+                )
+        ))
+
+        PropertiesComponent.getInstance().unsetValue(AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH)
+        parameters.validate(createHost())
+    }
+
+    @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Mono runtime not found\\. Please setup Mono path in settings \\(File \\| Settings \\| Build, Execution, Deployment \\| Toolset and Build\\)")
+    fun testValidate_MonoRuntime_MissingMonoConfig() {
+        val projectFilePath = File("project/file/path").path
+
+        val parameters = createParameters(
+                project = project,
+                projectFilePath = projectFilePath,
+                trackProjectExePath = true,
+                trackProjectWorkingDirectory = true
+        ).apply { useMonoRuntime = true }
+
+        val host = createHost(monoRuntime = null)
+
+        project.solution.runnableProjectsModel.projects.set(listOf(
+                createRunnableProject(
+                        kind = RunnableProjectKind.AzureFunctions,
+                        projectFilePath = projectFilePath,
+                        problems = null)
+        ))
+
+        setCoreToolsPath()
+        parameters.validate(host)
+    }
+
+    //endregion Invalid
+
+    //region Valid
+
+    @Test
+    fun testValidate_Valid_UseMonoRuntime() {
+        val projectFilePath = File("project/file/path").path
+
+        val parameters = createParameters(
+                project = project,
+                projectFilePath = projectFilePath,
+                trackProjectExePath = true,
+                trackProjectWorkingDirectory = true
+        ).apply { useMonoRuntime = true }
+
+        val host = createHost(monoRuntime = MonoRuntime(monoExePath = ""))
+
+        project.solution.runnableProjectsModel.projects.set(listOf(
+                createRunnableProject(
+                        kind = RunnableProjectKind.AzureFunctions,
+                        projectFilePath = projectFilePath,
+                        problems = null)
+        ))
+
+        setCoreToolsPath()
+        parameters.validate(host)
+    }
+
+    @Test
+    fun testValidate_Valid_NetCoreRuntime() {
+        val projectFilePath = File("project/file/path").path
+
+        val parameters = createParameters(
+                project = project,
+                projectFilePath = projectFilePath,
+                trackProjectExePath = true,
+                trackProjectWorkingDirectory = true
+        ).apply { useMonoRuntime = false }
+
+        val host = createHost()
+
+        project.solution.runnableProjectsModel.projects.set(listOf(
+                createRunnableProject(
+                        kind = RunnableProjectKind.AzureFunctions,
+                        projectFilePath = projectFilePath,
+                        problems = null)
+        ))
+
+        setCoreToolsPath()
+        parameters.validate(host)
+    }
+
+    //endregion Valid
+
+    private fun createParameters(
+            project: Project = this.project,
+            exePath: String = "",
+            programParameters: String = "host start --port 7071 --pause-on-error",
+            workingDirectory: String = File("working/path").path,
+            envs: Map<String, String> = emptyMap(),
+            isPassParentEnvs: Boolean = true,
+            useExternalConsole: Boolean = false,
+            projectFilePath: String = "",
+            trackProjectExePath: Boolean = false,
+            trackProjectArguments: Boolean = false,
+            trackProjectWorkingDirectory: Boolean = false,
+            projectKind: RunnableProjectKind = RunnableProjectKind.AzureFunctions,
+            projectTfm: String = ".NETCoreApp,Version=v3.1",
+            functionNames: String = "",
+            startBrowserParameters: DotNetStartBrowserParameters = DotNetStartBrowserParameters()
+    ): AzureFunctionsHostConfigurationParameters =
+            AzureFunctionsHostConfigurationParameters(
+                    project = project,
+                    exePath = exePath,
+                    programParameters = programParameters,
+                    workingDirectory = workingDirectory,
+                    envs = envs,
+                    isPassParentEnvs = isPassParentEnvs,
+                    useExternalConsole = useExternalConsole,
+                    projectFilePath = projectFilePath,
+                    trackProjectExePath = trackProjectExePath,
+                    trackProjectArguments = trackProjectArguments,
+                    trackProjectWorkingDirectory = trackProjectWorkingDirectory,
+                    projectKind = projectKind,
+                    projectTfm = projectTfm,
+                    functionNames = functionNames,
+                    startBrowserParameters = startBrowserParameters
+            )
+
+    fun createHost(monoRuntime: MonoRuntime? = null): RiderDotNetActiveRuntimeHost {
+        val host = RiderDotNetActiveRuntimeHost(project)
+        host.monoRuntime = monoRuntime
+
+        return host
+    }
+
+    fun createRunnableProject(
+            name: String = "TestName",
+            fullName: String = "TestFullName",
+            projectFilePath: String = "",
+            kind: RunnableProjectKind = RunnableProjectKind.AzureFunctions,
+            projectOutputs: List<ProjectOutput> = emptyList(),
+            environmentVariables: List<EnvironmentVariable> = emptyList(),
+            problems: String? = null,
+            customAttributes: List<CustomAttribute> = emptyList()
+    ): RunnableProject =
+        RunnableProject(
+                name = name,
+                fullName = fullName,
+                projectFilePath = projectFilePath,
+                kind = kind,
+                projectOutputs = projectOutputs,
+                environmentVariables = environmentVariables,
+                problems = problems,
+                customAttributes = customAttributes
+        )
+
+    private fun setCoreToolsPath(): File {
+        val funcCoreTools = tempTestDirectory.resolve("func")
+        funcCoreTools.createNewFile()
+        funcCoreTools.setExecutable(true)
+
+        PropertiesComponent.getInstance().setValue(AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH, tempTestDirectory.canonicalPath)
+
+        return funcCoreTools
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationTest.kt
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2020 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.cases.runconfig.functionapp
+
+import com.intellij.execution.RunManagerEx
+import com.intellij.execution.configurations.ConfigurationType
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.ide.util.PropertiesComponent
+import com.jetbrains.rider.build.BuildHost
+import com.jetbrains.rider.model.RunnableProjectKind
+import com.jetbrains.rider.model.runnableProjectsModel
+import com.jetbrains.rider.projectView.solution
+import com.jetbrains.rider.test.annotations.TestEnvironment
+import com.jetbrains.rider.test.asserts.shouldBe
+import com.jetbrains.rider.test.asserts.shouldContain
+import com.jetbrains.rider.test.base.BaseTestWithSolution
+import com.jetbrains.rider.test.enums.CoreVersion
+import com.jetbrains.rider.test.scriptingApi.*
+import com.microsoft.intellij.configuration.AzureRiderSettings
+import org.jetbrains.plugins.azure.functions.buildTasks.BuildFunctionsProjectBeforeRunTaskProvider
+import org.jetbrains.plugins.azure.functions.run.AzureFunctionsHostConfiguration
+import org.jetbrains.plugins.azure.functions.run.AzureFunctionsHostConfigurationType
+import org.testng.annotations.AfterMethod
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+import kotlin.test.fail
+
+@TestEnvironment(coreVersion = CoreVersion.DEFAULT)
+class FunctionHostConfigurationTest : BaseTestWithSolution() {
+
+    override fun getSolutionDirectoryName(): String = "FunctionApp"
+
+    override val waitForCaches: Boolean = true
+
+    override val restoreNuGetPackages: Boolean = true
+
+    private var originalCoreToolsProperty: String? = null
+
+    @BeforeMethod(alwaysRun = true)
+    fun collectCoreToolsProperties() {
+        originalCoreToolsProperty =
+                PropertiesComponent.getInstance().getValue(AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH)
+    }
+
+    @AfterMethod(alwaysRun = true)
+    fun restoreCoreToolsProperty() {
+        PropertiesComponent.getInstance().setValue(
+                AzureRiderSettings.PROPERTY_FUNCTIONS_CORETOOLS_PATH, originalCoreToolsProperty)
+    }
+
+    //region Configuration
+
+    @Test(description = "Function App project should create one default run configuration to run function app.")
+    fun testFunctionHost_DefaultRunConfigurations() {
+        val allConfigurations = RunManagerEx.getInstanceEx(project).allConfigurationsList
+
+        allConfigurations.size.shouldBe(1)
+        allConfigurations[0].javaClass.shouldBe(AzureFunctionsHostConfiguration::class.java)
+        allConfigurations[0].name.shouldBe("Default")
+    }
+
+    //endregion Configuration
+
+    //region Before Run Tasks
+
+    @Test(description = "Verifies Function Host run configuration has Build Function App before run task by default.")
+    fun testFunctionHost_BeforeRunTasks_Defaults() {
+        val configuration  = createRunConfiguration(
+                name = "Run Function App: ${project.name}",
+                configurationType = AzureFunctionsHostConfigurationType::class.java
+        ) as AzureFunctionsHostConfiguration
+
+        configuration.name.shouldBe("Run Function App: FunctionApp")
+
+        configuration.beforeRunTasks.size.shouldBe(1)
+        configuration.beforeRunTasks[0].providerId.shouldBe(BuildFunctionsProjectBeforeRunTaskProvider.providerId)
+    }
+
+    // TODO: Need to make sure function core tools is available on a server before enable.
+    @Test(enabled = false, description = "Check before run task that should build a function app project.")
+    fun testFunctionHost_BeforeRunTasks_BuildFunctionProject() {
+        addProject(arrayOf("FunctionApp"), "ConsoleApp1", ProjectTemplateIds.Core.consoleApplicationCoreDefault)
+
+        val configuration = createRunConfiguration(
+                name = "Run Function App: ${project.name}",
+                type = AzureFunctionsHostConfigurationType::class.java
+        ) as AzureFunctionsHostConfiguration
+
+        val projectToRun = project.solution.runnableProjectsModel.projects.valueOrNull?.find { it.name == "FunctionApp" }
+                ?: fail("Project to run is not found.")
+
+        configuration.parameters.projectKind = RunnableProjectKind.AzureFunctions
+        configuration.parameters.projectTfm = ".NETCoreApp,Version=v3.1"
+        configuration.parameters.projectFilePath = projectToRun.projectFilePath
+        configuration.parameters.workingDirectory = projectToRun.projectOutputs.first().workingDirectory
+        configuration.parameters.exePath = projectToRun.projectOutputs.first().exePath
+        configuration.parameters.projectTfm = projectToRun.projectOutputs.first().tfm
+
+        configuration.beforeRunTasks.size.shouldBe(1)
+        configuration.beforeRunTasks[0].providerId.shouldBe(BuildFunctionsProjectBeforeRunTaskProvider.providerId)
+
+        checkCanExecuteRunConfiguration(configuration)
+
+        val buildResult = dumpProjectBuildSession {
+            executeBeforeRunTasksForSelectedConfiguration(project, DEFAULT_BUILD_TIMEOUT)
+        }
+
+        buildResult.size.shouldBe(1, "Expected to build FunctionApp project once, but got: ${buildResult.size}")
+        assertBuildProjectSucceeded(projectName = "FunctionApp", buildResult = buildResult.first())
+    }
+
+    //endregion Before Run Tasks
+
+    //region Run
+
+    // TODO: Need to make sure function core tools is available on a server before enable.
+    @Test(enabled = false, description = "Start a function app and verify output.")
+    fun testFunctionHost_Run() { }
+
+    //endregion Run
+
+    private fun createRunConfiguration(name: String, type: Class<out ConfigurationType>): RunConfiguration {
+        val runManagerEx = RunManagerEx.getInstanceEx(project)
+        val settings = runManagerEx.createConfiguration(name, type)
+        runManagerEx.addConfiguration(settings)
+        runManagerEx.selectedConfiguration = settings
+
+        return settings.configuration
+    }
+
+    private fun assertBuildProjectSucceeded(projectName: String, buildResult: BuildSessionAssertion) {
+        checkBuildResult(buildResult = buildResult.result.kind, errors = emptyList())
+        BuildHost.getBuildTargetName(buildResult.target).shouldBe("Build")
+
+        assertBuildCompleteMessage(projectName = projectName, buildOutput = buildResult.output)
+    }
+
+    private fun assertBuildCompleteMessage(projectName: String, buildOutput: String) {
+        buildOutput.shouldContain("------- Started building project: $projectName")
+        buildOutput.shouldContain("------- Finished building project: $projectName. Succeeded: True.")
+        buildOutput.shouldContain("Build completed in")
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/com/microsoft/intellij/serviceexplorer/azure/database/actions/IpAddressInputValidatorTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/com/microsoft/intellij/serviceexplorer/azure/database/actions/IpAddressInputValidatorTest.kt
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2020 JetBrains s.r.o.
+ * <p/>
+ * All rights reserved.
+ * <p/>
+ * MIT License
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.intellij.serviceexplorer.azure.database.actions
+
+import com.jetbrains.rider.test.asserts.shouldBe
+import com.microsoft.intellij.helpers.validator.IpAddressInputValidator
+import org.testng.annotations.DataProvider
+import org.testng.annotations.Test
+
+class IpAddressInputValidatorTest {
+
+    @DataProvider(name = "validateIpV4AddressData")
+    fun validateIpV4AddressData() = arrayOf(
+            arrayOf("Zeros", "0.0.0.0", true),
+            arrayOf("Localhost", "127.0.0.1", true),
+            arrayOf("Max", "255.255.255.255", true),
+            arrayOf("OneInvalid", "198.0.256.1", false),
+            arrayOf("Empty", "...", false),
+            arrayOf("Chars", "0.0.a.0", false),
+            arrayOf("Negative", "0.0.-1.0", false),
+            arrayOf("Symbol", "0.0.-.0", false),
+            arrayOf("Trim", "127.0.1", false)
+    )
+
+    @Test(dataProvider = "validateIpV4AddressData")
+    fun testValidateIpV4Address(name: String, address: String, isValid: Boolean) {
+        val validator = IpAddressInputValidator.instance
+        val isValidAddress = validator.validateIpV4Address(address)
+        isValidAddress.shouldBe(isValid)
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_DigitPrefix/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_DigitPrefix/source/Function.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp
+{
+    public static class TimerTrigger
+    {
+        [FunctionName("TimerTrigger")]
+        public static async Task RunAsync([TimerTrigger("<caret>")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+            
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_FullListOnBasicCompletion/gold/Function.gold
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_FullListOnBasicCompletion/gold/Function.gold
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp
+{
+    public static class TimerTrigger
+    {
+        [FunctionName("TimerTrigger")]
+        public static async Task RunAsync([TimerTrigger("*/15 * * * * *<caret>")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+            
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_FullListOnBasicCompletion/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_FullListOnBasicCompletion/source/Function.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp
+{
+    public static class TimerTrigger
+    {
+        [FunctionName("TimerTrigger")]
+        public static async Task RunAsync([TimerTrigger("<caret>")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+            
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_FullListOnQuote/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_FullListOnQuote/source/Function.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp
+{
+    public static class TimerTrigger
+    {
+        [FunctionName("TimerTrigger")]
+        public static async Task RunAsync([TimerTrigger(<caret>)] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+            
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_FullListOnQuote/testPopup_CompletionList_DigitPrefix/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_FullListOnQuote/testPopup_CompletionList_DigitPrefix/source/Function.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp
+{
+    public static class TimerTrigger
+    {
+        [FunctionName("TimerTrigger")]
+        public static async Task RunAsync([TimerTrigger("<caret>")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+            
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_LiteralPrefix/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_LiteralPrefix/source/Function.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp
+{
+    public static class TimerTrigger
+    {
+        [FunctionName("TimerTrigger")]
+        public static async Task RunAsync([TimerTrigger("<caret>")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+            
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_MixedPrefix/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_MixedPrefix/source/Function.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp
+{
+    public static class TimerTrigger
+    {
+        [FunctionName("TimerTrigger")]
+        public static async Task RunAsync([TimerTrigger("<caret>")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+            
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_SymbolPrefix_Comma/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_SymbolPrefix_Comma/source/Function.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp
+{
+    public static class TimerTrigger
+    {
+        [FunctionName("TimerTrigger")]
+        public static async Task RunAsync([TimerTrigger("<caret>")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+            
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_SymbolPrefix_Slash/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_SymbolPrefix_Slash/source/Function.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp
+{
+    public static class TimerTrigger
+    {
+        [FunctionName("TimerTrigger")]
+        public static async Task RunAsync([TimerTrigger("<caret>")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+            
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_SymbolPrefix_Space/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_SymbolPrefix_Space/source/Function.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp
+{
+    public static class TimerTrigger
+    {
+        [FunctionName("TimerTrigger")]
+        public static async Task RunAsync([TimerTrigger("<caret>")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+            
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_SymbolPrefix_Star/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/documentmodel/completion/csharp/AzureFunctionsTimerTriggerCompletionTest/testPopup_CompletionList_SymbolPrefix_Star/source/Function.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp
+{
+    public static class TimerTrigger
+    {
+        [FunctionName("TimerTrigger")]
+        public static async Task RunAsync([TimerTrigger("<caret>")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+            
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerFromItemTemplate_Detected/gold/Function.gold
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerFromItemTemplate_Detected/gold/Function.gold
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        [FunctionName("Function")]
+        public static async Task<IActionResult> <AZURE_FUNCTION_APP_RUN_METHOD_GUTTER_MARK>RunAsync</AZURE_FUNCTION_APP_RUN_METHOD_GUTTER_MARK>(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]
+            HttpRequest req, ILogger log)
+        {
+            log.LogInformation("C# HTTP trigger function processed a request.");
+
+            string name = req.Query["name"];
+
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            dynamic data = JsonConvert.DeserializeObject(requestBody);
+            name = name ?? data?.name;
+
+            return name != null
+                ? (ActionResult) new OkObjectResult($"Hello, {name}")
+                : new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerFromItemTemplate_Detected/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerFromItemTemplate_Detected/source/Function.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        [FunctionName("Function")]
+        public static async Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]
+            HttpRequest req, ILogger log)
+        {
+            log.LogInformation("C# HTTP trigger function processed a request.");
+
+            string name = req.Query["name"];
+
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            dynamic data = JsonConvert.DeserializeObject(requestBody);
+            name = name ?? data?.name;
+
+            return name != null
+                ? (ActionResult) new OkObjectResult($"Hello, {name}")
+                : new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerMissingAttribute_NotDetected/gold/Function.gold
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerMissingAttribute_NotDetected/gold/Function.gold
@@ -1,0 +1,31 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        public static async Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]
+            HttpRequest req, ILogger log)
+        {
+            log.LogInformation("C# HTTP trigger function processed a request.");
+
+            string name = req.Query["name"];
+
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            dynamic data = JsonConvert.DeserializeObject(requestBody);
+            name = name ?? data?.name;
+
+            return name != null
+                ? (ActionResult) new OkObjectResult($"Hello, {name}")
+                : new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerMissingAttribute_NotDetected/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerMissingAttribute_NotDetected/source/Function.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        public static async Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]
+            HttpRequest req, ILogger log)
+        {
+            log.LogInformation("C# HTTP trigger function processed a request.");
+
+            string name = req.Query["name"];
+
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            dynamic data = JsonConvert.DeserializeObject(requestBody);
+            name = name ?? data?.name;
+
+            return name != null
+                ? (ActionResult) new OkObjectResult($"Hello, {name}")
+                : new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerWithIncorrectAttribute_NotDetected/gold/Function.gold
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerWithIncorrectAttribute_NotDetected/gold/Function.gold
@@ -1,0 +1,33 @@
+using System.IO;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        [DisplayName("ThisIsMyHttpTimer")]
+        public static async Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]
+            HttpRequest req, ILogger log)
+        {
+            log.LogInformation("C# HTTP trigger function processed a request.");
+
+            string name = req.Query["name"];
+
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            dynamic data = JsonConvert.DeserializeObject(requestBody);
+            name = name ?? data?.name;
+
+            return name != null
+                ? (ActionResult) new OkObjectResult($"Hello, {name}")
+                : new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerWithIncorrectAttribute_NotDetected/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerWithIncorrectAttribute_NotDetected/source/Function.cs
@@ -1,0 +1,33 @@
+using System.IO;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        [DisplayName("ThisIsMyHttpTimer")]
+        public static async Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]
+            HttpRequest req, ILogger log)
+        {
+            log.LogInformation("C# HTTP trigger function processed a request.");
+
+            string name = req.Query["name"];
+
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            dynamic data = JsonConvert.DeserializeObject(requestBody);
+            name = name ?? data?.name;
+
+            return name != null
+                ? (ActionResult) new OkObjectResult($"Hello, {name}")
+                : new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerWithMultipleAttributes_Detected/gold/Function.gold
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerWithMultipleAttributes_Detected/gold/Function.gold
@@ -1,0 +1,34 @@
+using System.IO;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        [FunctionName("Function")]
+        [DisplayName("ThisIsMyHttpTimer")]
+        public static async Task<IActionResult> <AZURE_FUNCTION_APP_RUN_METHOD_GUTTER_MARK>RunAsync</AZURE_FUNCTION_APP_RUN_METHOD_GUTTER_MARK>(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]
+            HttpRequest req, ILogger log)
+        {
+            log.LogInformation("C# HTTP trigger function processed a request.");
+
+            string name = req.Query["name"];
+
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            dynamic data = JsonConvert.DeserializeObject(requestBody);
+            name = name ?? data?.name;
+
+            return name != null
+                ? (ActionResult) new OkObjectResult($"Hello, {name}")
+                : new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerWithMultipleAttributes_Detected/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerWithMultipleAttributes_Detected/source/Function.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        [FunctionName("Function")]
+        [DisplayName("ThisIsMyHttpTimer")]
+        public static async Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]
+            HttpRequest req, ILogger log)
+        {
+            log.LogInformation("C# HTTP trigger function processed a request.");
+
+            string name = req.Query["name"];
+
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            dynamic data = JsonConvert.DeserializeObject(requestBody);
+            name = name ?? data?.name;
+
+            return name != null
+                ? (ActionResult) new OkObjectResult($"Hello, {name}")
+                : new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerWithNamespaceAttribute_NotDetected/gold/Function.gold
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerWithNamespaceAttribute_NotDetected/gold/Function.gold
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+[assembly: FunctionName("Function")]
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        public static async Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]
+            HttpRequest req, ILogger log)
+        {
+            log.LogInformation("C# HTTP trigger function processed a request.");
+
+            string name = req.Query["name"];
+
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            dynamic data = JsonConvert.DeserializeObject(requestBody);
+            name = name ?? data?.name;
+
+            return name != null
+                ? (ActionResult) new OkObjectResult($"Hello, {name}")
+                : new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerWithNamespaceAttribute_NotDetected/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_HttpTriggerWithNamespaceAttribute_NotDetected/source/Function.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+[assembly: FunctionName("Function")]
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        public static async Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]
+            HttpRequest req, ILogger log)
+        {
+            log.LogInformation("C# HTTP trigger function processed a request.");
+
+            string name = req.Query["name"];
+
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            dynamic data = JsonConvert.DeserializeObject(requestBody);
+            name = name ?? data?.name;
+
+            return name != null
+                ? (ActionResult) new OkObjectResult($"Hello, {name}")
+                : new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_MethodWithAttribute_Detected/gold/Function.gold
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_MethodWithAttribute_Detected/gold/Function.gold
@@ -1,0 +1,20 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        [FunctionName("Function")]
+        public static void <AZURE_FUNCTION_APP_RUN_METHOD_GUTTER_MARK>Main</AZURE_FUNCTION_APP_RUN_METHOD_GUTTER_MARK>(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_MethodWithAttribute_Detected/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_MethodWithAttribute_Detected/source/Function.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        [FunctionName("Function")]
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_MultipleFunctionApps_Detected/gold/Function.gold
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_MultipleFunctionApps_Detected/gold/Function.gold
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        [FunctionName("Function")]
+        public static async Task<IActionResult> <AZURE_FUNCTION_APP_RUN_METHOD_GUTTER_MARK>RunHttpAsync</AZURE_FUNCTION_APP_RUN_METHOD_GUTTER_MARK>(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]
+            HttpRequest req, ILogger log)
+        {
+            log.LogInformation("C# HTTP trigger function processed a request.");
+
+            string name = req.Query["name"];
+
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            dynamic data = JsonConvert.DeserializeObject(requestBody);
+            name = name ?? data?.name;
+
+            return name != null
+                ? (ActionResult) new OkObjectResult($"Hello, {name}")
+                : new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+        }
+
+        [FunctionName("MyTimerTrigger")]
+        public static async Task <AZURE_FUNCTION_APP_RUN_METHOD_GUTTER_MARK>RunTimerAsync</AZURE_FUNCTION_APP_RUN_METHOD_GUTTER_MARK>([TimerTrigger("0 */5 * * * *")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_MultipleFunctionApps_Detected/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_MultipleFunctionApps_Detected/source/Function.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        [FunctionName("Function")]
+        public static async Task<IActionResult> RunHttpAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]
+            HttpRequest req, ILogger log)
+        {
+            log.LogInformation("C# HTTP trigger function processed a request.");
+
+            string name = req.Query["name"];
+
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            dynamic data = JsonConvert.DeserializeObject(requestBody);
+            name = name ?? data?.name;
+
+            return name != null
+                ? (ActionResult) new OkObjectResult($"Hello, {name}")
+                : new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+        }
+
+        [FunctionName("MyTimerTrigger")]
+        public static async Task RunTimerAsync([TimerTrigger("0 */5 * * * *")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_TimerTriggerFromItemTemplate_Detected/gold/Function.gold
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_TimerTriggerFromItemTemplate_Detected/gold/Function.gold
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        [FunctionName("MyTimerTrigger")]
+        public static async Task <AZURE_FUNCTION_APP_RUN_METHOD_GUTTER_MARK>RunAsync</AZURE_FUNCTION_APP_RUN_METHOD_GUTTER_MARK>([TimerTrigger("0 */5 * * * *")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_TimerTriggerFromItemTemplate_Detected/source/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/markup/functionapp/csharp/AzureFunctionRunMarkerTest/testFunctionApp_TimerTriggerFromItemTemplate_Detected/source/Function.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace Company.FunctionApp
+{
+    public static class Function
+    {
+        [FunctionName("MyTimerTrigger")]
+        public static async Task RunAsync([TimerTrigger("0 */5 * * * *")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/solutions/FunctionApp/FunctionApp.sln
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/solutions/FunctionApp/FunctionApp.sln
@@ -1,0 +1,16 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FunctionApp", "FunctionApp\FunctionApp.csproj", "{ADBF75E4-45E0-404D-B11B-7E9757AC16E9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ADBF75E4-45E0-404D-B11B-7E9757AC16E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADBF75E4-45E0-404D-B11B-7E9757AC16E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADBF75E4-45E0-404D-B11B-7E9757AC16E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADBF75E4-45E0-404D-B11B-7E9757AC16E9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/solutions/FunctionApp/FunctionApp/Function.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/solutions/FunctionApp/FunctionApp/Function.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionApp
+{
+    public static class Function
+    {
+        [FunctionName("TimerTrigger")]
+        public static async Task RunAsync([TimerTrigger("0 */5 * * * *")] TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.UtcNow}");
+            
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/solutions/FunctionApp/FunctionApp/FunctionApp.csproj
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/solutions/FunctionApp/FunctionApp/FunctionApp.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <AzureFunctionsVersion>V3</AzureFunctionsVersion>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="host.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="local.settings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+        </None>
+    </ItemGroup>
+</Project>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/solutions/FunctionApp/FunctionApp/host.json
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/solutions/FunctionApp/FunctionApp/host.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingExcludedTypes": "Request",
+            "samplingSettings": {
+                "isEnabled": true
+            }
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/solutions/FunctionApp/FunctionApp/local.settings.json
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/solutions/FunctionApp/FunctionApp/local.settings.json
@@ -1,0 +1,7 @@
+{
+    "IsEncrypted": false,
+    "Values": {
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet"
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/MethodUtils.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/util/MethodUtils.java
@@ -1,5 +1,6 @@
-/**
+/*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2020 JetBrains s.r.o.
  * <p/>
  * All rights reserved.
  * <p/>
@@ -21,7 +22,9 @@
  */
 package com.microsoft.intellij.util;
 
-import com.intellij.openapi.module.*;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.module.ModuleTypeId;
 import com.intellij.openapi.project.Project;
 import com.microsoft.intellij.AzurePlugin;
 import com.microsoft.intellij.ui.libraries.AILibraryHandler;

--- a/RunRiderTests
+++ b/RunRiderTests
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+tc_open() {
+    set +x
+    echo "##teamcity[blockOpened name='$1' description='$1']"
+    set -x
+}
+
+tc_close() {
+    set +x
+    echo "##teamcity[blockClosed name='$1']"
+    set -x
+}
+
+set -e
+
+# echo shell commands when they are executed.
+set -x
+
+tc_open "Initializing build script"
+{
+    SCRIPTPATH=$(pwd -P)
+    echo "Script path: $SCRIPTPATH"
+    cd "$SCRIPTPATH"
+
+    MAVEN_LOCAL_DIR="$SCRIPTPATH"/.repository
+    if [ -d "$MAVEN_LOCAL_DIR" ]; then
+        echo "Found existing Maven local repository in '$MAVEN_LOCAL_DIR'. Deleting..."
+        rm -rf "$MAVEN_LOCAL_DIR"
+    fi
+    echo "Creating maven local directory $MAVEN_LOCAL_DIR"
+    mkdir -p "$MAVEN_LOCAL_DIR"
+
+    # Artifacts
+    ARTIFACTS_DIR="$SCRIPTPATH/artifacts"
+    if [ ! -d "$ARTIFACTS_DIR" ]; then
+        echo "Creating artifacts directory $ARTIFACTS_DIR"
+        mkdir -p "$ARTIFACTS_DIR"
+    fi
+
+    # Utils Artifacts
+    UTILS_ARTIFACTS_DIR="$SCRIPTPATH/utilsArtifacts"
+    if [ ! -d "$UTILS_ARTIFACTS_DIR" ]; then
+        echo "Unable to find Utils artifacts directory: '$UTILS_ARTIFACTS_DIR'"
+        exit 1
+    fi
+
+    UTILS_ARTIFACTS_COMMON_DIR="$UTILS_ARTIFACTS_DIR"/common
+    if [ ! -d "$UTILS_ARTIFACTS_COMMON_DIR" ]; then
+        echo "Unable to find Utils artifacts common directory: '$UTILS_ARTIFACTS_COMMON_DIR'"
+        exit 1
+    fi
+
+    df -h
+}
+tc_close "Initializing build script"
+
+prepare_maven_repository() {
+    set +x
+    cp -r "$UTILS_ARTIFACTS_COMMON_DIR"/maven_local/.repository "$SCRIPTPATH"
+    set -x
+}
+
+prepare_spark_jars() {
+    set +x
+    local sparkResourceDir="$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij/resources/spark/
+    cp "$UTILS_ARTIFACTS_COMMON_DIR"/spark/spark-tools-*.jar "$sparkResourceDir"
+    set -x
+}
+
+prepare_applicationinsights_management_jars() {
+    set +x
+    local azureSdkDir="$SCRIPTPATH"/PluginsAndFeatures/AddLibrary/AzureLibraries/com.microsoft.azuretools.sdk/dependencies
+    cp "$UTILS_ARTIFACTS_COMMON_DIR"/applicationinsights/applicationinsights-management-*.jar "$azureSdkDir"
+    set -x
+}
+
+tc_open "Prepare JAR dependencies"
+{
+    prepare_maven_repository
+    prepare_spark_jars
+    prepare_applicationinsights_management_jars
+
+    echo "Deleting Utils artifacts folder"
+    rm -rf "$UTILS_ARTIFACTS_DIR"
+}
+tc_close "Prepare JAR dependencies"
+
+tc_open "Run Rider tests"
+{
+    (cd "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info clean --console=plain)
+    (cd "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info :rider:test -s --console=plain)
+    (cd "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info :rider:integrationTest -s --console=plain)
+
+    cp -r "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij/rider/build/idea-sandbox/system-test/log/ "$ARTIFACTS_DIR"/
+
+    df -h
+}
+tc_close "Run Rider tests"
+
+echo "ALL BUILD SUCCESSFUL"


### PR DESCRIPTION
- Bump kotlin version
- Bump Java version to be able to run Rider Test Framework tests
- Fix JDK 11 compilation and tests run
- Bump gralde plugin version to fix the issue with loading plugin dependencies when running Rider Test Framework integration tests
- Move more string constants into localized strings
- Add IP checker instead of using library that is not compartible with Java 11
- Add tests to cover Function App gutter marks
- Add tests to cover Timer Function completion
- Update Gradle tasks to be able to run Rider integration tests