### PR TITLE
Use Release build configuration when preparing Plugin builds on build server

### DIFF
--- a/BuildPlugin
+++ b/BuildPlugin
@@ -154,10 +154,11 @@ if $BUILD_INTELLIJ; then
 fi
 
 BUILD_NUMBER="3.35.0.$BUILD_COUNTER-2020.2"
+BUILD_CONFIGURATION=Release
 
 tc_open "Building Rider plugin"
 {
-    (cd "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info --rerun-tasks :rider:buildPlugin -s -Pbuild_common_code_with=rider -PBuildNumber=$BUILD_NUMBER --console=plain)
+    (cd "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info --rerun-tasks :rider:buildPlugin -s -Pbuild_common_code_with=rider -PBuildNumber=$BUILD_NUMBER -PBuildConfiguration=$BUILD_CONFIGURATION --console=plain)
     cp "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij/rider/build/distributions/azure-toolkit-for-rider-"$BUILD_NUMBER".zip "$ARTIFACTS_DIR"/azure-toolkit-for-rider-"$BUILD_NUMBER".zip
     df -h
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/backend.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/backend.gradle
@@ -8,6 +8,9 @@ ext.riderSdkVersionPropsPath = new File(resharperPluginPath, 'RiderSdkPackageVer
 // https://www.nuget.org/packages/JetBrains.Rider.SDK/
 ext.riderNugetSdkVersion = rider_nuget_sdk_version
 
+if (!ext.has('BuildConfiguration'))
+    ext.BuildConfiguration = rider_backend_build_configuration
+
 task prepareBuildProps {
     group = backendGroup
 
@@ -113,18 +116,18 @@ task buildReSharperPlugin {
     dependsOn restoreReSharperPluginPackages, ':rider:protocol:generateModel'
 
     def libFiles = [
-            "**/bin/$rider_backend_build_configuration/net461/JetBrains.ReSharper.Azure*.dll",
-            "**/bin/$rider_backend_build_configuration/net461/JetBrains.ReSharper.Azure*.pdb",
-            "Azure.Daemon/bin/$rider_backend_build_configuration/net461/NCrontab.Signed.dll",
+            "**/bin/$BuildConfiguration/net461/JetBrains.ReSharper.Azure*.dll",
+            "**/bin/$BuildConfiguration/net461/JetBrains.ReSharper.Azure*.pdb",
+            "Azure.Daemon/bin/$BuildConfiguration/net461/NCrontab.Signed.dll",
     ]
 
     def srcPath = "${resharperPluginPath.absolutePath}/src"
 
     doLast {
         def executableName = 'dotnet'
-        def arguments = [ 'build', "${resharperPluginPath.canonicalPath}/ReSharper.Azure.sln" ]
+        def arguments = [ 'build', "${resharperPluginPath.canonicalPath}/ReSharper.Azure.sln", "-c", BuildConfiguration ]
 
-        println("Building ReSharper.Azure solution...")
+        println("Building ReSharper.Azure solution [$BuildConfiguration]...")
         exec {
             executable = executableName
             args = arguments

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/build.gradle
@@ -28,6 +28,7 @@ ext.resharperPluginPath = new File(projectDir, 'ReSharper.Azure')
 apply plugin: 'org.jetbrains.intellij'
 apply from: 'backend.gradle'
 
+// Plugin version
 if (!ext.has('BuildNumber'))
     ext.BuildNumber = buildNumber
 

--- a/RunRiderTests
+++ b/RunRiderTests
@@ -86,11 +86,12 @@ tc_open "Prepare JAR dependencies"
 }
 tc_close "Prepare JAR dependencies"
 
+BUILD_CONFIGURATION=Release
+
 tc_open "Run Rider tests"
 {
-    (cd "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info clean --console=plain)
-    (cd "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info :rider:test -s --console=plain)
-    (cd "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info :rider:integrationTest -s --console=plain)
+    (cd "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info :rider:test -s -PBuildConfiguration=$BUILD_CONFIGURATION --console=plain)
+    (cd "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij && ./gradlew --info :rider:integrationTest -s -PBuildConfiguration=$BUILD_CONFIGURATION --console=plain)
 
     cp -r "$SCRIPTPATH"/PluginsAndFeatures/azure-toolkit-for-intellij/rider/build/idea-sandbox/system-test/log/ "$ARTIFACTS_DIR"/
 


### PR DESCRIPTION
* Update BuildScripts (`BuildPlugins` and `RunRiderTests`) to correctly set Build Configuration when building Rider backend
* Update build.gradle for rider module to use new BuildConfiguration properties