### PR TITLE
Fixed RIDER-47955. Fix compartibility with IRunConfigurationWithDefault

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -7,7 +7,7 @@ sources=false
 
 # TODO: Bump IDEA SDK version to 202 when fix issue with Scala plugin
 idea_version=IC-201.6668.121
-rider_version=RD-2020.2-SNAPSHOT
+rider_version=RD-2020.2-EAP8-SNAPSHOT
 build_common_code_with=rider
 
 rider_backend_build_configuration=Debug
@@ -22,7 +22,7 @@ patchPluginXmlSinceBuild=202
 gradle_plugin_version=0.4.21
 kotlin_version=1.3.72
 rd_version=0.202.118
-rider_nuget_sdk_version=2020.2.0-eap07
+rider_nuget_sdk_version=2020.2.0-eap08
 web_socket_version=1.3.9
 retrofit_version=2.8.1
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -6,18 +6,12 @@
     <html>
       <h4>Compatibility:</h4>
       <ul>
-        <li>Plugin build compatible with Rider 2020.2 EAP</li>
+        <li>Fix Plugin compatible with Rider 2020.2 EAP7</li>
+        <li>Remove JavaFX dependency that is not bundled with platform SDK - <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/329">#329</a></li>
       </ul>
-      <h4>Improvements:</h4>
+      <h4>Bug fixes:</h4>
       <ul>
-        <li>Integrate Azurite Storage Emulator - <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/312">#312</a></li>
-        <li>Autodetect installed Function App core tools path - <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/293">#293</a></li>
-        <li>Improve running Function Apps from gutter mark logic - <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/234">#234</a></li>
-        <li>Add Function Apps Timer Trigger completion options and Cron expression inspections - <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/296">#296</a></li>
-      </ul>
-      <h4>Fixed bugs:</h4>
-      <ul>
-		<li>Persists launch browser settings for launch Function Apps run configuration - <a href="https://youtrack.jetbrains.com/issue/RIDER-45405">RIDER-45405</a></li>
+        <li>Fix highlighting and analysis initialization when plugin is enabled - <a href="https://youtrack.jetbrains.com/issue/RIDER-47182">RIDER-47182</a></li>
       </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Project/FunctionApp/FunctionAppProjectDetector.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Project/FunctionApp/FunctionAppProjectDetector.cs
@@ -20,17 +20,79 @@
 
 using JetBrains.Annotations;
 using JetBrains.ProjectModel;
-using JetBrains.ReSharper.Host.Features.ProjectModel;
+using JetBrains.ProjectModel.Assemblies.Interfaces;
+using JetBrains.ProjectModel.MSBuild;
+using JetBrains.ProjectModel.Properties;
+using JetBrains.ProjectModel.Properties.Managed;
+using JetBrains.Util;
+using JetBrains.Util.Dotnet.TargetFrameworkIds;
 
 namespace JetBrains.ReSharper.Azure.Project.FunctionApp
 {
     public static class FunctionAppProjectDetector
     {
         // TODO: Migrate [AzureFunctionsProjectDetector] from Rider to plugin codebase if possible.
-        public static bool IsAzureFunctionsProject([CanBeNull] IProject project)
+        // TODO: Grabbed it from ReSharper backend to handle the issue with moved [AzureFunctionsProjectDetector] class into
+        //       [JetBrains.ReSharper.Host.Features.ProjectModel.Azure] namespace. Unable to fix until EAP 8 with updated
+        //       assembly is released. So, copy the logic here to prevent blocking plugin release.
+        public static bool IsAzureFunctionsProject([NotNull] IProject project)
         {
-            if (project == null) return false;
-            return AzureFunctionsProjectDetector.IsAzureFunctionsProject(project);
+            foreach (var tfm in project.TargetFrameworkIds)
+            {
+                var configuration = project.ProjectProperties.TryGetConfiguration<IManagedProjectConfiguration>(tfm);
+                if (configuration == null || configuration.OutputType != ProjectOutputType.LIBRARY) return false;
+
+                if (IsAzureFunctionsProject(project, tfm, out _, null))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsAzureFunctionsProject(IProject project, TargetFrameworkId targetFrameworkId,
+            out string problems, [CanBeNull] ILogger logger)
+        {
+            // Support .NET Core/Standard, NetCoreApp, NetFx
+            if (!(targetFrameworkId.IsNetCore ||
+                  targetFrameworkId.IsNetStandard ||
+                  targetFrameworkId.IsNetCoreApp ||
+                  targetFrameworkId.IsNetFramework))
+            {
+                logger?.Trace(
+                    $"Target framework not supported by Azure Functions: ${targetFrameworkId.PresentableString}");
+                problems = null;
+                return false;
+            }
+
+            // 1) Check MSBuild properties. When property is defined but is empty, this will yield false.
+            var hasMsBuildProperty = !string.IsNullOrEmpty(project
+                .GetRequestedProjectProperties(MSBuildProjectUtil.AzureFunctionsVersion)
+                .FirstNotNull());
+
+            // 2) Check package references. If Microsoft.NET.Sdk.Functions is referenced, we're good.
+            var hasExpectedPackageReference =
+                project.GetPackagesReference(new NugetId("Microsoft.NET.Sdk.Functions"), targetFrameworkId) != null;
+
+            // 3) Check existence of host.json in the project folder
+            var hasHostJsonFile = project.ProjectFileLocation
+                .GetParent(FileSystemPathInternStrategy.TRY_GET_INTERNED_BUT_DO_NOT_INTERN)
+                .GetChildFiles("host.json")
+                .Any();
+
+            // Build problem description
+            if (!hasHostJsonFile)
+            {
+                problems =
+                    "Consider adding missing host.json file required by Azure Functions runtime to your project.";
+            }
+            else
+            {
+                problems = null;
+            }
+
+            return hasMsBuildProperty || hasExpectedPackageReference || hasHostJsonFile;
         }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/messages/RiderAzureMessages.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/messages/RiderAzureMessages.properties
@@ -294,7 +294,6 @@ run_config.run_function_app.form.function_app.url=URL
 run_config.run_function_app.form.function_app.factory_name=Azure Functions host factory
 run_config.run_function_app.form.function_app.type_name=Azure Functions host
 run_config.run_function_app.form.function_app.type_description=Azure Function Applications runner
-run_config.run_function_app.form.function_app.type_default_name=Default
 run_config.run_function_app.form.function_app.before_run_tasks.build_function_project_name=Build Functions Project
 run_config.run_function_app.form.function_app.before_run_tasks.build_function_project_description=Build Functions project
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationParameters.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationParameters.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 JetBrains s.r.o.
+ * Copyright (c) 2019-2020 JetBrains s.r.o.
  * <p/>
  * All rights reserved.
  * <p/>
@@ -163,10 +163,10 @@ open class AzureFunctionsHostConfigurationParameters(
             logger.warn("Multiple applicable runnable projects detected for .NET Project configuration ($projectFilePath): ${applicableProjects.joinToString("; ")}")
         }
 
-        val runnableProject = applicableProjects.singleOrNull()
-        if (runnableProject != null) {
-            return AzureFunctionsRunnableProjectUtil.patchRunnableProjectOutputs(runnableProject)
-        }
+        val applicableProject = applicableProjects.firstOrNull()
+
+        if (applicableProject != null)
+            return AzureFunctionsRunnableProjectUtil.patchRunnableProjectOutputs(applicableProject)
 
         return null
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationParametersTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationParametersTest.kt
@@ -88,7 +88,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
 
     @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Project is not specified\\.")
     fun testValidate_RunnableProjects_MultipleRunnableProjectsMatch() {
-        val projectFilePath = File("project/file/path").path
+        val projectFilePath = File("/project/file/path").absolutePath
         val parameters = createParameters(project = project, projectFilePath = projectFilePath)
 
         project.solution.runnableProjectsModel.projects.set(listOf(
@@ -100,7 +100,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
 
     @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Function App is not loaded properly\\.")
     fun testValidate_RunnableProjects_ProjectWithProblems() {
-        val projectFilePath = File("project/file/path").path
+        val projectFilePath = File("/project/file/path").absolutePath
         val parameters = createParameters(project = project, projectFilePath = projectFilePath)
         project.solution.runnableProjectsModel.projects.set(listOf(
                 createRunnableProject(
@@ -114,7 +114,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
 
     @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Invalid exe path: '/not/existing/path'\\.")
     fun testValidate_TrackProjectExePath_NotExists() {
-        val projectFilePath = File("project/file/path").path
+        val projectFilePath = File("/project/file/path").absolutePath
 
         val parameters =
                 createParameters(project = project, projectFilePath = projectFilePath, trackProjectExePath = false, exePath = "/not/existing/path")
@@ -131,7 +131,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
 
     @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Invalid exe path: '<empty>'\\.")
     fun testValidate_TrackProjectExePath_EmptyExePath() {
-        val projectFilePath = File("project/file/path").path
+        val projectFilePath = File("/project/file/path").absolutePath
 
         val parameters =
                 createParameters(project = project, projectFilePath = projectFilePath, trackProjectExePath = false, exePath = "")
@@ -148,7 +148,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
 
     @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Invalid exe path:\\s.+\\.")
     fun testValidate_TrackProjectExePath_NotAFile() {
-        val projectFilePath = File("project/file/path").path
+        val projectFilePath = File("/project/file/path").absolutePath
 
         val parameters = createParameters(
                 project = project,
@@ -169,7 +169,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
 
     @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Invalid working directory: '/not/existing/path'\\.")
     fun testValidate_TrackProjectWorkingDirectory_NotExists() {
-        val projectFilePath = File("project/file/path").path
+        val projectFilePath = File("/project/file/path").absolutePath
 
         val parameters = createParameters(
                 project = project,
@@ -191,7 +191,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
 
     @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Invalid working directory: '<empty>'\\.")
     fun testValidate_TrackProjectWorkingDirectory_EmptyDirectory() {
-        val projectFilePath = File("project/file/path").path
+        val projectFilePath = File("/project/file/path").absolutePath
 
         val parameters = createParameters(
                 project = project,
@@ -213,7 +213,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
 
     @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Invalid working directory:\\s.+\\.")
     fun testValidate_TrackProjectWorkingDirectory_NotADirectory() {
-        val projectFilePath = File("project/file/path").path
+        val projectFilePath = File("/project/file/path").absolutePath
 
         val workingDirectoryFile = tempTestDirectory.resolve("FunctionApp.dll")
         workingDirectoryFile.createNewFile()
@@ -238,7 +238,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
 
     @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Path to Azure Functions core tools has not been configured\\. This can be done in the settings under Tools \\| Azure \\| Functions\\.")
     fun testValidate_FunctionCoreTools_NotInstalled() {
-        val projectFilePath = File("project/file/path").path
+        val projectFilePath = File("/project/file/path").absolutePath
 
         val parameters = createParameters(
                 project = project,
@@ -261,7 +261,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
 
     @Test(expectedExceptions = [RuntimeConfigurationError::class], expectedExceptionsMessageRegExp = "Mono runtime not found\\. Please setup Mono path in settings \\(File \\| Settings \\| Build, Execution, Deployment \\| Toolset and Build\\)")
     fun testValidate_MonoRuntime_MissingMonoConfig() {
-        val projectFilePath = File("project/file/path").path
+        val projectFilePath = File("/project/file/path").absolutePath
 
         val parameters = createParameters(
                 project = project,
@@ -289,7 +289,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
 
     @Test
     fun testValidate_Valid_UseMonoRuntime() {
-        val projectFilePath = File("project/file/path").path
+        val projectFilePath = File("/project/file/path").absolutePath
 
         val parameters = createParameters(
                 project = project,
@@ -313,7 +313,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
 
     @Test
     fun testValidate_Valid_NetCoreRuntime() {
-        val projectFilePath = File("project/file/path").path
+        val projectFilePath = File("/project/file/path").absolutePath
 
         val parameters = createParameters(
                 project = project,
@@ -341,7 +341,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
             project: Project = this.project,
             exePath: String = "",
             programParameters: String = "host start --port 7071 --pause-on-error",
-            workingDirectory: String = File("working/path").path,
+            workingDirectory: String = File("/working/path").absolutePath,
             envs: Map<String, String> = emptyMap(),
             isPassParentEnvs: Boolean = true,
             useExternalConsole: Boolean = false,
@@ -382,7 +382,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
     fun createRunnableProject(
             name: String = "TestName",
             fullName: String = "TestFullName",
-            projectFilePath: String = "",
+            projectFilePath: String = File("/project/file/path").absolutePath,
             kind: RunnableProjectKind = RunnableProjectKind.AzureFunctions,
             projectOutputs: List<ProjectOutput> = emptyList(),
             environmentVariables: List<EnvironmentVariable> = emptyList(),

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationTest.kt
@@ -76,7 +76,7 @@ class FunctionHostConfigurationTest : BaseTestWithSolution() {
 
         allConfigurations.size.shouldBe(1)
         allConfigurations[0].javaClass.shouldBe(AzureFunctionsHostConfiguration::class.java)
-        allConfigurations[0].name.shouldBe("Default")
+        allConfigurations[0].name.shouldBe("FunctionApp")
     }
 
     //endregion Configuration


### PR DESCRIPTION
- The original issue is related to the fact that signature for IDEA #comment() method was chnaged between Rider EAP SDK versions. No need to chnage any code in plugin
- Fix compartibility with IRunConfigurationWithDefault inteface that was updated with no backward compartibility. Updated to new signature
- Fix general logic of default Function App Host run configurations for each project (based on Rider defaults)
- Fix Rider integration tests for Function App Host configuraiton parameters
- Fix Rider integratiomn tests VFS root access setup