### PR TITLE
Add customized Application Property View

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/ui/component/appservice/ExistingAppsTableComponent.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/ui/component/appservice/ExistingAppsTableComponent.kt
@@ -230,23 +230,30 @@ open class ExistingAppsTableComponent<T : WebAppBase> :
     /**
      * Get a user friendly text for net framework for an existing Azure web app base instance
      *
-     * Note: For .NET Framework there are two valid values for version (v4.7 and v3.5). Azure SDK
-     *       does not set the right values. They set the "v4.0" for "v4.7" and "v2.0" for "v3.5" instances
-     *       For .Net Core Framework we get the correct runtime value from the linux fx version that store
-     *       a instance name representation
+     * Note: Windows instances - there are two valid .NET Framework values for Windows instances (v4.7 and v3.5).
+     *       Azure SDK provides a CLR values set in "netFrameworkVersion" property. It has one of two CLR values:
+     *       - "v4.0" which refers to .Net Framework 4.7 version
+     *       - "v2.0" which refers to .Net Framework 3.5 version
+     *       We do mapping using this rules above to display it to a user.
      *
-     * Note: 2.0 and 4.0 are CLR versions most likely
+     *       Linux instances - we get the runtime value stored in "linuxFxVersion" property. Possible values can be
+     *       found by running "az webapp list-runtimes --linux" in Azure CLI.
+     *       Result example for dotnet containers: "DOTNETCORE|2.1", "DOTNETCORE|3.1"
+     *       Return the value as is.
      *
      * @param app web app base instance
      * @return [String] with a .Net Framework version for a web app base instance
      */
-    private fun mapAppFrameworkVersion(app: T): String {
-        return if (app.operatingSystem() == OperatingSystem.LINUX) {
-            "Core v${app.linuxFxVersion().split('|')[1]}"
-        } else {
-            val version = app.netFrameworkVersion().toString()
-            if (version.startsWith("v4")) "v4.7"
-            else "v3.5"
-        }
-    }
+    private fun mapAppFrameworkVersion(app: T): String =
+            when (app.operatingSystem()) {
+                OperatingSystem.WINDOWS -> {
+                    val version = app.netFrameworkVersion().toString()
+                    if (version.startsWith("v4")) "v4.7"
+                    else "v3.5"
+                }
+                OperatingSystem.LINUX -> {
+                    app.linuxFxVersion()
+                }
+                else -> ""
+            }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/icons/CommonIcons.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/icons/CommonIcons.kt
@@ -42,7 +42,6 @@ object CommonIcons {
     val SaveChanges by lazy { load("SaveChanges.svg") }
     val Open by lazy { load("AzureOpen.svg") }
     val Upload by lazy { load("AzureUpload.svg") }
-    val Download by lazy { load("download.svg") }
 
     val PublishAzure by lazy { load("publishAzure.svg") }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/base/AppBasePropertyView.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/base/AppBasePropertyView.kt
@@ -1,0 +1,369 @@
+/**
+ * Copyright (c) 2020 JetBrains s.r.o.
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.intellij.helpers.base
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.fileChooser.FileChooser
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.MessageType
+import com.intellij.openapi.util.Comparing
+import com.intellij.openapi.wm.StatusBar
+import com.intellij.openapi.wm.WindowManager
+import com.intellij.ui.HideableTitledPanel
+import com.intellij.ui.HyperlinkLabel
+import com.microsoft.azure.management.appservice.OperatingSystem
+import com.microsoft.azuretools.core.mvp.ui.webapp.WebAppProperty
+import com.microsoft.icons.CommonIcons
+import com.microsoft.intellij.ui.components.AppSettingsComponent
+import com.microsoft.intellij.ui.components.AzureActionListenerWrapper
+import com.microsoft.intellij.ui.util.UIUtils
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppBasePropertyMvpView
+import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter
+import net.miginfocom.swing.MigLayout
+import java.awt.Font
+import java.awt.event.ActionEvent
+import javax.swing.*
+import javax.swing.table.DefaultTableModel
+
+abstract class AppBasePropertyView(val project: Project,
+                                   val subscriptionId: String,
+                                   val resourceId: String,
+                                   val slotName: String?) : BaseEditor(), WebAppBasePropertyMvpView {
+
+    companion object {
+        private const val HEADER_OVERVIEW = "Overview"
+        private const val HEADER_APP_SETTINGS = "App Settings"
+
+        private const val TXT_NA = "N/A"
+        private const val TABLE_EMPTY_MESSAGE = "No available settings."
+        private const val FILE_SELECTOR_TITLE = "Choose Where You Want to Save the Publish Profile."
+        private const val NOTIFY_PROPERTY_UPDATE_SUCCESS = "Properties updated."
+        private const val NOTIFY_PROFILE_GET_SUCCESS = "Publish Profile saved."
+        private const val NOTIFY_PROFILE_GET_FAIL = "Failed to get Publish Profile."
+        private const val TEXT_LOADING = "Loading..."
+
+        private const val INSIGHT_NAME = "AzurePlugin.IntelliJ.Editor.AppBasePropertyView"
+    }
+
+    private val pnlMain = JPanel(MigLayout("novisualpadding, ins 5, fillx, wrap 1"))
+    private val pnlControlButtons = JPanel(MigLayout("novisualpadding, ins 0, wrap 3"))
+    private val btnGetPublishFile = JButton("Get Publish Profile", AllIcons.Actions.Download)
+    private val btnSave = JButton("Save", CommonIcons.SaveChanges)
+    private val btnDiscard = JButton("Discard", CommonIcons.Discard)
+
+    // TODO: This this layout
+    private val pnlOverview = JPanel(MigLayout("novisualpadding, ins 0, fillx, wrap 4",
+            "[10%][shrink 0, shrinkprio 1][10%][40%, shrinkprio 2]"))
+    private val pnlOverviewHolder = HideableTitledPanel(HEADER_OVERVIEW, false, pnlOverview, true)
+
+    private val lblResourceGroup = JLabel("Resource Group:")
+    private val txtResourceGroup = JTextField(TEXT_LOADING)
+
+    private val lblStatus = JLabel("Status:")
+    private val txtStatus = JTextField(TEXT_LOADING)
+
+    private val lblLocation = JLabel("Location:")
+    private val txtLocation = JTextField(TEXT_LOADING)
+
+    private val lblSubscription = JLabel("Subscription ID:")
+    private val txtSubscription = JTextField(TEXT_LOADING)
+
+    private val lblAppServicePlan = JLabel("App Service Plan:")
+    private val txtAppServicePlan = JTextField(TEXT_LOADING)
+
+    private val lblUrl = JLabel("URL:")
+    private val lnkUrl = HyperlinkLabel()
+
+    private val lblPricingTier = JLabel("Pricing Tier:")
+    private val txtPricingTier = JTextField(TEXT_LOADING)
+
+    private val lblOperatingSystem = JLabel("OS:")
+    private val txtOperatingSystem = JLabel(TEXT_LOADING)
+
+    private val lblRuntime = JLabel("Runtime:")
+    private val txtRuntime = JTextField(TEXT_LOADING)
+
+    private val pnlAppSettings = AppSettingsComponent()
+    private val pnlAppSettingsHolder = HideableTitledPanel(HEADER_APP_SETTINGS, false, pnlAppSettings, true)
+
+    val appId: String
+    protected val presenter: WebAppBasePropertyViewPresenter<WebAppBasePropertyMvpView>
+    private val statusBar: StatusBar
+
+    init {
+        initButtons()
+        initAppSettingTable()
+
+        pnlControlButtons.apply {
+            add(btnGetPublishFile)
+            add(btnSave)
+            add(btnDiscard)
+        }
+
+        setBoldFont(
+                lblResourceGroup,
+                lblStatus,
+                lblLocation,
+                lblUrl,
+                lblSubscription,
+                lblAppServicePlan,
+                lblPricingTier,
+                lblOperatingSystem,
+                lblRuntime
+        )
+
+        pnlOverview.apply {
+            add(lblResourceGroup)
+            add(txtResourceGroup, "growx")
+            add(lblAppServicePlan)
+            add(txtAppServicePlan, "growx")
+            add(lblStatus)
+            add(txtStatus, "growx")
+            add(lblUrl)
+            add(lnkUrl, "growx")
+            add(lblLocation)
+            add(txtLocation, "growx")
+            add(lblPricingTier)
+            add(txtPricingTier, "growx")
+            add(lblSubscription)
+            add(txtSubscription, "growx")
+            add(lblOperatingSystem)
+            add(txtOperatingSystem, "growx")
+            add(lblRuntime)
+            add(txtRuntime, "growx")
+        }
+
+        pnlMain.apply {
+            add(pnlControlButtons, "growx")
+            add(pnlOverviewHolder, "growx")
+            add(pnlAppSettingsHolder, "growx")
+        }
+
+        appId = getId()
+        presenter = createPresenter()
+        presenter.onAttachView(this)
+        statusBar = WindowManager.getInstance().getStatusBar(project)
+
+        lnkUrl.setHyperlinkText("<Loading...>")
+        setTextFieldStyle()
+    }
+
+    protected abstract fun getId(): String
+
+    protected abstract fun createPresenter(): WebAppBasePropertyViewPresenter<WebAppBasePropertyMvpView>
+
+    override fun onLoadWebAppProperty(sid: String, appId: String, slotName: String?) =
+            presenter.onLoadWebAppProperty(sid, appId, slotName)
+
+    override fun getComponent() = pnlMain
+
+    override fun getName() = appId
+
+    override fun dispose() {
+        presenter.onDetachView()
+    }
+
+    override fun showProperty(property: WebAppProperty) {
+        txtResourceGroup.text  = property.getValue(WebAppBasePropertyViewPresenter.KEY_RESOURCE_GRP) as? String ?: TXT_NA
+        txtStatus.text         = property.getValue(WebAppBasePropertyViewPresenter.KEY_STATUS) as? String ?: TXT_NA
+        txtLocation.text       = property.getValue(WebAppBasePropertyViewPresenter.KEY_LOCATION) as? String ?: TXT_NA
+        txtSubscription.text   = property.getValue(WebAppBasePropertyViewPresenter.KEY_SUB_ID) as? String ?: TXT_NA
+        txtAppServicePlan.text = property.getValue(WebAppBasePropertyViewPresenter.KEY_PLAN) as? String ?: TXT_NA
+
+        val url = property.getValue(WebAppBasePropertyViewPresenter.KEY_URL) as? String
+        if (url == null) {
+            lnkUrl.setHyperlinkText(TXT_NA)
+        } else {
+            val linkText = "http://$url"
+            lnkUrl.setHyperlinkText(linkText)
+            lnkUrl.setHyperlinkTarget(linkText)
+        }
+
+        txtPricingTier.text = property.getValue(WebAppBasePropertyViewPresenter.KEY_PRICING) as? String ?: TXT_NA
+
+        // Operating System
+        val operatingSystem = property.getValue(WebAppBasePropertyViewPresenter.KEY_OPERATING_SYS) as? OperatingSystem
+        txtOperatingSystem.text = operatingSystem?.name?.toLowerCase()?.capitalize() ?: TXT_NA
+        txtOperatingSystem.icon = when (operatingSystem) {
+            OperatingSystem.WINDOWS -> CommonIcons.OS.Windows
+            OperatingSystem.LINUX -> CommonIcons.OS.Linux
+            else -> null
+        }
+
+        // Runtime
+        txtRuntime.text =
+                when (operatingSystem) {
+                    OperatingSystem.WINDOWS -> {
+                        val netFrameworkVersionString = property.getValue(WebAppBasePropertyViewPresenter
+                                .KEY_NET_FRAMEWORK_VERSION) as? String ?: TXT_NA
+                        when {
+                            netFrameworkVersionString.startsWith("v4") -> "v4.7"
+                            netFrameworkVersionString.startsWith("v2") -> "v3.5"
+                            else -> netFrameworkVersionString
+                        }
+                    }
+                    OperatingSystem.LINUX -> {
+                        property.getValue(WebAppBasePropertyViewPresenter.KEY_LINUX_FX_VERSION) as? String ?: TXT_NA
+                    }
+                    else -> TXT_NA
+                }
+
+        // App Settings
+        val tableModel = pnlAppSettings.table.model as DefaultTableModel
+        tableModel.dataVector.removeAllElements()
+        pnlAppSettings.cachedAppSettings.clear()
+        pnlAppSettings.table.emptyText.text = TABLE_EMPTY_MESSAGE
+        val appSettings = property.getValue(WebAppBasePropertyViewPresenter.KEY_APP_SETTING) as? Map<*, *>
+        if (appSettings != null) {
+            for (key in appSettings.keys) {
+                if (key !is String) continue
+                val value = appSettings[key] as? String ?: continue
+                tableModel.addRow(arrayOf(key, value))
+                pnlAppSettings.cachedAppSettings[key] = value
+            }
+        }
+        updateMapStatus(pnlAppSettings.editedAppSettings, pnlAppSettings.cachedAppSettings)
+        pnlOverview.revalidate()
+        pnlAppSettings.revalidate()
+    }
+
+    override fun showPropertyUpdateResult(isSuccess: Boolean) {
+        setBtnEnableStatus(true)
+        if (isSuccess) {
+            updateMapStatus(pnlAppSettings.cachedAppSettings, pnlAppSettings.editedAppSettings)
+            UIUtils.showNotification(statusBar, NOTIFY_PROPERTY_UPDATE_SUCCESS, MessageType.INFO)
+        }
+    }
+
+    override fun showGetPublishingProfileResult(isSuccess: Boolean) {
+        if (isSuccess) {
+            UIUtils.showNotification(statusBar, NOTIFY_PROFILE_GET_SUCCESS, MessageType.INFO)
+        } else {
+            UIUtils.showNotification(statusBar, NOTIFY_PROFILE_GET_FAIL, MessageType.ERROR)
+        }
+    }
+
+    private fun updateMapStatus(to: MutableMap<String, String>, from: Map<String, String>) {
+        to.clear()
+        to.putAll(from)
+        updateSaveAndDiscardBtnStatus()
+    }
+
+    private fun setBtnEnableStatus(enabled: Boolean) {
+        btnSave.isEnabled = enabled
+        btnDiscard.isEnabled = enabled
+        pnlAppSettings.btnAdd.isEnabled = enabled
+        pnlAppSettings.btnDelete.isEnabled = enabled
+        pnlAppSettings.btnEdit.isEnabled = enabled
+        pnlAppSettings.table.isEnabled = enabled
+    }
+
+    private fun updateSaveAndDiscardBtnStatus() {
+        if (Comparing.equal(pnlAppSettings.editedAppSettings, pnlAppSettings.cachedAppSettings)) {
+            btnDiscard.isEnabled = false
+            btnSave.isEnabled = false
+        } else {
+            btnDiscard.isEnabled = true
+            btnSave.isEnabled = true
+        }
+    }
+
+    private fun setTextFieldStyle() {
+        val controls = arrayOf<JComponent>(
+                txtResourceGroup,
+                txtStatus,
+                txtLocation,
+                txtSubscription,
+                txtAppServicePlan,
+                txtPricingTier,
+                txtOperatingSystem,
+                txtRuntime
+        )
+
+        controls.forEach { control ->
+            control.border = BorderFactory.createEmptyBorder()
+            control.background = null
+        }
+    }
+
+    private fun initButtons() {
+        btnGetPublishFile.addActionListener(object : AzureActionListenerWrapper(INSIGHT_NAME, "btnGetPublishFile", null) {
+            override fun actionPerformedFunc(event: ActionEvent) {
+                val fileChooserDescriptor = FileChooserDescriptor(
+                        false,
+                        true,
+                        false,
+                        false,
+                        false,
+                        false
+                )
+                fileChooserDescriptor.title = FILE_SELECTOR_TITLE
+                val file = FileChooser.chooseFile(fileChooserDescriptor, null, null)
+                        ?: return
+
+                presenter.onGetPublishingProfileXmlWithSecrets(subscriptionId, resourceId, slotName, file.path)
+            }
+        })
+
+        btnDiscard.isEnabled = false
+        btnDiscard.addActionListener(object : AzureActionListenerWrapper(INSIGHT_NAME, "btnDiscard", null) {
+            override fun actionPerformedFunc(event: ActionEvent) {
+                val tableModel = pnlAppSettings.table.model as DefaultTableModel
+
+                updateMapStatus(pnlAppSettings.editedAppSettings, pnlAppSettings.cachedAppSettings)
+                tableModel.dataVector.removeAllElements()
+                for (key in pnlAppSettings.editedAppSettings.keys) {
+                    tableModel.addRow(arrayOf(key, pnlAppSettings.editedAppSettings[key]))
+                }
+                tableModel.fireTableDataChanged()
+            }
+        })
+
+        btnSave.isEnabled = false
+        btnSave.addActionListener(object : AzureActionListenerWrapper(INSIGHT_NAME, "btnSave", null) {
+            override fun actionPerformedFunc(event: ActionEvent) {
+                setBtnEnableStatus(false)
+                presenter.onUpdateWebAppProperty(subscriptionId, resourceId, slotName, pnlAppSettings.cachedAppSettings, pnlAppSettings.editedAppSettings)
+            }
+        })
+    }
+
+    private fun initAppSettingTable() {
+        pnlAppSettings.table.addPropertyChangeListener { event ->
+            if ("tableCellEditor" != event.propertyName || pnlAppSettings.table.isEditing)
+                return@addPropertyChangeListener
+
+            updateSaveAndDiscardBtnStatus()
+        }
+
+        pnlAppSettings.deleteButtonAction = { updateSaveAndDiscardBtnStatus() }
+    }
+
+    private fun setBoldFont(vararg components: JLabel) {
+        components.forEach { component ->
+            val font = component.font
+            component.font = Font(font.name, Font.BOLD, font.size)
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/function/FunctionAppPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/function/FunctionAppPropertyView.java
@@ -25,7 +25,7 @@ package com.microsoft.intellij.helpers.function;
 import com.intellij.openapi.project.Project;
 import com.microsoft.azure.management.appservice.WebAppBase;
 import com.microsoft.azuretools.core.mvp.model.function.AzureFunctionMvpModel;
-import com.microsoft.intellij.helpers.webapp.WebAppBasePropertyView;
+import com.microsoft.intellij.helpers.base.AppBasePropertyView;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 import org.jetbrains.annotations.NotNull;
 
@@ -33,11 +33,11 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
-public class FunctionAppPropertyView extends WebAppBasePropertyView {
+public class FunctionAppPropertyView extends AppBasePropertyView {
     private static final String ID = "com.microsoft.intellij.helpers.function.FunctionAppPropertyView";
 
-    public static WebAppBasePropertyView create(@NotNull final Project project, @NotNull final String sid,
-                                                @NotNull final String webAppId) {
+    public static AppBasePropertyView create(@NotNull final Project project, @NotNull final String sid,
+                                             @NotNull final String webAppId) {
         final FunctionAppPropertyView view = new FunctionAppPropertyView(project, sid, webAppId);
         view.onLoadWebAppProperty(sid, webAppId, null);
         return view;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/DeploymentSlotPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/DeploymentSlotPropertyView.java
@@ -22,21 +22,22 @@
 
 package com.microsoft.intellij.helpers.webapp;
 
+import com.microsoft.intellij.helpers.base.AppBasePropertyView;
 import org.jetbrains.annotations.NotNull;
 
 import com.intellij.openapi.project.Project;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.deploymentslot.DeploymentSlotPropertyViewPresenter;
 
-public class DeploymentSlotPropertyView extends WebAppBasePropertyView {
+public class DeploymentSlotPropertyView extends AppBasePropertyView {
     private static final String ID = "com.microsoft.intellij.helpers.webapp.DeploymentSlotPropertyView";
 
     /**
      * Initialize the Web App Property View and return it.
      */
-    public static WebAppBasePropertyView create(@NotNull final Project project, @NotNull final String sid,
-                                                @NotNull final String resId, @NotNull final String slotName) {
-        DeploymentSlotPropertyView view = new DeploymentSlotPropertyView(project, sid, resId, slotName);
+    public static AppBasePropertyView create(@NotNull final Project project, @NotNull final String sid,
+                                             @NotNull final String resId, @NotNull final String slotName) {
+        final DeploymentSlotPropertyView view = new DeploymentSlotPropertyView(project, sid, resId, slotName);
         view.onLoadWebAppProperty(sid, resId, slotName);
         return view;
     }
@@ -48,7 +49,7 @@ public class DeploymentSlotPropertyView extends WebAppBasePropertyView {
 
     @Override
     protected String getId() {
-        return this.ID;
+        return ID;
     }
 
     @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppPropertyView.java
@@ -22,21 +22,22 @@
 
 package com.microsoft.intellij.helpers.webapp;
 
+import com.microsoft.intellij.helpers.base.AppBasePropertyView;
 import org.jetbrains.annotations.NotNull;
 
 import com.intellij.openapi.project.Project;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.WebAppPropertyViewPresenter;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.webapp.base.WebAppBasePropertyViewPresenter;
 
-public class WebAppPropertyView extends WebAppBasePropertyView {
+public class WebAppPropertyView extends AppBasePropertyView {
     private static final String ID = "com.microsoft.intellij.helpers.webapp.WebAppBasePropertyView";
 
     /**
      * Initialize the Web App Property View and return it.
      */
-    public static WebAppBasePropertyView create(@NotNull final Project project, @NotNull final String sid,
-                                                @NotNull final String webAppId) {
-        WebAppPropertyView view = new WebAppPropertyView(project, sid, webAppId);
+    public static AppBasePropertyView create(@NotNull final Project project, @NotNull final String sid,
+                                             @NotNull final String webAppId) {
+        final WebAppPropertyView view = new WebAppPropertyView(project, sid, webAppId);
         view.onLoadWebAppProperty(sid, webAppId, null);
         return view;
     }
@@ -48,7 +49,7 @@ public class WebAppPropertyView extends WebAppBasePropertyView {
 
     @Override
     protected String getId() {
-        return this.ID;
+        return ID;
     }
 
     @Override

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/base/WebAppBasePropertyViewPresenter.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/base/WebAppBasePropertyViewPresenter.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.appservice.AppServicePlan;
 import com.microsoft.azure.management.appservice.AppSetting;
+import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.management.appservice.WebAppBase;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
@@ -57,6 +58,8 @@ public abstract class WebAppBasePropertyViewPresenter<V extends WebAppBaseProper
     public static final String KEY_JAVA_CONTAINER_VERSION = "javaContainerVersion";
     public static final String KEY_OPERATING_SYS = "operatingSystem";
     public static final String KEY_APP_SETTING = "appSetting";
+    public static final String KEY_NET_FRAMEWORK_VERSION = "netFrameworkVersion";
+    public static final String KEY_LINUX_FX_VERSION = "linuxFxVersion";
 
     private static final String CANNOT_GET_WEB_APP_PROPERTY = "An exception occurred when getting the application settings.";
 
@@ -102,6 +105,8 @@ public abstract class WebAppBasePropertyViewPresenter<V extends WebAppBaseProper
         }
         propertyMap.put(KEY_OPERATING_SYS, webAppBase.operatingSystem());
         propertyMap.put(KEY_APP_SETTING, appSettingsMap);
+        propertyMap.put(KEY_NET_FRAMEWORK_VERSION, webAppBase.netFrameworkVersion().toString());
+        propertyMap.put(KEY_LINUX_FX_VERSION, webAppBase.linuxFxVersion());
 
         return new WebAppProperty(propertyMap);
     }


### PR DESCRIPTION
- Modify WebAppBasePropertyView to a custom implementation - AppBasePropertyView. The view avoid all Java related infomration and provides more information about dotnet runtime
- Fix displaying runtime in publish run configurations for Web and Function apps
- Add `Runtime` information in properties.
- Updated images for buttons in Properties view and. Add OS icon (Windows/Linux). Remove unexisting image constants
- Update context menu and make it same for Function App and Web Apps - `Show Properties` vs. previous of `Open Properties` for function apps.

Moving Properties View from this:
Function App:
<img width="895" alt="AppPropertiesView_FunctionApp_Present" src="https://user-images.githubusercontent.com/6064345/89755726-13a46f00-dae9-11ea-98ad-148bc18f492f.png">

Web App:
<img width="895" alt="AppPropertiesView_WebApp_Present" src="https://user-images.githubusercontent.com/6064345/89755746-2454e500-dae9-11ea-874c-33a6e4c2de09.png">

to this view for all entries (Function, Web apps and Deployment Slots):
<img width="905" alt="AppPropertiesView_FunctionApp_New" src="https://user-images.githubusercontent.com/6064345/89755733-18692300-dae9-11ea-8fa7-db6cd36f2e51.png">