### PR TITLE
Storage: show queues node in Azure Explorer for storage emulator/Azurite

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/.idea/misc.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/.idea/misc.xml
@@ -48,5 +48,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -7,6 +7,7 @@
       <h4>Features:</h4>
       <ul>
         <li>Compatibility with Rider 2020.3 EAP</li>
+        <li>Add queue support to storage explorer (for Azurite storage emulator) <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/96">#96</a></li>
       </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/icons/queue.svg
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/icons/queue.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M1 6H11V14.0714H1V6ZM9.88889 8.53673V7.15306L6 9.74745L2.11111 7.15306V8.53673L6 11.1311L9.88889 8.53673Z" fill="#f4af3d" fill-opacity="0.8"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M15 2H5V5H6.80553L6.11111 4.53673V3.15306L8.8796 5H11.1204L13.8889 3.15306V4.53673L12 5.79687V10.0714H15V2Z" fill="#9AA7B0" fill-opacity="0.8"/>
+</svg>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -25,6 +25,7 @@
         <p>[3.40.0-2020.3]</p>
         <ul>
           <li>Compatibility with Rider 2020.3 EAP</li>
+          <li>Add queue support to storage explorer (for Azurite storage emulator) <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/96">#96</a></li>
         </ul>
         <p>[3.40.0-2020.2]</p>
         <ul>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -220,6 +220,10 @@
     <serviceViewContributor implementation="org.jetbrains.plugins.azure.storage.azurite.AzuriteServiceViewContributor" />
 
     <editorNotificationProvider implementation="org.jetbrains.plugins.azure.identity.ad.notifications.DefaultAzureAdApplicationRegistrationNotificationProvider"/>
+
+    <notificationGroup id="Azure" displayType="BALLOON" isLogByDefault="true"/>
+    <notificationGroup id="AzureFunctions" displayType="BALLOON" isLogByDefault="true"/>
+    <notificationGroup id="Azure Web App Publish Message" displayType="BALLOON" isLogByDefault="true" toolWindowId="Run"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.microsoft.intellij">

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/config/FunctionAppRunState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/config/FunctionAppRunState.kt
@@ -24,10 +24,7 @@ package com.microsoft.intellij.runner.functionapp.config
 
 import com.intellij.execution.process.ProcessOutputTypes
 import com.intellij.ide.util.PropertiesComponent
-import com.intellij.notification.Notification
-import com.intellij.notification.NotificationGroup
-import com.intellij.notification.NotificationType
-import com.intellij.notification.Notifications
+import com.intellij.notification.*
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowId
 import com.microsoft.azure.management.appservice.FunctionApp
@@ -173,8 +170,10 @@ class FunctionAppRunState(project: Project,
     }
 
     private fun showPublishNotification(text: String, type: NotificationType) {
-        val displayId = NotificationGroup.toolWindowGroup("Azure Web App Publish Message", ToolWindowId.RUN).displayId
-        val notification = Notification(displayId, "", text, type)
+        val notification = NotificationGroupManager.getInstance()
+                .getNotificationGroup("Azure Web App Publish Message")
+                .createNotification(text, type)
+
         Notifications.Bus.notify(notification, project)
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/RiderWebAppRunState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/RiderWebAppRunState.kt
@@ -24,12 +24,10 @@ package com.microsoft.intellij.runner.webapp.config
 
 import com.intellij.execution.process.ProcessOutputTypes
 import com.intellij.ide.util.PropertiesComponent
-import com.intellij.notification.Notification
-import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.wm.ToolWindowId
 import com.microsoft.azure.management.appservice.OperatingSystem
 import com.microsoft.azure.management.appservice.WebApp
 import com.microsoft.azure.management.sql.SqlDatabase
@@ -190,8 +188,10 @@ class RiderWebAppRunState(project: Project,
     }
 
     private fun showPublishNotification(text: String, type: NotificationType) {
-        val displayId = NotificationGroup.toolWindowGroup("Azure Web App Publish Message", ToolWindowId.RUN).displayId
-        val notification = Notification(displayId, "", text, type)
+        val notification = NotificationGroupManager.getInstance()
+                .getNotificationGroup("Azure Web App Publish Message")
+                .createNotification(text, type)
+
         Notifications.Bus.notify(notification, project)
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/AzureNotifications.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/AzureNotifications.kt
@@ -21,16 +21,26 @@
  */
 package org.jetbrains.plugins.azure
 
-import com.intellij.notification.*
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationListener
+import com.intellij.notification.NotificationType
+import com.intellij.notification.Notifications
 import com.intellij.openapi.project.Project
 
 class AzureNotifications {
     companion object {
-        val notificationGroup = NotificationGroup("Azure", NotificationDisplayType.BALLOON, true, null, null)
+        private const val notificationGroupName = "Azure"
 
         fun notify(project: Project, title: String?, subtitle: String?, content: String?, type: NotificationType, listener: NotificationListener? = null) {
-            val notification = notificationGroup.createNotification(
-                    title, subtitle, content, type, listener)
+            val notification = NotificationGroupManager.getInstance()
+                    .getNotificationGroup(notificationGroupName)
+                    .createNotification(
+                            title = title,
+                            subtitle = subtitle,
+                            content = content,
+                            type = type,
+                            listener = listener
+                    )
 
             Notifications.Bus.notify(notification, project)
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/AzureCoreToolsNotification.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/AzureCoreToolsNotification.kt
@@ -41,13 +41,7 @@ import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsManager
 // TODO: FIX_VERSION: Replace with [SolutionLoadNotification] when async notifications are merged into 202
 class AzureCoreToolsNotification : StartupActivity {
     companion object {
-        private val notificationGroup = NotificationGroup(
-                displayId = "AzureFunctions",
-                displayType = NotificationDisplayType.BALLOON,
-                isLogByDefault = true,
-                toolWindowId = null,
-                icon = null
-        )
+        private const val notificationGroupName = "AzureFunctions"
     }
 
     override fun runActivity(project: Project) {
@@ -80,12 +74,14 @@ class AzureCoreToolsNotification : StartupActivity {
     private fun createInstallNotification(project: Project, allowPreRelease: Boolean): Notification {
         val title = message("notification.function_app.core_tools.install.title")
         val description = message("notification.function_app.core_tools.install.description")
-        val notification = notificationGroup.createNotification(
-                title = title,
-                subtitle = null,
-                content = description,
-                type = NotificationType.INFORMATION
-        )
+        val notification = NotificationGroupManager.getInstance()
+                .getNotificationGroup(notificationGroupName)
+                .createNotification(
+                        title = title,
+                        subtitle = null,
+                        content = description,
+                        type = NotificationType.INFORMATION
+                )
 
         notification.appendDownloadCoreToolsAction(
                 project = project,
@@ -100,12 +96,14 @@ class AzureCoreToolsNotification : StartupActivity {
         val title = message("notification.function_app.core_tools.update.title")
         val description = message("notification.function_app.core_tools.update.description")
 
-        val notification = notificationGroup.createNotification(
-                title = title,
-                subtitle = null,
-                content = description,
-                type = NotificationType.INFORMATION
-        )
+        val notification = NotificationGroupManager.getInstance()
+                .getNotificationGroup(notificationGroupName)
+                .createNotification(
+                        title = title,
+                        subtitle = null,
+                        content = description,
+                        type = NotificationType.INFORMATION
+                )
 
         notification.appendDownloadCoreToolsAction(
                 project = project,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsManager.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsManager.kt
@@ -125,7 +125,7 @@ object FunctionsCoreToolsManager {
             indicator.text = message("progress.function_app.core_tools.extracting")
             indicator.isIndeterminate = true
             try {
-                ZipUtil.extract(tempFile, latestDirectory, null)
+                ZipUtil.extract(tempFile.toPath(), latestDirectory.toPath(), null)
             } catch (e: Exception) {
                 logger.error("Error while extracting $tempFile.path to $latestDirectory.path", e)
             }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/org/jetbrains/plugins/azure/functions/run/HostJsonPatcherTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/org/jetbrains/plugins/azure/functions/run/HostJsonPatcherTest.kt
@@ -39,8 +39,8 @@ class HostJsonPatcherTest {
 
     companion object {
         private val hostJsonContent = StringBuilder()
-                .appendln("{")
-                .appendln("  \"version\": \"2.0\"")
+                .appendLine("{")
+                .appendLine("  \"version\": \"2.0\"")
                 .append("}")
                 .toString()
     }
@@ -97,11 +97,11 @@ class HostJsonPatcherTest {
 
         hostJsonFile.exists().shouldBeTrue()
         hostJsonFile.readText().shouldBe(StringBuilder()
-                .appendln("{")
-                .appendln("  \"version\": \"2.0\",")
-                .appendln("  \"functions\": [")
-                .appendln("    \"function\"")
-                .appendln("  ]")
+                .appendLine("{")
+                .appendLine("  \"version\": \"2.0\",")
+                .appendLine("  \"functions\": [")
+                .appendLine("    \"function\"")
+                .appendLine("  ]")
                 .append("}").toString())
     }
 
@@ -112,11 +112,11 @@ class HostJsonPatcherTest {
 
         HostJsonPatcher.tryPatchHostJsonFile(workingDirectory = workingDir.path, functionNames = "function")
         hostJsonFile.readText().shouldBe(StringBuilder()
-                .appendln("{")
-                .appendln("  \"version\": \"2.0\",")
-                .appendln("  \"functions\": [")
-                .appendln("    \"function\"")
-                .appendln("  ]")
+                .appendLine("{")
+                .appendLine("  \"version\": \"2.0\",")
+                .appendLine("  \"functions\": [")
+                .appendLine("    \"function\"")
+                .appendLine("  ]")
                 .append("}").toString())
     }
 
@@ -127,11 +127,11 @@ class HostJsonPatcherTest {
 
         HostJsonPatcher.tryPatchHostJsonFile(workingDirectory = workingDir.path, functionNames = "function")
         hostJsonFile.readText().shouldBe(StringBuilder()
-                .appendln("{")
-                .appendln("  \"version\": \"2.0\",")
-                .appendln("  \"functions\": [")
-                .appendln("    \"function\"")
-                .appendln("  ]")
+                .appendLine("{")
+                .appendLine("  \"version\": \"2.0\",")
+                .appendLine("  \"functions\": [")
+                .appendLine("    \"function\"")
+                .appendLine("  ]")
                 .append("}").toString())
     }
 
@@ -153,12 +153,12 @@ class HostJsonPatcherTest {
         HostJsonPatcher.tryPatchHostJsonFile(workingDirectory = workingDir, functionNames = "function1, function2")
 
         hostJsonFile.readText().shouldBe(StringBuilder()
-                .appendln("{")
-                .appendln("  \"version\": \"2.0\",")
-                .appendln("  \"functions\": [")
-                .appendln("    \"function1\",")
-                .appendln("    \"function2\"")
-                .appendln("  ]")
+                .appendLine("{")
+                .appendLine("  \"version\": \"2.0\",")
+                .appendLine("  \"functions\": [")
+                .appendLine("    \"function1\",")
+                .appendLine("    \"function2\"")
+                .appendLine("  ]")
                 .append("}").toString())
     }
 
@@ -178,11 +178,11 @@ class HostJsonPatcherTest {
 
         hostJsonFile.readText().shouldBe(hostJsonContent)
         hostJsonFileRoot.readText().shouldBe(StringBuilder()
-                .appendln("{")
-                .appendln("  \"version\": \"2.0\",")
-                .appendln("  \"functions\": [")
-                .appendln("    \"function\"")
-                .appendln("  ]")
+                .appendLine("{")
+                .appendLine("  \"version\": \"2.0\",")
+                .appendLine("  \"functions\": [")
+                .appendLine("    \"function\"")
+                .appendLine("  ]")
                 .append("}").toString())
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/forms/CreateBlobContainerForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/forms/CreateBlobContainerForm.java
@@ -70,6 +70,11 @@ public class CreateBlobContainerForm extends AzureDialogWrapper {
         init();
     }
 
+    @Override
+    public @Nullable JComponent getPreferredFocusedComponent() {
+        return nameTextField;
+    }
+
     @Nullable
     @Override
     protected ValidationInfo doValidate() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/forms/CreateQueueForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/forms/CreateQueueForm.java
@@ -28,9 +28,15 @@ import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.ValidationInfo;
+import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.intellij.helpers.LinkListener;
 import com.microsoft.intellij.ui.components.AzureDialogWrapper;
+import com.microsoft.intellij.ui.messages.AzureBundle;
+import com.microsoft.intellij.util.PluginUtil;
+import com.microsoft.tooling.msservices.components.DefaultLoader;
+import com.microsoft.tooling.msservices.helpers.azure.sdk.StorageClientSDKManager;
 import com.microsoft.tooling.msservices.model.storage.ClientStorageAccount;
+import com.microsoft.tooling.msservices.model.storage.Queue;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -39,14 +45,14 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
 public class CreateQueueForm extends AzureDialogWrapper {
-    private static final String NAME_REGEX = "^[a-z0-9](?!.*--)[a-z0-9-]+[a-z0-9]$";
-    private static final int NAME_MAX = 63;
-    private static final int NAME_MIN = 3;
-    private JPanel contentPane;
     private JLabel namingGuidelinesLink;
     private JTextField nameTextField;
     private Runnable onCreate;
     private ClientStorageAccount storageAccount;
+    private static final String NAME_REGEX = "^[a-z0-9](?!.*--)[a-z0-9-]+[a-z0-9]$";
+    private static final int NAME_MAX = 63;
+    private static final int NAME_MIN = 3;
+    private JPanel contentPane;
     private Project project;
 
     public CreateQueueForm(Project project) {
@@ -111,17 +117,13 @@ public class CreateQueueForm extends AzureDialogWrapper {
         ProgressManager.getInstance().run(new Task.Backgroundable(project, "Creating queue...", false) {
             @Override
             public void run(@NotNull ProgressIndicator progressIndicator) {
-                /*try {
+                try {
                     progressIndicator.setIndeterminate(true);
 
                     for (Queue queue : StorageClientSDKManager.getManager().getQueues(storageAccount)) {
                         if (queue.getName().equals(name)) {
-                            DefaultLoader.getIdeHelper().invokeLater(new Runnable() {
-                                @Override
-                                public void run() {
-                                    JOptionPane.showMessageDialog(null, "A queue with the specified name already exists.", "Azure Explorer", JOptionPane.ERROR_MESSAGE);
-                                }
-                            });
+                            DefaultLoader.getIdeHelper().invokeLater(
+                                    () -> JOptionPane.showMessageDialog(null, "A queue with the specified name already exists.", "Azure Explorer", JOptionPane.ERROR_MESSAGE));
 
                             return;
                         }
@@ -134,9 +136,9 @@ public class CreateQueueForm extends AzureDialogWrapper {
                         DefaultLoader.getIdeHelper().invokeLater(onCreate);
                     }
                 } catch (AzureCmdException e) {
-                    String msg = "An error occurred while attempting to create queue." + "\n" + String.format(message("webappExpMsg"), e.getMessage());
-                    PluginUtil.displayErrorDialogAndLog(message("errTtl"), msg, e);
-                }*/
+                    String msg = "An error occurred while attempting to create queue." + "\n" + String.format(AzureBundle.message("webappExpMsg"), e.getMessage());
+                    PluginUtil.displayErrorDialogAndLog(AzureBundle.message("errTtl"), msg, e);
+                }
             }
         });
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/forms/CreateQueueForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/forms/CreateQueueForm.java
@@ -59,7 +59,6 @@ public class CreateQueueForm extends AzureDialogWrapper {
         super(project, true);
 
         this.project = project;
-        setModal(true);
 
         setTitle("Create Queue");
         namingGuidelinesLink.addMouseListener(new LinkListener("https://go.microsoft.com/fwlink/?LinkId=255557"));
@@ -82,6 +81,11 @@ public class CreateQueueForm extends AzureDialogWrapper {
         });
 
         init();
+    }
+
+    @Override
+    public @Nullable JComponent getPreferredFocusedComponent() {
+        return nameTextField;
     }
 
     private void changedName() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/forms/QueueMessageForm.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/forms/QueueMessageForm.java
@@ -22,15 +22,21 @@
 
 package com.microsoft.intellij.forms;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.ValidationInfo;
+import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.intellij.ui.components.AzureDialogWrapper;
+import com.microsoft.intellij.ui.messages.AzureBundle;
+import com.microsoft.intellij.util.PluginUtil;
+import com.microsoft.tooling.msservices.helpers.azure.sdk.StorageClientSDKManager;
 import com.microsoft.tooling.msservices.model.storage.ClientStorageAccount;
 import com.microsoft.tooling.msservices.model.storage.Queue;
+import com.microsoft.tooling.msservices.model.storage.QueueMessage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -39,6 +45,7 @@ import javax.swing.text.AbstractDocument;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DocumentFilter;
+import java.util.GregorianCalendar;
 import java.util.regex.Pattern;
 
 import static java.util.regex.Pattern.compile;
@@ -57,6 +64,7 @@ public class QueueMessageForm extends AzureDialogWrapper {
         super(project, true);
         this.project = project;
         setModal(true);
+        setTitle("Create Queue Message");
 
         ((AbstractDocument) expireTimeTextField.getDocument()).setDocumentFilter(new DocumentFilter() {
             Pattern pat = compile("\\d+");
@@ -119,7 +127,7 @@ public class QueueMessageForm extends AzureDialogWrapper {
         ProgressManager.getInstance().run(new Task.Backgroundable(project, "Adding queue message", false) {
             @Override
             public void run(@NotNull ProgressIndicator progressIndicator) {
-                /*try {
+                try {
                     QueueMessage queueMessage = new QueueMessage(
                             "",
                             queue.getName(),
@@ -134,9 +142,10 @@ public class QueueMessageForm extends AzureDialogWrapper {
                         ApplicationManager.getApplication().invokeLater(onAddedMessage);
                     }
                 } catch (AzureCmdException e) {
-                    String msg = "An error occurred while attempting to add queue message." + "\n" + String.format(message("webappExpMsg"), e.getMessage());
-                    PluginUtil.displayErrorDialogAndLog(message("errTtl"), msg, e);
-                }*/
+                    String msg = "An error occurred while attempting to add queue message." + "\n"
+                            + String.format(AzureBundle.message("webappExpMsg"), e.getMessage());
+                    PluginUtil.displayErrorDialogAndLog(AzureBundle.message("errTtl"), msg, e);
+                }
             }
         });
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/UIHelperImpl.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/UIHelperImpl.java
@@ -102,7 +102,7 @@ import static com.microsoft.intellij.helpers.springcloud.SpringCloudAppPropertyV
 
 
 public class UIHelperImpl implements UIHelper {
-    public static Key<StorageAccount> STORAGE_KEY = new Key<StorageAccount>("storageAccount");
+    public static Key<StorageAccount> STORAGE_KEY = new Key<>("storageAccount");
     public static Key<ClientStorageAccount> CLIENT_STORAGE_KEY = new Key<ClientStorageAccount>("clientStorageAccount");
     public static final Key<String> SUBSCRIPTION_ID = new Key<>("subscriptionId");
     public static final Key<String> RESOURCE_ID = new Key<>("resourceId");
@@ -303,12 +303,12 @@ public class UIHelperImpl implements UIHelper {
     }
 
     @Override
-    public void refreshQueue(@NotNull final Object projectObject, @NotNull final StorageAccount storageAccount,
+    public void refreshQueue(@NotNull final Object projectObject, @NotNull final ClientStorageAccount storageAccount,
                              @NotNull final Queue queue) {
         ApplicationManager.getApplication().runReadAction(new Runnable() {
             @Override
             public void run() {
-                VirtualFile file = (VirtualFile) getOpenedFile(projectObject, storageAccount.name(), queue);
+                VirtualFile file = (VirtualFile) getOpenedFile(projectObject, storageAccount.getName(), queue);
                 if (file != null) {
                     final QueueFileEditor queueFileEditor = (QueueFileEditor) FileEditorManager.getInstance((Project) projectObject).getEditors(file)[0];
                     ApplicationManager.getApplication().invokeLater(new Runnable() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/storage/QueueExplorerFileEditorProvider.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/storage/QueueExplorerFileEditorProvider.java
@@ -33,6 +33,7 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.intellij.helpers.UIHelperImpl;
+import com.microsoft.tooling.msservices.model.storage.ClientStorageAccount;
 import com.microsoft.tooling.msservices.model.storage.Queue;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
@@ -42,7 +43,7 @@ public class QueueExplorerFileEditorProvider implements FileEditorProvider, Dumb
 
     @Override
     public boolean accept(@NotNull Project project, @NotNull VirtualFile virtualFile) {
-        StorageAccount storageAccount = virtualFile.getUserData(UIHelperImpl.STORAGE_KEY);
+        ClientStorageAccount storageAccount = virtualFile.getUserData(UIHelperImpl.CLIENT_STORAGE_KEY);
         Queue queue = virtualFile.getUserData(QUEUE_KEY);
 
         return (storageAccount != null && queue != null);
@@ -53,11 +54,11 @@ public class QueueExplorerFileEditorProvider implements FileEditorProvider, Dumb
     public FileEditor createEditor(@NotNull Project project, @NotNull VirtualFile virtualFile) {
         QueueFileEditor queueFileEditor = new QueueFileEditor(project);
 
-        StorageAccount storageAccount = virtualFile.getUserData(UIHelperImpl.STORAGE_KEY);
+        ClientStorageAccount storageAccount = virtualFile.getUserData(UIHelperImpl.CLIENT_STORAGE_KEY);
         Queue queue = virtualFile.getUserData(QUEUE_KEY);
 
         queueFileEditor.setQueue(queue);
-//        queueFileEditor.setStorageAccount(storageAccount);
+        queueFileEditor.setStorageAccount(storageAccount);
 
         queueFileEditor.fillGrid();
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/storage/CreateQueueAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/storage/CreateQueueAction.java
@@ -29,7 +29,6 @@ import com.microsoft.intellij.forms.CreateQueueForm;
 import com.microsoft.tooling.msservices.helpers.Name;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
-import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.ClientStorageNode;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.QueueModule;
 
 @Name("New Queue")
@@ -43,14 +42,11 @@ public class CreateQueueAction extends NodeActionListener {
     @Override
     public void actionPerformed(NodeActionEvent e) {
         CreateQueueForm form = new CreateQueueForm((Project) queueModule.getProject());
-//        form.setStorageAccount(queueModule.getStorageAccount());
+        form.setStorageAccount(queueModule.getStorageAccount());
 
-        form.setOnCreate(new Runnable() {
-            @Override
-            public void run() {
-                queueModule.getParent().removeAllChildNodes();
-                ((ClientStorageNode) queueModule.getParent()).load(false);
-            }
+        form.setOnCreate(() -> {
+            queueModule.removeAllChildNodes();
+            queueModule.load(false);
         });
 
         form.show();

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/helpers/UIHelper.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/helpers/UIHelper.java
@@ -86,7 +86,7 @@ public interface UIHelper {
 
     void openItem(@NotNull Object projectObject, @NotNull Object itemVirtualFile);
 
-    void refreshQueue(@NotNull Object projectObject, @NotNull StorageAccount storageAccount, @NotNull Queue queue);
+    void refreshQueue(@NotNull Object projectObject, @NotNull ClientStorageAccount storageAccount, @NotNull Queue queue);
 
     void refreshBlobs(@NotNull Object projectObject, @NotNull String accountName, @NotNull BlobContainer container);
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/helpers/azure/sdk/StorageClientSDKManager.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/helpers/azure/sdk/StorageClientSDKManager.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2018-2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -436,7 +437,7 @@ public class StorageClientSDKManager {
     }
 
     @NotNull
-    public List<Queue> getQueues(@NotNull StorageAccount storageAccount)
+    public List<Queue> getQueues(@NotNull ClientStorageAccount storageAccount)
             throws AzureCmdException {
         List<Queue> qList = new ArrayList<Queue>();
 
@@ -458,7 +459,7 @@ public class StorageClientSDKManager {
     }
 
     @NotNull
-    public Queue createQueue(@NotNull StorageAccount storageAccount,
+    public Queue createQueue(@NotNull ClientStorageAccount storageAccount,
                              @NotNull Queue queue)
             throws AzureCmdException {
         try {
@@ -480,7 +481,7 @@ public class StorageClientSDKManager {
         }
     }
 
-    public void deleteQueue(@NotNull StorageAccount storageAccount, @NotNull Queue queue)
+    public void deleteQueue(@NotNull ClientStorageAccount storageAccount, @NotNull Queue queue)
             throws AzureCmdException {
         try {
             CloudQueueClient client = getCloudQueueClient(storageAccount);
@@ -493,7 +494,7 @@ public class StorageClientSDKManager {
     }
 
     @NotNull
-    public List<QueueMessage> getQueueMessages(@NotNull StorageAccount storageAccount, @NotNull Queue queue)
+    public List<QueueMessage> getQueueMessages(@NotNull ClientStorageAccount storageAccount, @NotNull Queue queue)
             throws AzureCmdException {
         List<QueueMessage> qmList = new ArrayList<QueueMessage>();
 
@@ -530,7 +531,7 @@ public class StorageClientSDKManager {
         }
     }
 
-    public void clearQueue(@NotNull StorageAccount storageAccount, @NotNull Queue queue)
+    public void clearQueue(@NotNull ClientStorageAccount storageAccount, @NotNull Queue queue)
             throws AzureCmdException {
         try {
             CloudQueueClient client = getCloudQueueClient(storageAccount);
@@ -542,7 +543,7 @@ public class StorageClientSDKManager {
         }
     }
 
-    public void createQueueMessage(@NotNull StorageAccount storageAccount,
+    public void createQueueMessage(@NotNull ClientStorageAccount storageAccount,
                                    @NotNull QueueMessage queueMessage,
                                    int timeToLiveInSeconds)
             throws AzureCmdException {
@@ -557,7 +558,7 @@ public class StorageClientSDKManager {
     }
 
     @NotNull
-    public QueueMessage dequeueFirstQueueMessage(@NotNull StorageAccount storageAccount, @NotNull Queue queue)
+    public QueueMessage dequeueFirstQueueMessage(@NotNull ClientStorageAccount storageAccount, @NotNull Queue queue)
             throws AzureCmdException {
         try {
             CloudQueueClient client = getCloudQueueClient(storageAccount);
@@ -781,9 +782,9 @@ public class StorageClientSDKManager {
     }
 
     @NotNull
-    private static CloudQueueClient getCloudQueueClient(@NotNull StorageAccount storageAccount)
+    private static CloudQueueClient getCloudQueueClient(@NotNull ClientStorageAccount storageAccount)
             throws Exception {
-        CloudStorageAccount csa = getCloudStorageAccount(getConnectionString(storageAccount));
+        CloudStorageAccount csa = getCloudStorageAccount(storageAccount.getConnectionString());
 
         return csa.createCloudQueueClient();
     }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/ClientStorageNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/ClientStorageNode.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2018-2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -22,10 +23,8 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.storage;
 
-import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.tooling.msservices.model.storage.ClientStorageAccount;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.asm.ClientBlobModule;
 
@@ -52,10 +51,10 @@ public abstract class ClientStorageNode extends RefreshableNode {
 
         addChildNode(blobsNode);
 
-//        QueueModule queueNode = new QueueModule(this, storageAccount);
-//        queueNode.load();
-//
-//        addChildNode(queueNode);
+        QueueModule queueNode = new QueueModule(this, storageAccount);
+        queueNode.load(false);
+
+        addChildNode(queueNode);
 //
 //        TableModule tableNode = new TableModule(this, storageAccount);
 //        tableNode.load();

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/QueueModule.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/QueueModule.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2018-2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -22,9 +23,9 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.storage;
 
-import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.tooling.msservices.helpers.azure.sdk.StorageClientSDKManager;
+import com.microsoft.tooling.msservices.model.storage.ClientStorageAccount;
 import com.microsoft.tooling.msservices.model.storage.Queue;
 import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode;
 
@@ -32,10 +33,10 @@ import java.util.List;
 
 public class QueueModule extends RefreshableNode {
     private static final String QUEUES = "Queues";
-    final StorageAccount storageAccount;
+    final ClientStorageAccount storageAccount;
 
-    public QueueModule(ClientStorageNode parent, StorageAccount storageAccount) {
-        super(QUEUES + storageAccount.name(), QUEUES, parent, null);
+    public QueueModule(ClientStorageNode parent, ClientStorageAccount storageAccount) {
+        super(QUEUES + storageAccount.getName(), QUEUES, parent, null);
 
         this.storageAccount = storageAccount;
         this.parent = parent;
@@ -51,7 +52,7 @@ public class QueueModule extends RefreshableNode {
         }
     }
 
-    public StorageAccount getStorageAccount() {
+    public ClientStorageAccount getStorageAccount() {
         return storageAccount;
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/QueueNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/QueueNode.java
@@ -31,6 +31,7 @@ import com.microsoft.azuretools.telemetry.TelemetryProperties;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.tooling.msservices.helpers.azure.sdk.StorageClientSDKManager;
+import com.microsoft.tooling.msservices.model.storage.ClientStorageAccount;
 import com.microsoft.tooling.msservices.model.storage.Queue;
 import com.microsoft.tooling.msservices.serviceexplorer.*;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPromptListener;
@@ -47,8 +48,7 @@ public class QueueNode extends RefreshableNode implements TelemetryProperties{
     @Override
     public Map<String, String> toProperties() {
         final Map<String, String> properties = new HashMap<>();
-        properties.put(AppInsightsConstants.SubscriptionId, ResourceId.fromString(this.storageAccount.id()).subscriptionId());
-        properties.put(AppInsightsConstants.Region, this.storageAccount.regionName());
+        properties.put(AppInsightsConstants.SubscriptionId, ResourceId.fromString(this.storageAccount.getSubscriptionId()).subscriptionId());
         return properties;
     }
 
@@ -69,7 +69,7 @@ public class QueueNode extends RefreshableNode implements TelemetryProperties{
         @Override
         protected void azureNodeAction(NodeActionEvent e)
                 throws AzureCmdException {
-            Object openedFile = DefaultLoader.getUIHelper().getOpenedFile(getProject(), storageAccount.name(), queue);
+            Object openedFile = DefaultLoader.getUIHelper().getOpenedFile(getProject(), storageAccount.getName(), queue);
 
             if (openedFile != null) {
                 DefaultLoader.getIdeHelper().closeFile(getProject(), openedFile);
@@ -117,11 +117,11 @@ public class QueueNode extends RefreshableNode implements TelemetryProperties{
     }
 
     private static final String QUEUE_MODULE_ID = QueueNode.class.getName();
-    private static final String ICON_PATH = "container.svg";
+    private static final String ICON_PATH = "queue.svg";
     private final Queue queue;
-    private final StorageAccount storageAccount;
+    private final ClientStorageAccount storageAccount;
 
-    public QueueNode(QueueModule parent, StorageAccount storageAccount, Queue queue) {
+    public QueueNode(QueueModule parent, ClientStorageAccount storageAccount, Queue queue) {
         super(QUEUE_MODULE_ID, queue.getName(), parent, ICON_PATH, true);
 
         this.storageAccount = storageAccount;
@@ -132,10 +132,10 @@ public class QueueNode extends RefreshableNode implements TelemetryProperties{
 
     @Override
     protected void onNodeClick(NodeActionEvent ex) {
-        final Object openedFile = DefaultLoader.getUIHelper().getOpenedFile(getProject(), storageAccount.name(), queue);
+        final Object openedFile = DefaultLoader.getUIHelper().getOpenedFile(getProject(), storageAccount.getName(), queue);
 
         if (openedFile == null) {
-            DefaultLoader.getUIHelper().openItem(getProject(), storageAccount, queue, " [Queue]", "Queue", "container.svg");
+            DefaultLoader.getUIHelper().openItem(getProject(), storageAccount, queue, " [Queue]", "Queue", "queue.svg");
         } else {
             DefaultLoader.getUIHelper().openItem(getProject(), openedFile);
         }


### PR DESCRIPTION
Related to #96 

Good news! Let's bring queues from the storage emulator/Azurite into Rider!

![image](https://user-images.githubusercontent.com/485230/94939050-e6b17e80-04d1-11eb-973f-c3048e12e77e.png)

Currently supports:

* List/create/clear/delete queue
* Queue editor
  * Peek messages
  * Add message
  * Dequeue first message
  * Clear queue