### PR TITLE
Fix #230. Add API to set icon path for Azure Explorer node actions set on Plugin level

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/OpenInBrowserAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/OpenInBrowserAction.kt
@@ -1,24 +1,25 @@
 /**
- * Copyright (c) 2018 JetBrains s.r.o.
- * <p/>
+ * Copyright (c) 2018-2020 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package com.microsoft.intellij.serviceexplorer.azure.database.actions
 
 import com.intellij.ide.BrowserUtil
@@ -49,4 +50,6 @@ abstract class OpenInBrowserAction(private val subscriptionId: String, private v
             throw RuntimeException(message)
         }
     }
+
+    override fun getIconPath(): String = "OpenInBrowser.svg"
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/docker/DeleteDockerHostAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/docker/DeleteDockerHostAction.java
@@ -31,6 +31,7 @@ import com.microsoft.azure.docker.AzureDockerHostsManager;
 import com.microsoft.azure.docker.model.DockerHost;
 import com.microsoft.azure.docker.ops.utils.AzureDockerUtils;
 import com.microsoft.azure.management.Azure;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.intellij.docker.utils.AzureDockerUIResources;
 import com.microsoft.intellij.docker.wizards.publish.forms.CalculateDockerDeletionSafenessBackgroundTask;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
@@ -39,7 +40,6 @@ import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.docker.DockerHostNode;
 import org.jetbrains.concurrency.AsyncPromise;
-
 
 @Name("Delete")
 public class DeleteDockerHostAction extends NodeActionListener {
@@ -94,6 +94,11 @@ public class DeleteDockerHostAction extends NodeActionListener {
         });
 
         ProgressManager.getInstance().run(task);
+    }
+
+    @Override
+    protected @Nullable String getIconPath() {
+        return "Discard.svg";
     }
 }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/docker/ViewDockerHostAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/docker/ViewDockerHostAction.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -27,6 +28,7 @@ import com.intellij.openapi.project.Project;
 import com.microsoft.azure.docker.AzureDockerHostsManager;
 import com.microsoft.azure.docker.model.DockerHost;
 import com.microsoft.azure.docker.model.EditableDockerHost;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.intellij.docker.dialogs.AzureViewDockerDialog;
 import com.microsoft.intellij.docker.utils.AzureDockerUIResources;
 import com.microsoft.tooling.msservices.helpers.Name;
@@ -59,5 +61,10 @@ public class ViewDockerHostAction extends NodeActionListener {
     if (viewDockerDialog.getInternalExitCode() == AzureViewDockerDialog.UPDATE_EXIT_CODE) {
       AzureDockerUIResources.updateDockerHost(project, new EditableDockerHost(dockerHost), dockerManager, true);
     }
+  }
+
+  @Override
+  protected @Nullable String getIconPath() {
+    return "gearPlain.svg";
   }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/azure/CommonIcons.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/azure/CommonIcons.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2018-2020 JetBrains s.r.o.
+/*
+ * Copyright (c) 2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -20,11 +20,15 @@
  * SOFTWARE.
  */
 
-package com.microsoft.intellij.serviceexplorer.azure.database.actions
+package com.microsoft.azure;
 
-import com.microsoft.tooling.msservices.helpers.Name
-import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqldatabase.SqlDatabaseNode
+public class CommonIcons {
 
-@Name("Open in browser")
-class SqlDatabaseOpenInBrowserAction(sqlDatabaseNode: SqlDatabaseNode)
-    : OpenInBrowserAction(sqlDatabaseNode.subscriptionId, sqlDatabaseNode)
+    public static final String ACTION_OPEN_PREFERENCES = "gearPlain.svg";
+    public static final String ACTION_DISCARD = "Discard.svg";
+    public static final String ACTION_OPEN_IN_BROWSER = "OpenInBrowser.svg";
+
+    public static final String ACTION_START = "AzureStart.svg";
+    public static final String ACTION_STOP = "AzureStop.svg";
+    public static final String ACTION_RESTART = "AzureRestart.svg";
+}

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/Node.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/Node.java
@@ -275,9 +275,12 @@ public class Node implements MvpView, BasicTelemetryProperty {
             try {
                 for (Class<? extends NodeActionListener> actionListener : actions) {
                     Name nameAnnotation = actionListener.getAnnotation(Name.class);
-                    if (nameAnnotation != null) {
-                        addAction(nameAnnotation.value(), createNodeActionListener(actionListener));
-                    }
+                    if (nameAnnotation == null) continue;
+
+                    NodeActionListener actionInstance = createNodeActionListener(actionListener);
+                    if (actionInstance == null) continue;
+
+                    addAction(nameAnnotation.value(), actionInstance.getIconPath(), actionInstance);
                 }
             } catch (Throwable e) {
                 throw new RuntimeException("MS Services - Error", e);

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/NodeActionListener.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/NodeActionListener.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -25,6 +26,7 @@ package com.microsoft.tooling.msservices.serviceexplorer;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.telemetry.AppInsightsClient;
 import com.microsoft.azuretools.telemetry.TelemetryConstants;
 import com.microsoft.azuretools.telemetry.TelemetryProperties;
@@ -35,6 +37,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 public abstract class NodeActionListener implements EventListener {
+
+    @Nullable
+    private String iconPath;
+
     public NodeActionListener() {
         // need a nullary constructor defined in order for
         // Class.newInstance to work on sub-classes
@@ -85,6 +91,15 @@ public abstract class NodeActionListener implements EventListener {
         } finally {
             operation.complete();
         }
+    }
+
+    public void setIconPath(String path) {
+        iconPath = path;
+    }
+
+    @Nullable
+    protected String getIconPath() {
+        return iconPath;
     }
 
     /**

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/appservice/functionapp/FunctionAppNode.kt
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/appservice/functionapp/FunctionAppNode.kt
@@ -1,18 +1,18 @@
 /**
- * Copyright (c) 2019 JetBrains s.r.o.
- * <p/>
+ * Copyright (c) 2019-2020 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
@@ -22,6 +22,7 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.appservice.functionapp
 
+import com.microsoft.azure.CommonIcons
 import com.microsoft.azuretools.core.mvp.model.functionapp.AzureFunctionAppMvpModel
 import com.microsoft.tooling.msservices.components.DefaultLoader
 import com.microsoft.tooling.msservices.serviceexplorer.*
@@ -55,12 +56,6 @@ class FunctionAppNode(parent: AzureFunctionAppModule,
 
         private const val ICON_FUNCTION_APP_RUNNING = "FunctionAppRunning.svg"
         private const val ICON_FUNCTION_APP_STOPPED = "FunctionAppStopped.svg"
-        private const val ICON_ACTION_START = "AzureStart.svg"
-        private const val ICON_ACTION_STOP = "AzureStop.svg"
-        private const val ICON_ACTION_RESTART = "AzureRestart.svg"
-        private const val ICON_ACTION_OPEN_IN_BROWSER = "OpenInBrowser.svg"
-        private const val ICON_ACTION_DELETE = "Discard.svg"
-        private const val ICON_ACTION_SHOW_PROPERTIES = "gearPlain.svg"
 
         private fun getFunctionAppIcon(state: String) =
                 if (FunctionAppState.fromString(state) == FunctionAppState.RUNNING) ICON_FUNCTION_APP_RUNNING
@@ -75,11 +70,11 @@ class FunctionAppNode(parent: AzureFunctionAppModule,
 
     init {
         startAction = NodeAction(this, ACTION_START)
-        startAction.iconPath = ICON_ACTION_START
+        startAction.iconPath = CommonIcons.ACTION_START
         startAction.addListener(createBackgroundActionListener("Starting Function App") { startFunctionApp() })
 
         stopAction = NodeAction(this, ACTION_STOP)
-        stopAction.iconPath = ICON_ACTION_STOP
+        stopAction.iconPath = CommonIcons.ACTION_STOP
         stopAction.addListener(createBackgroundActionListener("Stopping Function App") { stopFunctionApp() })
 
         loadActions()
@@ -93,10 +88,10 @@ class FunctionAppNode(parent: AzureFunctionAppModule,
     }
 
     override fun loadActions() {
-        addAction(ACTION_RESTART, ICON_ACTION_RESTART, createBackgroundActionListener("Restarting Function App") { restartFunctionApp() })
-        addAction(ACTION_DELETE, ICON_ACTION_DELETE, DeleteFunctionAppAction())
-        addAction(ACTION_OPEN_IN_BROWSER, ICON_ACTION_OPEN_IN_BROWSER, OpenInBrowserAction())
-        addAction(ACTION_OPEN_PROPERTIES, ICON_ACTION_SHOW_PROPERTIES, OpenProperties())
+        addAction(ACTION_RESTART, CommonIcons.ACTION_RESTART, createBackgroundActionListener("Restarting Function App") { restartFunctionApp() })
+        addAction(ACTION_DELETE, CommonIcons.ACTION_DISCARD, DeleteFunctionAppAction())
+        addAction(ACTION_OPEN_IN_BROWSER, CommonIcons.ACTION_OPEN_IN_BROWSER, OpenInBrowserAction())
+        addAction(ACTION_OPEN_PROPERTIES, CommonIcons.ACTION_OPEN_PREFERENCES, OpenProperties())
         super.loadActions()
     }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/arm/deployments/DeploymentNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/arm/deployments/DeploymentNode.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
- * Copyright (c) 2019 JetBrains s.r.o.
+ * Copyright (c) 2019-2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -23,6 +23,7 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.arm.deployments;
 
+import com.microsoft.azure.CommonIcons;
 import com.microsoft.azure.management.resources.Deployment;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.telemetrywrapper.EventType;
@@ -51,9 +52,6 @@ public class DeploymentNode extends Node implements DeploymentNodeView {
     private final DeploymentNodePresenter deploymentNodePresenter;
     private final String subscriptionId;
 
-    private static final String ICON_ACTION_DELETE = "Discard.svg";
-    private static final String ICON_ACTION_SHOW_PROPERTIES = "gearPlain.svg";
-
     public DeploymentNode(ResourceManagementNode parent, String subscriptionId, Deployment deployment) {
         super(deployment.id(), deployment.name(), parent, ICON_PATH, true);
         this.deployment = deployment;
@@ -74,8 +72,8 @@ public class DeploymentNode extends Node implements DeploymentNodeView {
 
     @Override
     protected void loadActions() {
-        addAction(SHOW_PROPERTY_ACTION, ICON_ACTION_SHOW_PROPERTIES, new ShowDeploymentPropertyAction());
-        addAction(DELETE_ACTION, ICON_ACTION_DELETE, new DeleteDeploymentAction());
+        addAction(SHOW_PROPERTY_ACTION, CommonIcons.ACTION_OPEN_PREFERENCES, new ShowDeploymentPropertyAction());
+        addAction(DELETE_ACTION, CommonIcons.ACTION_DISCARD, new DeleteDeploymentAction());
         super.loadActions();
     }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/docker/DockerContainerNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/docker/DockerContainerNode.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.docker;
 
+import com.microsoft.azure.CommonIcons;
 import com.microsoft.azure.docker.AzureDockerHostsManager;
 import com.microsoft.azure.docker.model.DockerContainer;
 import com.microsoft.azure.docker.model.DockerHost;
@@ -52,10 +53,6 @@ public class DockerContainerNode extends AzureRefreshableNode implements Telemet
   private static final String DOCKER_CONTAINER_ICON_PATH = "DockerInstance2.svg";
   private static final String DOCKER_CONTAINER_WEB_RUN_ICON = "DockerInstanceRunning2.svg";
   private static final String DOCKER_CONTAINER_WEB_STOP_ICON = "DockerInstanceStopped2.svg";
-
-  private static final String ACTION_STOP_ICON = "AzureStop.svg";
-  private static final String ACTION_START_ICON = "AzureStart.svg";
-  private static final String ACTION_DELETE_ICON = "Discard.svg";
 
   public static final String ACTION_START = "Start";
   public static final String ACTION_DELETE = "Delete";
@@ -156,7 +153,7 @@ public class DockerContainerNode extends AzureRefreshableNode implements Telemet
         });
       }
     }));
-    addAction(ACTION_STOP, ACTION_STOP_ICON, new WrappedTelemetryNodeActionListener(DOCKER, STOP_DOCKER_CONTAINER,
+    addAction(ACTION_STOP, CommonIcons.ACTION_STOP, new WrappedTelemetryNodeActionListener(DOCKER, STOP_DOCKER_CONTAINER,
         new NodeActionListener() {
       @Override
       public void actionPerformed(NodeActionEvent e) {
@@ -170,7 +167,7 @@ public class DockerContainerNode extends AzureRefreshableNode implements Telemet
         });
       }
     }));
-    addAction(ACTION_START, ACTION_START_ICON, new WrappedTelemetryNodeActionListener(DOCKER, START_DOCKER_CONTAINER,
+    addAction(ACTION_START, CommonIcons.ACTION_START, new WrappedTelemetryNodeActionListener(DOCKER, START_DOCKER_CONTAINER,
         new NodeActionListener() {
       @Override
       public void actionPerformed(NodeActionEvent e) {
@@ -200,7 +197,7 @@ public class DockerContainerNode extends AzureRefreshableNode implements Telemet
         });
       }
     }));
-    addAction(ACTION_RESTART, ACTION_START_ICON, new WrappedTelemetryNodeActionListener(DOCKER, RESTART_DOCKER_CONTAINER,
+    addAction(ACTION_RESTART, CommonIcons.ACTION_START, new WrappedTelemetryNodeActionListener(DOCKER, RESTART_DOCKER_CONTAINER,
         new NodeActionListener() {
       @Override
       public void actionPerformed(NodeActionEvent e) {
@@ -215,7 +212,7 @@ public class DockerContainerNode extends AzureRefreshableNode implements Telemet
         });
       }
     }));
-    addAction(ACTION_DELETE, ACTION_DELETE_ICON, new DeleteDockerContainerAction());
+    addAction(ACTION_DELETE, CommonIcons.ACTION_DISCARD, new DeleteDockerContainerAction());
     super.loadActions();
   }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/docker/DockerHostNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/docker/DockerHostNode.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.docker;
 
+import com.microsoft.azure.CommonIcons;
 import com.microsoft.azure.docker.AzureDockerHostsManager;
 import com.microsoft.azure.docker.model.DockerContainer;
 import com.microsoft.azure.docker.model.DockerHost;
@@ -62,8 +63,8 @@ public class DockerHostNode extends AzureRefreshableNode implements TelemetryPro
   public static final String ACTION_SHUTDOWN = "Shutdown";
   public static final String ACTION_VIEW = "Details";
   public static final String ACTION_DEPLOY = "Publish";
-  private static final String ACTION_SHUTDOWN_ICON = "AzureStop.svg";
-  private static final String ACTION_START_ICON = "AzureStart.svg";
+  private static final String ACTION_SHUTDOWN_ICON = "Stop.png";
+  private static final String ACTION_START_ICON = "Start.png";
 
   DockerHost dockerHost;
   AzureDockerHostsManager dockerManager;
@@ -167,7 +168,7 @@ public class DockerHostNode extends AzureRefreshableNode implements TelemetryPro
 
   @Override
   protected void loadActions() {
-    addAction(ACTION_START, ACTION_START_ICON, new WrappedTelemetryNodeActionListener(DOCKER, START_DOCKER_HOST,
+    addAction(ACTION_START, CommonIcons.ACTION_START, new WrappedTelemetryNodeActionListener(DOCKER, START_DOCKER_HOST,
         new NodeActionListener() {
       @Override
       public void actionPerformed(NodeActionEvent e) {
@@ -191,8 +192,8 @@ public class DockerHostNode extends AzureRefreshableNode implements TelemetryPro
         });
       }
     }));
-    addAction(ACTION_RESTART, ACTION_START_ICON, new RestartDockerHostAction());
-    addAction(ACTION_SHUTDOWN, ACTION_SHUTDOWN_ICON, new ShutdownDockerHostAction());
+    addAction(ACTION_RESTART, CommonIcons.ACTION_START, new RestartDockerHostAction());
+    addAction(ACTION_SHUTDOWN, CommonIcons.ACTION_STOP, new ShutdownDockerHostAction());
     super.loadActions();
   }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/rediscache/RedisCacheNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/rediscache/RedisCacheNode.java
@@ -29,6 +29,7 @@ import static com.microsoft.azuretools.telemetry.TelemetryConstants.REDIS_OPEN_B
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.REDIS_OPEN_EXPLORER;
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.REDIS_READPROP;
 
+import com.microsoft.azure.CommonIcons;
 import com.microsoft.tooling.msservices.serviceexplorer.WrappedTelemetryNodeActionListener;
 import java.util.HashMap;
 import java.util.Map;
@@ -154,13 +155,13 @@ public class RedisCacheNode extends Node implements TelemetryProperties {
     @Override
     protected void loadActions() {
         if (!CREATING_STATE.equals(this.provisionState)) {
-            addAction(DELETE_ACTION, null, new DeleteRedisCacheAction());
-            addAction(SHOW_PROPERTY_ACTION, null, new WrappedTelemetryNodeActionListener(REDIS, REDIS_READPROP,
+            addAction(DELETE_ACTION, CommonIcons.ACTION_DISCARD, new DeleteRedisCacheAction());
+            addAction(SHOW_PROPERTY_ACTION, CommonIcons.ACTION_OPEN_PREFERENCES, new WrappedTelemetryNodeActionListener(REDIS, REDIS_READPROP,
                 new ShowRedisCachePropertyAction()));
             addAction(OPEN_EXPLORER, null, new WrappedTelemetryNodeActionListener(REDIS, REDIS_OPEN_EXPLORER,
                 new OpenRedisExplorerAction()));
         }
-        addAction(OPEN_IN_BROWSER_ACTION, null, new WrappedTelemetryNodeActionListener(REDIS, REDIS_OPEN_BROWSER,
+        addAction(OPEN_IN_BROWSER_ACTION, CommonIcons.ACTION_OPEN_IN_BROWSER, new WrappedTelemetryNodeActionListener(REDIS, REDIS_OPEN_BROWSER,
             new OpenInBrowserAction()));
         super.loadActions();
     }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/ContainerNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/ContainerNode.java
@@ -24,9 +24,11 @@
 package com.microsoft.tooling.msservices.serviceexplorer.azure.storage;
 
 import com.google.common.collect.ImmutableMap;
+import com.microsoft.azure.CommonIcons;
 import com.microsoft.azure.management.resources.fluentcore.arm.ResourceId;
 import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.telemetry.AppInsightsConstants;
 import com.microsoft.azuretools.telemetry.TelemetryProperties;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
@@ -120,6 +122,11 @@ public class ContainerNode extends Node implements TelemetryProperties{
         @Override
         protected void onSubscriptionsChanged(NodeActionEvent e)
                 throws AzureCmdException {
+        }
+
+        @Override
+        protected @Nullable String getIconPath() {
+            return CommonIcons.ACTION_DISCARD;
         }
     }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/asm/StorageNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/asm/StorageNode.java
@@ -26,6 +26,7 @@ package com.microsoft.tooling.msservices.serviceexplorer.azure.storage.asm;
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.DELETE_STORAGE_ACCOUNT;
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.STORAGE;
 
+import com.microsoft.azure.CommonIcons;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.telemetry.AppInsightsConstants;
 import com.microsoft.azuretools.telemetry.TelemetryProperties;
@@ -111,7 +112,7 @@ public class StorageNode extends ClientStorageNode implements TelemetryPropertie
 
     @Override
     protected Map<String, Class<? extends NodeActionListener>> initActions() {
-        addAction("Delete", new DeleteStorageAccountAction());
+        addAction("Delete", CommonIcons.ACTION_DISCARD, new DeleteStorageAccountAction());
         return super.initActions();
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/vmarm/VMNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/vmarm/VMNode.java
@@ -30,6 +30,7 @@ import static com.microsoft.azuretools.telemetry.TelemetryConstants.START_VM;
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.VM;
 
 import com.microsoft.azure.CloudException;
+import com.microsoft.azure.CommonIcons;
 import com.microsoft.azure.management.compute.InstanceViewStatus;
 import com.microsoft.azure.management.compute.VirtualMachine;
 import com.microsoft.azure.management.resources.fluentcore.arm.ResourceId;
@@ -251,10 +252,10 @@ public class VMNode extends RefreshableNode implements TelemetryProperties {
     @Override
     protected void loadActions() {
         super.loadActions();
-        addAction(ACTION_START, ACTION_START_ICON, new StartVMAction());
+        addAction(ACTION_START, CommonIcons.ACTION_START, new StartVMAction());
         addAction(ACTION_RESTART, new RestartVMAction());
-        addAction(ACTION_SHUTDOWN, ACTION_SHUTDOWN_ICON, new ShutdownVMAction());
-        addAction(ACTION_DELETE, ACTION_DELETE_ICON, new DeleteVMAction());
+        addAction(ACTION_SHUTDOWN, CommonIcons.ACTION_STOP, new ShutdownVMAction());
+        addAction(ACTION_DELETE, CommonIcons.ACTION_DISCARD, new DeleteVMAction());
     }
 
     @Override

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/WebAppNode.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
- * Copyright (c) 2019 JetBrains s.r.o.
+ * Copyright (c) 2019-2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -23,41 +23,30 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.webapp;
 
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.DELETE_WEBAPP;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.RESTART_WEBAPP;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.START_WEBAPP;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.STOP_WEBAPP;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.WEBAPP;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.WEBAPP_OPEN_INBROWSER;
-import static com.microsoft.azuretools.telemetry.TelemetryConstants.WEBAPP_SHOWPROP;
-
-import com.microsoft.tooling.msservices.serviceexplorer.WrappedTelemetryNodeActionListener;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeAction;
-import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot.DeploymentSlotModule;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.microsoft.azure.CommonIcons;
 import com.microsoft.azuretools.telemetry.AppInsightsConstants;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
+import com.microsoft.tooling.msservices.serviceexplorer.NodeAction;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPromptListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBaseNode;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBaseState;
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot.DeploymentSlotModule;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.DELETE_WEBAPP;
+import static com.microsoft.azuretools.telemetry.TelemetryConstants.WEBAPP;
 
 public class WebAppNode extends WebAppBaseNode implements WebAppNodeView {
     private static final String DELETE_WEBAPP_PROMPT_MESSAGE = "This operation will delete the Web App: %s.\n"
         + "Are you sure you want to continue?";
     private static final String DELETE_WEBAPP_PROGRESS_MESSAGE = "Deleting Web App";
     private static final String LABEL = "WebApp";
-
-    private static final String ICON_ACTION_START = "AzureStart.svg";
-    private static final String ICON_ACTION_STOP = "AzureStop.svg";
-    private static final String ICON_ACTION_RESTART = "AzureRestart.svg";
-    private static final String ICON_ACTION_OPEN_IN_BROWSER = "OpenInBrowser.svg";
-    private static final String ICON_ACTION_DELETE = "Discard.svg";
-    private static final String ICON_ACTION_SHOW_PROPERTIES = "gearPlain.svg";
 
     private final WebAppNodePresenter<WebAppNode> webAppNodePresenter;
     protected String webAppName;
@@ -80,11 +69,11 @@ public class WebAppNode extends WebAppBaseNode implements WebAppNodeView {
         webAppNodePresenter.onAttachView(WebAppNode.this);
 
         startAction = new NodeAction(this, ACTION_START);
-        startAction.setIconPath(ICON_ACTION_START);
+        startAction.setIconPath(CommonIcons.ACTION_START);
         startAction.addListener(createBackgroundActionListener("Starting Web App", this::startWebApp));
 
         stopAction = new NodeAction(this, ACTION_STOP);
-        stopAction.setIconPath(ICON_ACTION_STOP);
+        stopAction.setIconPath(CommonIcons.ACTION_STOP);
         stopAction.addListener(createBackgroundActionListener("Stopping Web App", this::stopWebApp));
 
         loadActions();
@@ -102,15 +91,15 @@ public class WebAppNode extends WebAppBaseNode implements WebAppNodeView {
 
     @Override
     protected void loadActions() {
-        addAction(ACTION_RESTART, ICON_ACTION_RESTART, createBackgroundActionListener("Restarting Web App", () -> restartWebApp()));
-        addAction(ACTION_DELETE, ICON_ACTION_DELETE, new DeleteWebAppAction());
-        addAction(ACTION_OPEN_IN_BROWSER, ICON_ACTION_OPEN_IN_BROWSER, new NodeActionListener() {
+        addAction(ACTION_RESTART, CommonIcons.ACTION_RESTART, createBackgroundActionListener("Restarting Web App", () -> restartWebApp()));
+        addAction(ACTION_DELETE, CommonIcons.ACTION_DISCARD, new DeleteWebAppAction());
+        addAction(ACTION_OPEN_IN_BROWSER, CommonIcons.ACTION_OPEN_IN_BROWSER, new NodeActionListener() {
             @Override
             protected void actionPerformed(NodeActionEvent e) {
                 DefaultLoader.getUIHelper().openInBrowser("http://" + hostName);
             }
         });
-        addAction(ACTION_SHOW_PROPERTY, ICON_ACTION_SHOW_PROPERTIES, new NodeActionListener() {
+        addAction(ACTION_SHOW_PROPERTY, CommonIcons.ACTION_OPEN_PREFERENCES, new NodeActionListener() {
             @Override
             protected void actionPerformed(NodeActionEvent e) {
                 DefaultLoader.getUIHelper().openWebAppPropertyView(WebAppNode.this);


### PR DESCRIPTION
- Add properties for icon path for actions that are passed to Azure Explorer node from IDE side
- Set missing icons for existing actions