### PR TITLE
Move Storage Emulator node persistent at the top of Storage Account module in Azure Explorer

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/components/ServerExplorerToolWindowFactory.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/components/ServerExplorerToolWindowFactory.java
@@ -222,7 +222,7 @@ public class ServerExplorerToolWindowFactory implements ToolWindowFactory, Prope
     }
 
     private SortableTreeNode createTreeNode(Node node, Project project) {
-        SortableTreeNode treeNode = new SortableTreeNode(node, true);
+        SortableTreeNode treeNode = new SortableTreeNode(node, true, node.getNodeComparator());
 
         // associate the DefaultMutableTreeNode with the Node via it's "viewData"
         // property; this allows us to quickly retrieve the DefaultMutableTreeNode

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/components/SortableTreeNode.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/components/SortableTreeNode.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -22,6 +23,9 @@
 
 package com.microsoft.intellij.components;
 
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
+import com.microsoft.tooling.msservices.serviceexplorer.Node;
+
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.MutableTreeNode;
 import java.util.Comparator;
@@ -34,6 +38,15 @@ public class SortableTreeNode extends DefaultMutableTreeNode {
 
     public SortableTreeNode(Object userObject, boolean allowsChildren) {
         super(userObject, allowsChildren);
+    }
+
+    public SortableTreeNode(Object userObject, boolean allowsChildren, @Nullable Comparator<Node> comparator) {
+        super(userObject, allowsChildren);
+        if (comparator != null) {
+            // Cast Comparator<Node> to Comparator<SortableTreeNode> instance to be able to sort presentation nodes.
+            this.nodeComparator =
+                    (Comparator<SortableTreeNode>) (node1, node2) -> comparator.compare((Node)node1.userObject, (Node)node2.userObject);
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -50,6 +63,6 @@ public class SortableTreeNode extends DefaultMutableTreeNode {
         this.children.sort(nodeComparator);
     }
 
-    private static final Comparator nodeComparator =
+    private Comparator nodeComparator =
             (Comparator<SortableTreeNode>) (node1, node2) -> node1.toString().compareToIgnoreCase(node2.toString());
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/Node.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/Node.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Iterators;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.azuretools.azurecommons.helpers.NotNull;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.core.mvp.ui.base.MvpView;
 import com.microsoft.azuretools.core.mvp.ui.base.NodeContent;
 import com.microsoft.azuretools.sdkmanage.AzureManager;
@@ -46,6 +47,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -402,5 +404,10 @@ public class Node implements MvpView, BasicTelemetryProperty {
         } catch (IOException e) {
             throw new AzureCmdException(OPEN_RESOURCES_IN_PORTAL_FAILED, e);
         }
+    }
+
+    @Nullable
+    public Comparator<Node> getNodeComparator() {
+        return null;
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/EmulatorStorageNode.kt
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/EmulatorStorageNode.kt
@@ -1,18 +1,18 @@
 /**
- * Copyright (c) 2018 JetBrains s.r.o.
- * <p/>
+ * Copyright (c) 2018-2020 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
@@ -22,11 +22,16 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.storage
 
+import com.microsoft.azuretools.utils.WebAppUtils
+import com.microsoft.tooling.msservices.components.DefaultLoader
 import com.microsoft.tooling.msservices.model.storage.ClientStorageAccount
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener
+import java.util.logging.Logger
 
 class EmulatorStorageNode(parent: StorageModule) : ExternalStorageNode(parent, emulatorStorageAccount) {
     companion object {
+        private val logger = Logger.getLogger(EmulatorStorageNode::class.java.name)
+
         // https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator
         private const val connectionName = "devstoreaccount1"
         private const val protocol = "http"
@@ -53,4 +58,19 @@ class EmulatorStorageNode(parent: StorageModule) : ExternalStorageNode(parent, e
     override fun initActions(): Map<String, Class<out NodeActionListener>>? {
         return emptyMap()
     }
+
+    override fun refreshItems() {
+        if (!isUrlAccessible(blobsUri) && !isUrlAccessible(tablesUri) && !isUrlAccessible(queuesUri)) {
+            logger.info("Unable to get any of storage emulator URLs: '$blobsUri', '$tablesUri', '$queuesUri'.")
+            DefaultLoader.getUIHelper().showError(
+                    "Please make sure local storage emulator is running. Unable to connect to blob ($blobsUri), table ($tablesUri), queue ($queuesUri) storage emulator instances.",
+                    "Unable to connect to local storage emulator"
+            )
+            return
+        }
+        super.refreshItems()
+    }
+
+    private fun isUrlAccessible(url: String): Boolean =
+            WebAppUtils.isUrlAccessible(url)
 }


### PR DESCRIPTION
- Provide an ability to define a comparator on Azure Explorer Node level
- Set comparator for Storage Account module that move Storage Emulator at the top
- Fix comparator in Azure Explorer on Plugin level with ability to get defined comparator instance
- Show notification if running Storage Emulator is not accessible instead of throwing "connection refused" exception after timeout when refreshing Storage Emulator node

<img width="457" alt="StorageEmulator_AtTheTop" src="https://user-images.githubusercontent.com/6064345/89983366-16859800-dc80-11ea-951e-da40a9107952.png">

<img width="903" alt="StorageEmulator_NotAvailable_Notification" src="https://user-images.githubusercontent.com/6064345/89983314-feae1400-dc7f-11ea-93ba-4fb7d77f7ba9.png">
