### PR TITLE
When expanding storage emulator node, only verify blob storage can be accessed

### DIFF
--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/EmulatorStorageNode.kt
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/EmulatorStorageNode.kt
@@ -60,10 +60,11 @@ class EmulatorStorageNode(parent: StorageModule) : ExternalStorageNode(parent, e
     }
 
     override fun refreshItems() {
-        if (!isUrlAccessible(blobsUri) && !isUrlAccessible(tablesUri) && !isUrlAccessible(queuesUri)) {
+        // NOTE: Since we only support blob storage right now, we're only checking for blob storage access
+        if (!isUrlAccessible(blobsUri)) {
             logger.info("Unable to get any of storage emulator URLs: '$blobsUri', '$tablesUri', '$queuesUri'.")
             DefaultLoader.getUIHelper().showError(
-                    "Please make sure local storage emulator is running. Unable to connect to blob ($blobsUri), table ($tablesUri), queue ($queuesUri) storage emulator instances.",
+                    "Please make sure local storage emulator is running. Unable to connect to the blob ($blobsUri) storage emulator instance.",
                     "Unable to connect to local storage emulator"
             )
             return
@@ -72,5 +73,5 @@ class EmulatorStorageNode(parent: StorageModule) : ExternalStorageNode(parent, e
     }
 
     private fun isUrlAccessible(url: String): Boolean =
-            WebAppUtils.isUrlAccessible(url)
+            WebAppUtils.isUrlAccessible(url, arrayOf(200, 400))
 }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/utils/WebAppUtils.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/utils/WebAppUtils.java
@@ -46,6 +46,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
@@ -279,12 +280,16 @@ public class WebAppUtils {
     }
 
     public static boolean isUrlAccessible(String url) throws IOException {
+        return isUrlAccessible(url, new Integer[] { HttpURLConnection.HTTP_OK });
+    }
+
+    public static boolean isUrlAccessible(String url, Integer[] validResponseCodes) throws IOException {
         HttpURLConnection.setFollowRedirects(false);
         HttpURLConnection con = (HttpURLConnection) new URL(url).openConnection();
         con.setRequestMethod("HEAD");
         con.setReadTimeout(Constants.connection_read_timeout_ms);
         try {
-            if (con.getResponseCode() != HttpURLConnection.HTTP_OK) {
+            if (!ArrayUtils.contains(validResponseCodes, con.getResponseCode())) {
                 return false;
             }
         } catch (IOException ex) {


### PR DESCRIPTION
* When expanding storage emulator node, only verify blob storage can be accessed
* Allow 200 & 400 response code when checking, which is what Azurite returns when running