### PR TITLE
Fix RIDER-48559. Structure actions for nodes in Azure Explorer

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs='-Duser.language=en'
 sources=false
 
 intellij_version=IC-203.3645-EAP-CANDIDATE-SNAPSHOT
-rider_version=RD-2020.3-SNAPSHOT
+rider_version=RD-2020.3-EAP2-SNAPSHOT
 build_common_code_with=rider
 
 rider_backend_build_configuration=Debug
@@ -25,6 +25,6 @@ retrofit_version=2.8.1
 assertj_version=3.15.0
 
 rd_version=0.203.154
-rider_nuget_sdk_version=2020.3.0-eap01
+rider_nuget_sdk_version=2020.3.0-eap02
 
 rider_test_local_env_run=true

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlDatabaseAddCurrentIpAddressToFirewallAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlDatabaseAddCurrentIpAddressToFirewallAction.kt
@@ -1,29 +1,30 @@
 /**
- * Copyright (c) 2018 JetBrains s.r.o.
- * <p/>
+ * Copyright (c) 2018-2020 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package com.microsoft.intellij.serviceexplorer.azure.database.actions
 
 import com.microsoft.tooling.msservices.helpers.Name
 import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqldatabase.SqlDatabaseNode
 
-@Name("Add firewall rule for my IP")
+@Name("Add Firewall Rule for my IP")
 class SqlDatabaseAddCurrentIpAddressToFirewallAction(private val sqlDatabaseNode: SqlDatabaseNode)
     : AddCurrentIpAddressToFirewallAction(sqlDatabaseNode)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlDatabaseConnectDataSourceAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlDatabaseConnectDataSourceAction.kt
@@ -1,24 +1,25 @@
 /**
- * Copyright (c) 2018 JetBrains s.r.o.
- * <p/>
+ * Copyright (c) 2018-2020 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package com.microsoft.intellij.serviceexplorer.azure.database.actions
 
 import com.intellij.database.autoconfig.DataSourceDetector
@@ -27,7 +28,7 @@ import com.microsoft.tooling.msservices.helpers.Name
 import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqldatabase.SqlDatabaseNode
 import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqlserver.SqlServerNode
 
-@Name("Connect to database")
+@Name("Connect to Database")
 class SqlDatabaseConnectDataSourceAction(private val databaseNode: SqlDatabaseNode)
     : ConnectDataSourceAction(databaseNode) {
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlDatabaseOpenInBrowserAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlDatabaseOpenInBrowserAction.kt
@@ -25,6 +25,6 @@ package com.microsoft.intellij.serviceexplorer.azure.database.actions
 import com.microsoft.tooling.msservices.helpers.Name
 import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqldatabase.SqlDatabaseNode
 
-@Name("Open in browser")
+@Name("Open in Browser")
 class SqlDatabaseOpenInBrowserAction(sqlDatabaseNode: SqlDatabaseNode)
     : OpenInBrowserAction(sqlDatabaseNode.subscriptionId, sqlDatabaseNode)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlServerAddCurrentIpAddressToFirewallAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlServerAddCurrentIpAddressToFirewallAction.kt
@@ -1,29 +1,30 @@
 /**
- * Copyright (c) 2018 JetBrains s.r.o.
- * <p/>
+ * Copyright (c) 2018-2020 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package com.microsoft.intellij.serviceexplorer.azure.database.actions
 
 import com.microsoft.tooling.msservices.helpers.Name
 import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqlserver.SqlServerNode
 
-@Name("Add firewall rule for my IP")
+@Name("Add Firewall Rule for my IP")
 class SqlServerAddCurrentIpAddressToFirewallAction(private val sqlServerNode: SqlServerNode)
     : AddCurrentIpAddressToFirewallAction(sqlServerNode)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlServerConnectDataSourceAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/serviceexplorer/azure/database/actions/SqlServerConnectDataSourceAction.kt
@@ -1,24 +1,25 @@
 /**
- * Copyright (c) 2018 JetBrains s.r.o.
- * <p/>
+ * Copyright (c) 2018-2020 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package com.microsoft.intellij.serviceexplorer.azure.database.actions
 
 import com.intellij.database.autoconfig.DataSourceDetector
@@ -26,7 +27,7 @@ import com.microsoft.azuretools.core.mvp.model.database.AzureSqlServerMvpModel
 import com.microsoft.tooling.msservices.helpers.Name
 import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqlserver.SqlServerNode
 
-@Name("Connect to server")
+@Name("Connect to Server")
 class SqlServerConnectDataSourceAction(private val databaseServerNode: SqlServerNode)
     : ConnectDataSourceAction(databaseServerNode) {
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/components/ServerExplorerToolWindowFactory.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/components/ServerExplorerToolWindowFactory.java
@@ -38,6 +38,7 @@ import com.intellij.openapi.wm.ex.ToolWindowEx;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.treeStructure.Tree;
+import com.intellij.util.ui.EmptyIcon;
 import com.intellij.util.ui.JBUI;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
 import com.microsoft.azuretools.ijidea.actions.AzureSignInAction;
@@ -209,9 +210,14 @@ public class ServerExplorerToolWindowFactory implements ToolWindowFactory, Prope
         for (final NodeAction nodeAction : node.getNodeActions()) {
             JMenuItem menuItem = new JMenuItem(nodeAction.getName());
             menuItem.setEnabled(nodeAction.isEnabled());
-            if (nodeAction.getIconPath() != null) {
-                menuItem.setIcon(UIHelperImpl.loadIcon(nodeAction.getIconPath()));
-            }
+
+            final String iconPath = nodeAction.getIconPath();
+            Icon icon = EmptyIcon.ICON_16;
+            if (iconPath != null && !iconPath.isEmpty())
+              icon = UIHelperImpl.loadIcon(nodeAction.getIconPath());
+
+            menuItem.setIcon(icon);
+
             // delegate the menu item click to the node action's listeners
             menuItem.addActionListener(e -> nodeAction.fireNodeActionEvent());
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/DefaultNodeActionsMap.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/DefaultNodeActionsMap.java
@@ -96,10 +96,10 @@ public class DefaultNodeActionsMap extends NodeActionsMap {
                                  .add(CreateNewDockerHostAction.class, PublishDockerContainerAction.class).build());
 
         final List<Class<? extends NodeActionListener>> deploymentNodeList = new ArrayList<>(Arrays.asList(
-                ExportTemplateAction.class,
-                ExportParameterAction.class,
+                EditDeploymentAction.class,
                 UpdateDeploymentAction.class,
-                EditDeploymentAction.class));
+                ExportTemplateAction.class,
+                ExportParameterAction.class));
 
         node2Actions.put(DeploymentNode.class,
                 new ImmutableList.Builder<Class<? extends NodeActionListener>>()

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/arm/CreateDeploymentAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/arm/CreateDeploymentAction.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -27,6 +28,7 @@ import com.intellij.openapi.ui.MessageType;
 import com.intellij.openapi.wm.StatusBar;
 import com.intellij.openapi.wm.WindowManager;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.ijidea.actions.AzureSignInAction;
 import com.microsoft.intellij.AzurePlugin;
 import com.microsoft.intellij.forms.arm.CreateDeploymentForm;
@@ -39,7 +41,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.arm.ResourceManagementModule;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.arm.ResourceManagementNode;
 
-@Name("Create Deployment")
+@Name("New Deployment")
 public class CreateDeploymentAction extends NodeActionListener {
     public static final String ERROR_CREATING_DEPLOYMENT = "Error creating Deployment";
     private final Project project;
@@ -77,5 +79,10 @@ public class CreateDeploymentAction extends NodeActionListener {
             UIUtils.showNotification(statusBar, NOTIFY_CREATE_DEPLOYMENT_FAIL + ", " + ex.getMessage(),
                                      MessageType.ERROR);
         }
+    }
+
+    @Override
+    protected @Nullable String getIconPath() {
+        return "AddEntity.svg";
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/docker/CreateNewDockerHostAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/docker/CreateNewDockerHostAction.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -27,6 +28,7 @@ import com.intellij.openapi.project.Project;
 import com.microsoft.azure.docker.AzureDockerHostsManager;
 import com.microsoft.azure.docker.model.DockerHost;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.ijidea.actions.AzureSignInAction;
 import com.microsoft.azuretools.sdkmanage.AzureManager;
 import com.microsoft.intellij.docker.utils.AzureDockerUIResources;
@@ -95,5 +97,10 @@ public class CreateNewDockerHostAction extends NodeActionListener {
         } catch (Exception ex1) {
             ex1.printStackTrace();
         }
+    }
+
+    @Override
+    protected @Nullable String getIconPath() {
+        return "AddEntity.svg";
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/rediscache/CreateRedisCacheAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/rediscache/CreateRedisCacheAction.java
@@ -25,6 +25,7 @@ package com.microsoft.intellij.serviceexplorer.azure.rediscache;
 
 import com.intellij.openapi.project.Project;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.ijidea.actions.AzureSignInAction;
 import com.microsoft.intellij.AzurePlugin;
 import com.microsoft.intellij.forms.CreateRedisCacheForm;
@@ -35,7 +36,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.rediscache.RedisCacheModule;
 
-@Name("Create Redis Cache")
+@Name("New Redis Cache")
 public class CreateRedisCacheAction extends NodeActionListener {
     private static final String ERROR_CREATING_REDIS_CACHE = "Error creating Redis cache";
     private RedisCacheModule redisCacheModule;
@@ -68,5 +69,10 @@ public class CreateRedisCacheAction extends NodeActionListener {
             AzurePlugin.log(ERROR_CREATING_REDIS_CACHE, ex);
             throw new RuntimeException("Error creating Redis Cache", ex);
         }
+    }
+
+    @Override
+    protected @Nullable String getIconPath() {
+        return "AddEntity.svg";
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/storage/AttachExternalStorageAccountAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/storage/AttachExternalStorageAccountAction.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -35,7 +36,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.StorageMod
 
 import javax.swing.*;
 
-@Name("Attach external storage account...")
+@Name("Attach External Storage Account...")
 public class AttachExternalStorageAccountAction extends NodeActionListener {
     private final StorageModule storageModule;
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/storage/CreateBlobContainer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/storage/CreateBlobContainer.java
@@ -1,18 +1,19 @@
-/**
+/*
  * Copyright (c) Microsoft Corporation
- * <p/>
+ * Copyright (c) 2020 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
@@ -23,6 +24,7 @@ package com.microsoft.intellij.serviceexplorer.azure.storage;
 
 import com.intellij.openapi.project.Project;
 import com.microsoft.azuretools.authmanage.models.SubscriptionDetail;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.intellij.forms.CreateBlobContainerForm;
 import com.microsoft.tooling.msservices.helpers.Name;
 import com.microsoft.tooling.msservices.helpers.azure.sdk.StorageClientSDKManager;
@@ -33,7 +35,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.BlobModule
 import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.StorageNode;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.asm.ClientBlobModule;
 
-@Name("Create blob container")
+@Name("New Blob container")
 public class CreateBlobContainer extends NodeActionListener {
     private RefreshableNode parent;
 
@@ -70,6 +72,10 @@ public class CreateBlobContainer extends NodeActionListener {
         });
 
         form.show();
+    }
 
+    @Override
+    protected @Nullable String getIconPath() {
+        return "AddEntity.svg";
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/storage/CreateQueueAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/storage/CreateQueueAction.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -23,6 +24,7 @@
 package com.microsoft.intellij.serviceexplorer.azure.storage;
 
 import com.intellij.openapi.project.Project;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.intellij.forms.CreateQueueForm;
 import com.microsoft.tooling.msservices.helpers.Name;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
@@ -30,7 +32,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.ClientStorageNode;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.QueueModule;
 
-@Name("Create new queue")
+@Name("New Queue")
 public class CreateQueueAction extends NodeActionListener {
     private QueueModule queueModule;
 
@@ -52,5 +54,10 @@ public class CreateQueueAction extends NodeActionListener {
         });
 
         form.show();
+    }
+
+    @Override
+    protected @Nullable String getIconPath() {
+        return "AddEntity.svg";
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/storage/CreateTableAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/storage/CreateTableAction.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -23,6 +24,7 @@
 package com.microsoft.intellij.serviceexplorer.azure.storage;
 
 import com.intellij.openapi.project.Project;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.intellij.forms.CreateTableForm;
 import com.microsoft.tooling.msservices.helpers.Name;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
@@ -30,7 +32,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.ClientStorageNode;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.TableModule;
 
-@Name("Create new table")
+@Name("New Table")
 public class CreateTableAction extends NodeActionListener {
     private TableModule tableModule;
 
@@ -53,5 +55,10 @@ public class CreateTableAction extends NodeActionListener {
         });
 
         form.show();
+    }
+
+    @Override
+    protected @Nullable String getIconPath() {
+        return "AddEntity.svg";
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/storagearm/CreateStorageAccountAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/storagearm/CreateStorageAccountAction.java
@@ -25,6 +25,7 @@ package com.microsoft.intellij.serviceexplorer.azure.storagearm;
 
 import com.intellij.openapi.project.Project;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.ijidea.actions.AzureSignInAction;
 import com.microsoft.intellij.AzurePlugin;
 import com.microsoft.intellij.forms.CreateArmStorageAccountForm;
@@ -35,7 +36,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.storage.StorageModule;
 
-@Name("Create Storage Account...")
+@Name("New Storage Account...")
 public class CreateStorageAccountAction extends NodeActionListener {
 
     public static final String ERROR_CREATING_STORAGE_ACCOUNT = "Error creating storage account";
@@ -69,5 +70,10 @@ public class CreateStorageAccountAction extends NodeActionListener {
             AzurePlugin.log(ERROR_CREATING_STORAGE_ACCOUNT, ex);
             throw new RuntimeException("Error creating storage account", ex);
         }
+    }
+
+    @Override
+    protected @Nullable String getIconPath() {
+        return "AddEntity.svg";
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/vmarm/CreateVMAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/serviceexplorer/azure/vmarm/CreateVMAction.java
@@ -25,6 +25,7 @@ package com.microsoft.intellij.serviceexplorer.azure.vmarm;
 
 import com.intellij.openapi.project.Project;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
+import com.microsoft.azuretools.azurecommons.helpers.Nullable;
 import com.microsoft.azuretools.ijidea.actions.AzureSignInAction;
 import com.microsoft.intellij.AzurePlugin;
 import com.microsoft.intellij.util.AzureLoginHelper;
@@ -35,7 +36,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.vmarm.VMArmModule;
 
-@Name("Create VM")
+@Name("New VM...")
 public class CreateVMAction extends NodeActionListener {
     private static final String ERROR_CREATING_VIRTUAL_MACHINE = "Error creating virtual machine";
     private VMArmModule vmModule;
@@ -60,5 +61,10 @@ public class CreateVMAction extends NodeActionListener {
             AzurePlugin.log(ERROR_CREATING_VIRTUAL_MACHINE, ex);
             throw new RuntimeException("Error creating virtual machine", ex);
         }
+    }
+
+    @Override
+    protected @Nullable String getIconPath() {
+        return "AddEntity.svg";
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/NodeActionListener.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/NodeActionListener.java
@@ -98,9 +98,7 @@ public abstract class NodeActionListener implements EventListener {
     }
 
     @Nullable
-    protected String getIconPath() {
-        return iconPath;
-    }
+    protected String getIconPath() { return iconPath; }
 
     /**
      * If nodeName contains spark and hdinsight, we just think it is a spark node.

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/NodeActionPosition.kt
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/NodeActionPosition.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2020 JetBrains s.r.o.
+ * Copyright (c) 2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -20,11 +20,10 @@
  * SOFTWARE.
  */
 
-package com.microsoft.intellij.serviceexplorer.azure.database.actions
+package com.microsoft.tooling.msservices.serviceexplorer
 
-import com.microsoft.tooling.msservices.helpers.Name
-import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqlserver.SqlServerNode
-
-@Name("Open in Browser")
-class SqlServerOpenInBrowserAction(private val sqlServerNode: SqlServerNode)
-    : OpenInBrowserAction(sqlServerNode.subscriptionId, sqlServerNode)
+enum class NodeActionPosition {
+    TOP,
+    NONE,
+    BOTTOM
+}

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/RefreshableNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/RefreshableNode.java
@@ -57,7 +57,7 @@ public abstract class RefreshableNode extends Node {
             public void actionPerformed(NodeActionEvent e) {
                 load(true);
             }
-        });
+        }, NodeActionPosition.TOP);
 
         super.loadActions();
     }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/arm/ResourceManagementNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/arm/ResourceManagementNode.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
- * Copyright (c) 2019 JetBrains s.r.o.
+ * Copyright (c) 2019-2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -23,6 +23,7 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.arm;
 
+import com.microsoft.azure.CommonIcons;
 import com.microsoft.azure.management.resources.Deployment;
 import com.microsoft.azure.management.resources.ResourceGroup;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
@@ -32,6 +33,7 @@ import com.microsoft.azuretools.telemetrywrapper.EventUtil;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionPosition;
 import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPromptListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.arm.deployments.DeploymentNode;
@@ -50,8 +52,6 @@ public class ResourceManagementNode extends RefreshableNode implements ResourceM
     private final String sid;
     private final String rgName;
     private final Object listenerObj = new Object();
-
-    private static final String ICON_ACTION_DELETE = "Discard.svg";
 
     public ResourceManagementNode(ResourceManagementModule parent, String subscriptionId, ResourceGroup resourceGroup) {
         super(resourceGroup.id(), resourceGroup.name(), parent, ICON_RESOURCE_MANAGEMENT, true);
@@ -73,7 +73,7 @@ public class ResourceManagementNode extends RefreshableNode implements ResourceM
 
     @Override
     protected void loadActions() {
-        addAction(ACTION_DELETE, ICON_ACTION_DELETE, new DeleteResourceGroupAction());
+        addAction(ACTION_DELETE, CommonIcons.ACTION_DISCARD, new DeleteResourceGroupAction(), NodeActionPosition.BOTTOM);
         super.loadActions();
     }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/arm/deployments/DeploymentNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/arm/deployments/DeploymentNode.java
@@ -32,6 +32,7 @@ import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionPosition;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPromptListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.arm.ResourceManagementNode;
 
@@ -73,7 +74,7 @@ public class DeploymentNode extends Node implements DeploymentNodeView {
     @Override
     protected void loadActions() {
         addAction(SHOW_PROPERTY_ACTION, CommonIcons.ACTION_OPEN_PREFERENCES, new ShowDeploymentPropertyAction());
-        addAction(DELETE_ACTION, CommonIcons.ACTION_DISCARD, new DeleteDeploymentAction());
+        addAction(DELETE_ACTION, CommonIcons.ACTION_DISCARD, new DeleteDeploymentAction(), NodeActionPosition.BOTTOM);
         super.loadActions();
     }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/database/sqldatabase/SqlDatabaseNode.kt
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/database/sqldatabase/SqlDatabaseNode.kt
@@ -22,10 +22,12 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqldatabase
 
+import com.microsoft.azure.CommonIcons
 import com.microsoft.azuretools.core.mvp.model.database.AzureSqlDatabaseMvpModel
 import com.microsoft.tooling.msservices.components.DefaultLoader
 import com.microsoft.tooling.msservices.serviceexplorer.Node
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionPosition
 import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode
 import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPromptListener
 import com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqlserver.SqlServerNode
@@ -42,7 +44,6 @@ class SqlDatabaseNode(parent: SqlServerNode,
         private const val ACTION_DELETE = "Delete"
         private const val SQL_DATABASE_ICON = "Database.svg"
         private const val DELETE_SQL_DATABASE_PROGRESS_MESSAGE = "Deleting SQL Database '%s'..."
-        private const val ICON_ACTION_DELETE = "Discard.svg"
 
         private val deleteSqlDatabasePromptMessage = StringBuilder()
                 .appendln("This operation will delete SQL Database %s.")
@@ -55,7 +56,7 @@ class SqlDatabaseNode(parent: SqlServerNode,
     }
 
     override fun loadActions() {
-        addAction(ACTION_DELETE, ICON_ACTION_DELETE, DeleteSqlDatabaseAction())
+        addAction(ACTION_DELETE, CommonIcons.ACTION_DISCARD, DeleteSqlDatabaseAction(), NodeActionPosition.BOTTOM)
         super.loadActions()
     }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/database/sqlserver/SqlServerNode.kt
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/database/sqlserver/SqlServerNode.kt
@@ -22,11 +22,13 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.database.sqlserver
 
+import com.microsoft.azure.CommonIcons
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException
 import com.microsoft.azuretools.core.mvp.model.database.AzureSqlDatabaseMvpModel
 import com.microsoft.azuretools.core.mvp.model.database.AzureSqlServerMvpModel
 import com.microsoft.tooling.msservices.components.DefaultLoader
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionPosition
 import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode
 import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPromptListener
 import com.microsoft.tooling.msservices.serviceexplorer.azure.database.AzureDatabaseModule
@@ -46,8 +48,6 @@ class SqlServerNode(parent: AzureDatabaseModule,
         private const val ACTION_DELETE = "Delete"
         private const val PROGRESS_MESSAGE_DELETE_SQL_SERVER = "Deleting SQL Server '%s'..."
 
-        private const val ICON_ACTION_DELETE = "Discard.svg"
-
         private val deleteSqlDatabasePromptMessage = StringBuilder()
                 .appendln("This operation will delete SQL Server '%s'.")
                 .append("Are you sure you want to continue?")
@@ -65,7 +65,7 @@ class SqlServerNode(parent: AzureDatabaseModule,
     }
 
     override fun loadActions() {
-        addAction(ACTION_DELETE, ICON_ACTION_DELETE, DeleteSqlServerAction())
+        addAction(ACTION_DELETE, CommonIcons.ACTION_DISCARD, DeleteSqlServerAction(), NodeActionPosition.BOTTOM)
         super.loadActions()
     }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/docker/DockerContainerNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/docker/DockerContainerNode.java
@@ -212,7 +212,7 @@ public class DockerContainerNode extends AzureRefreshableNode implements Telemet
         });
       }
     }));
-    addAction(ACTION_DELETE, CommonIcons.ACTION_DISCARD, new DeleteDockerContainerAction());
+    addAction(ACTION_DELETE, CommonIcons.ACTION_DISCARD, new DeleteDockerContainerAction(), NodeActionPosition.BOTTOM);
     super.loadActions();
   }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/docker/DockerImageNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/docker/DockerImageNode.java
@@ -26,6 +26,7 @@ package com.microsoft.tooling.msservices.serviceexplorer.azure.docker;
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.DELETE_DOCKER_IMAGE;
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.DOCKER;
 
+import com.microsoft.azure.CommonIcons;
 import com.microsoft.azure.docker.AzureDockerHostsManager;
 import com.microsoft.azure.docker.model.DockerContainer;
 import com.microsoft.azure.docker.model.DockerHost;
@@ -39,6 +40,7 @@ import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.serviceexplorer.AzureRefreshableNode;
 import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionPosition;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPromptListener;
 
 import java.util.HashMap;
@@ -103,7 +105,7 @@ public class DockerImageNode extends AzureRefreshableNode implements TelemetryPr
 
   @Override
   protected void loadActions() {
-    addAction(ACTION_DELETE, new DeleteDockerImageAction());
+    addAction(ACTION_DELETE, CommonIcons.ACTION_DISCARD, new DeleteDockerImageAction(), NodeActionPosition.BOTTOM);
     super.loadActions();
   }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/FunctionNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/FunctionNode.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -114,29 +115,48 @@ public class FunctionNode extends WebAppBaseNode implements FunctionNodeView {
     }
 
     @Override
-    protected void loadActions() {
-        addAction(ACTION_STOP, new WrappedTelemetryNodeActionListener(FUNCTION, STOP_FUNCTION_APP,
-                createBackgroundActionListener("Stopping", () -> stopFunctionApp())));
-        addAction(ACTION_START, new WrappedTelemetryNodeActionListener(FUNCTION, START_FUNCTION_APP,
-                createBackgroundActionListener("Starting", () -> startFunctionApp())));
-        addAction(ACTION_RESTART, new WrappedTelemetryNodeActionListener(FUNCTION, RESTART_FUNCTION_APP,
-                createBackgroundActionListener("Restarting", () -> restartFunctionApp())));
-        addAction(ACTION_DELETE, new DeleteFunctionAppAction());
-        addAction("Open in portal", new WrappedTelemetryNodeActionListener(FUNCTION, OPEN_INBROWSER_FUNCTION_APP,
-                new NodeActionListener() {
-                    @Override
-                    protected void actionPerformed(NodeActionEvent e) throws AzureCmdException {
-                        openResourcesInPortal(subscriptionId, functionAppId);
-                    }
-                }));
-        addAction(ACTION_SHOW_PROPERTY, new WrappedTelemetryNodeActionListener(FUNCTION, SHOWPROP_FUNCTION_APP,
+    protected NodeActionListener getStartActionListener() {
+        return new WrappedTelemetryNodeActionListener(FUNCTION, START_FUNCTION_APP,
+                createBackgroundActionListener("Starting", this::startFunctionApp));
+    }
+
+    @Override
+    protected NodeActionListener getRestartActionListener() {
+        return new WrappedTelemetryNodeActionListener(FUNCTION, RESTART_FUNCTION_APP,
+                createBackgroundActionListener("Restarting", this::restartFunctionApp));
+    }
+
+    @Override
+    protected NodeActionListener getStopActionListener() {
+        return new WrappedTelemetryNodeActionListener(FUNCTION, STOP_FUNCTION_APP,
+                createBackgroundActionListener("Stopping", this::stopFunctionApp));
+    }
+
+    @Override
+    protected NodeActionListener getShowPropertiesActionListener() {
+        return new WrappedTelemetryNodeActionListener(FUNCTION, SHOWPROP_FUNCTION_APP,
                 new NodeActionListener() {
                     @Override
                     protected void actionPerformed(NodeActionEvent e) {
                         DefaultLoader.getUIHelper().openFunctionAppPropertyView(FunctionNode.this);
                     }
-                }));
-        super.loadActions();
+                });
+    }
+
+    @Override
+    protected NodeActionListener getOpenInBrowserActionListener() {
+        return new WrappedTelemetryNodeActionListener(FUNCTION, OPEN_INBROWSER_FUNCTION_APP,
+                new NodeActionListener() {
+                    @Override
+                    protected void actionPerformed(NodeActionEvent e) throws AzureCmdException {
+                        openResourcesInPortal(subscriptionId, functionAppId);
+                    }
+                });
+    }
+
+    @Override
+    protected NodeActionListener getDeleteActionListener() {
+        return new DeleteFunctionAppAction();
     }
 
     @Override

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/rediscache/RedisCacheNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/rediscache/RedisCacheNode.java
@@ -30,6 +30,7 @@ import static com.microsoft.azuretools.telemetry.TelemetryConstants.REDIS_OPEN_E
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.REDIS_READPROP;
 
 import com.microsoft.azure.CommonIcons;
+import com.microsoft.tooling.msservices.serviceexplorer.NodeActionPosition;
 import com.microsoft.tooling.msservices.serviceexplorer.WrappedTelemetryNodeActionListener;
 import java.util.HashMap;
 import java.util.Map;
@@ -155,11 +156,9 @@ public class RedisCacheNode extends Node implements TelemetryProperties {
     @Override
     protected void loadActions() {
         if (!CREATING_STATE.equals(this.provisionState)) {
-            addAction(DELETE_ACTION, CommonIcons.ACTION_DISCARD, new DeleteRedisCacheAction());
-            addAction(SHOW_PROPERTY_ACTION, CommonIcons.ACTION_OPEN_PREFERENCES, new WrappedTelemetryNodeActionListener(REDIS, REDIS_READPROP,
-                new ShowRedisCachePropertyAction()));
-            addAction(OPEN_EXPLORER, null, new WrappedTelemetryNodeActionListener(REDIS, REDIS_OPEN_EXPLORER,
-                new OpenRedisExplorerAction()));
+            addAction(DELETE_ACTION, CommonIcons.ACTION_DISCARD, new DeleteRedisCacheAction(), NodeActionPosition.BOTTOM);
+            addAction(SHOW_PROPERTY_ACTION, CommonIcons.ACTION_OPEN_PREFERENCES, new WrappedTelemetryNodeActionListener(REDIS, REDIS_READPROP, new ShowRedisCachePropertyAction()));
+            addAction(OPEN_EXPLORER, null, new WrappedTelemetryNodeActionListener(REDIS, REDIS_OPEN_EXPLORER, new OpenRedisExplorerAction()));
         }
         addAction(OPEN_IN_BROWSER_ACTION, CommonIcons.ACTION_OPEN_IN_BROWSER, new WrappedTelemetryNodeActionListener(REDIS, REDIS_OPEN_BROWSER,
             new OpenInBrowserAction()));

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/springcloud/SpringCloudAppNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/springcloud/SpringCloudAppNode.java
@@ -22,6 +22,7 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.springcloud;
 
+import com.microsoft.azure.CommonIcons;
 import com.microsoft.azure.management.appplatform.v2019_05_01_preview.DeploymentResourceStatus;
 import com.microsoft.azure.management.appplatform.v2019_05_01_preview.implementation.AppResourceInner;
 import com.microsoft.azure.management.appplatform.v2019_05_01_preview.implementation.DeploymentResourceInner;
@@ -129,7 +130,7 @@ public class SpringCloudAppNode extends Node implements SpringCloudAppNodeView {
         addAction(ACTION_RESTART, new WrappedTelemetryNodeActionListener(SPRING_CLOUD, RESTART_SPRING_CLOUD_APP,
                                                                          createBackgroundActionListener("Restarting", () -> restartSpringCloudApp())));
 
-        addAction(ACTION_DELETE, new DeleteSpringCloudAppAction());
+        addAction(ACTION_DELETE, CommonIcons.ACTION_DISCARD, new DeleteSpringCloudAppAction(), NodeActionPosition.BOTTOM);
 
         addAction(ACTION_OPEN_IN_PORTAL, new WrappedTelemetryNodeActionListener(SPRING_CLOUD, OPEN_IN_PORTAL_SPRING_CLOUD_APP,
             new NodeActionListener() {

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/QueueNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/QueueNode.java
@@ -23,7 +23,7 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.storage;
 
-import com.google.common.collect.ImmutableMap;
+import com.microsoft.azure.CommonIcons;
 import com.microsoft.azure.management.resources.fluentcore.arm.ResourceId;
 import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.azuretools.telemetry.AppInsightsConstants;
@@ -32,28 +32,24 @@ import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
 import com.microsoft.tooling.msservices.helpers.azure.sdk.StorageClientSDKManager;
 import com.microsoft.tooling.msservices.model.storage.Queue;
-import com.microsoft.tooling.msservices.serviceexplorer.Node;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
+import com.microsoft.tooling.msservices.serviceexplorer.*;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPromptListener;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class QueueNode extends Node implements TelemetryProperties{
+public class QueueNode extends RefreshableNode implements TelemetryProperties{
+
+    private static final String ACTION_DELETE = "Delete";
+    private static final String ACTION_VIEW_QUEUE = "View Queue";
+    private static final String ACTION_CLEAR_QUEUE = "Clear Queue";
+
     @Override
     public Map<String, String> toProperties() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(AppInsightsConstants.SubscriptionId, ResourceId.fromString(this.storageAccount.id()).subscriptionId());
         properties.put(AppInsightsConstants.Region, this.storageAccount.regionName());
         return properties;
-    }
-
-    public class RefreshAction extends NodeActionListener {
-        @Override
-        public void actionPerformed(NodeActionEvent e) {
-            DefaultLoader.getUIHelper().refreshQueue(getProject(), storageAccount, queue);
-        }
     }
 
     public class ViewQueue extends NodeActionListener {
@@ -146,12 +142,15 @@ public class QueueNode extends Node implements TelemetryProperties{
     }
 
     @Override
-    protected Map<String, Class<? extends NodeActionListener>> initActions() {
-        return ImmutableMap.of(
-                "Refresh", RefreshAction.class,
-                "View Queue", ViewQueue.class,
-                "Delete", DeleteQueue.class,
-                "Clear Queue", ClearQueue.class
-        );
+    protected void refreshItems() throws AzureCmdException {
+        DefaultLoader.getUIHelper().refreshQueue(getProject(), storageAccount, queue);
+    }
+
+    @Override
+    protected void loadActions() {
+        addAction(ACTION_VIEW_QUEUE, new ViewQueue());
+        addAction(ACTION_CLEAR_QUEUE, new ClearQueue());
+        addAction(ACTION_DELETE, CommonIcons.ACTION_DISCARD, new DeleteQueue(), NodeActionPosition.BOTTOM);
+        super.loadActions();
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/StorageNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/StorageNode.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.tooling.msservices.serviceexplorer.azure.storage;
 
+import com.microsoft.azure.CommonIcons;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.azuretools.authmanage.AuthMethodManager;
@@ -33,10 +34,7 @@ import com.microsoft.azuretools.telemetry.TelemetryProperties;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.helpers.azure.sdk.StorageClientSDKManager;
 import com.microsoft.tooling.msservices.model.storage.BlobContainer;
-import com.microsoft.tooling.msservices.serviceexplorer.Node;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
-import com.microsoft.tooling.msservices.serviceexplorer.RefreshableNode;
+import com.microsoft.tooling.msservices.serviceexplorer.*;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPromptListener;
 
@@ -49,6 +47,10 @@ import static com.microsoft.azuretools.telemetry.TelemetryConstants.OPEN_STORAGE
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.STORAGE;
 
 public class StorageNode extends RefreshableNode implements TelemetryProperties {
+
+    private static final String ACTION_DELETE = "Delete";
+    private static final String ACTION_OPEN_IN_PORTAL = "Open in Portal";
+
     private static final String STORAGE_ACCOUNT_ICON_PATH = "StorageAccount.svg";
 
     private final StorageAccount storageAccount;
@@ -154,8 +156,8 @@ public class StorageNode extends RefreshableNode implements TelemetryProperties 
 
     @Override
     protected Map<String, Class<? extends NodeActionListener>> initActions() {
-        addAction("Open in Portal", new OpenInPortalAction());
-        addAction("Delete", new DeleteStorageAccountAction());
+        addAction(ACTION_OPEN_IN_PORTAL, CommonIcons.ACTION_OPEN_IN_BROWSER, new OpenInPortalAction());
+        addAction(ACTION_DELETE, CommonIcons.ACTION_DISCARD, new DeleteStorageAccountAction(), NodeActionPosition.BOTTOM);
         return super.initActions();
     }
 

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/TableNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/storage/TableNode.java
@@ -26,7 +26,7 @@ package com.microsoft.tooling.msservices.serviceexplorer.azure.storage;
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.DELETE_STORAGE_TABLE;
 import static com.microsoft.azuretools.telemetry.TelemetryConstants.STORAGE;
 
-import com.google.common.collect.ImmutableMap;
+import com.microsoft.azure.CommonIcons;
 import com.microsoft.azure.management.resources.fluentcore.arm.ResourceId;
 import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.azuretools.azurecommons.helpers.AzureCmdException;
@@ -35,28 +35,23 @@ import com.microsoft.azuretools.telemetry.TelemetryProperties;
 import com.microsoft.tooling.msservices.components.DefaultLoader;
 import com.microsoft.tooling.msservices.helpers.azure.sdk.StorageClientSDKManager;
 import com.microsoft.tooling.msservices.model.storage.Table;
-import com.microsoft.tooling.msservices.serviceexplorer.Node;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
-import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
+import com.microsoft.tooling.msservices.serviceexplorer.*;
 import com.microsoft.tooling.msservices.serviceexplorer.azure.AzureNodeActionPromptListener;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class TableNode extends Node implements TelemetryProperties {
+public class TableNode extends RefreshableNode implements TelemetryProperties {
+
+    private static final String ACTION_DELETE = "Delete";
+    private static final String ACTION_VIEW_TABLE = "View Table";
+
     @Override
     public Map<String, String> toProperties() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(AppInsightsConstants.SubscriptionId, ResourceId.fromString(this.storageAccount.id()).subscriptionId());
         properties.put(AppInsightsConstants.Region, this.storageAccount.regionName());
         return properties;
-    }
-
-    public class RefreshAction extends NodeActionListener {
-        @Override
-        public void actionPerformed(NodeActionEvent e) {
-            DefaultLoader.getUIHelper().refreshTable(getProject(), storageAccount, table);
-        }
     }
 
     public class ViewTable extends NodeActionListener {
@@ -138,11 +133,14 @@ public class TableNode extends Node implements TelemetryProperties {
     }
 
     @Override
-    protected Map<String, Class<? extends NodeActionListener>> initActions() {
-        return ImmutableMap.of(
-                "Refresh", RefreshAction.class,
-                "View Table", ViewTable.class,
-                "Delete", DeleteTable.class
-        );
+    protected void refreshItems() throws AzureCmdException {
+        DefaultLoader.getUIHelper().refreshTable(getProject(), storageAccount, table);
+    }
+
+    @Override
+    protected void loadActions() {
+        addAction(ACTION_VIEW_TABLE, new ViewTable());
+        addAction(ACTION_DELETE, CommonIcons.ACTION_DISCARD, new DeleteTable(), NodeActionPosition.BOTTOM);
+        super.loadActions();
     }
 }

--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/webapp/deploymentslot/DeploymentSlotNode.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2020 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -82,33 +83,55 @@ public class DeploymentSlotNode extends WebAppBaseNode implements DeploymentSlot
     }
 
     @Override
-    protected void loadActions() {
-        // todo: why only the stop action has icon?
-        addAction(ACTION_STOP, getIcon(this.os, this.label, WebAppBaseState.STOPPED),
-            new WrappedTelemetryNodeActionListener(WEBAPP, STOP_WEBAPP_SLOT,
-                createBackgroundActionListener("Stopping Deployment Slot", () -> stop())));
-        addAction(ACTION_START, new WrappedTelemetryNodeActionListener(WEBAPP, START_WEBAPP_SLOT,
-            createBackgroundActionListener("Starting Deployment Slot", () -> start())));
-        addAction(ACTION_RESTART, new WrappedTelemetryNodeActionListener(WEBAPP, RESTART_WEBAPP_SLOT,
-            createBackgroundActionListener("Restarting Deployment Slot", () -> restart())));
-        addAction(ACTION_SWAP_WITH_PRODUCTION, new WrappedTelemetryNodeActionListener(WEBAPP, SWAP_WEBAPP_SLOT,
-            createBackgroundActionListener("Swapping with Production", () -> swapWithProduction())));
-        addAction(ACTION_OPEN_IN_BROWSER, new WrappedTelemetryNodeActionListener(WEBAPP, OPERN_WEBAPP_SLOT_BROWSER,
-            new NodeActionListener() {
-            @Override
-            protected void actionPerformed(NodeActionEvent e) {
-                DefaultLoader.getUIHelper().openInBrowser("http://" + hostName);
-            }
-        }));
-        addAction(ACTION_DELETE, new DeleteDeploymentSlotAction());
-        addAction(ACTION_SHOW_PROPERTY, new WrappedTelemetryNodeActionListener(WEBAPP, SHOW_WEBAPP_SLOT_PROP,
-            new NodeActionListener() {
-                @Override
-                protected void actionPerformed(NodeActionEvent e) throws AzureCmdException {
-                    DefaultLoader.getUIHelper().openDeploymentSlotPropertyView(DeploymentSlotNode.this);
-                }
-            }));
+    protected NodeActionListener getStartActionListener() {
+        return new WrappedTelemetryNodeActionListener(WEBAPP, START_WEBAPP_SLOT,
+                createBackgroundActionListener("Starting Deployment Slot", this::start));
+    }
 
+    @Override
+    protected NodeActionListener getRestartActionListener() {
+        return new WrappedTelemetryNodeActionListener(WEBAPP, RESTART_WEBAPP_SLOT,
+                createBackgroundActionListener("Restarting Deployment Slot", this::restart));
+    }
+
+    @Override
+    protected NodeActionListener getStopActionListener() {
+        return new WrappedTelemetryNodeActionListener(WEBAPP, STOP_WEBAPP_SLOT,
+                createBackgroundActionListener("Stopping Deployment Slot", this::stop));
+    }
+
+    @Override
+    protected NodeActionListener getShowPropertiesActionListener() {
+        return new WrappedTelemetryNodeActionListener(WEBAPP, SHOW_WEBAPP_SLOT_PROP,
+                new NodeActionListener() {
+                    @Override
+                    protected void actionPerformed(NodeActionEvent e) throws AzureCmdException {
+                        DefaultLoader.getUIHelper().openDeploymentSlotPropertyView(DeploymentSlotNode.this);
+                    }
+                });
+    }
+
+    @Override
+    protected NodeActionListener getOpenInBrowserActionListener() {
+        return new WrappedTelemetryNodeActionListener(WEBAPP, OPERN_WEBAPP_SLOT_BROWSER,
+                new NodeActionListener() {
+                    @Override
+                    protected void actionPerformed(NodeActionEvent e) {
+                        DefaultLoader.getUIHelper().openInBrowser("http://" + hostName);
+                    }
+                });
+    }
+
+    @Override
+    protected NodeActionListener getDeleteActionListener() {
+        return new DeleteDeploymentSlotAction();
+    }
+
+    @Override
+    protected void loadActions() {
+        // Removed all base actions defined in WebAppBaseNode.
+        addAction(ACTION_SWAP_WITH_PRODUCTION, new WrappedTelemetryNodeActionListener(WEBAPP, SWAP_WEBAPP_SLOT,
+            createBackgroundActionListener("Swapping with Production", this::swapWithProduction)));
         super.loadActions();
     }
 


### PR DESCRIPTION
- Add ability to add Azure explorer node actions into three groups (top, general, bottom) to display them in a defined order
- Update existing node actions to provide a correct actions order
- Unify actions in all nodes derived from WebAppBaseNode. Unify behavior of Start/Stop actions to show/hide unrelevant actions
- Update Storage Account node to implement refreshable node interface. Replace logic with loading actions.
- Add missing icons for node actions on Utils and Plugin sides
- Add Empty icon for actions without an icon to align them in a menu
- Review all action names

Related ticket - https://youtrack.jetbrains.com/issue/RIDER-48559