### PR TITLE
Make all CommonIcons a @JvmField

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/rediscache/RedisCacheExplorer.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/rediscache/RedisCacheExplorer.java
@@ -141,7 +141,7 @@ public class RedisCacheExplorer extends BaseEditor implements RedisExplorerMvpVi
             }
         });
 
-        btnSearch.setIcon(CommonIcons.INSTANCE.getSearch());
+        btnSearch.setIcon(CommonIcons.Search);
         btnSearch.addActionListener(new AzureActionListenerWrapper(INSIGHT_NAME, "btnSearch", null) {
             @Override
             public void actionPerformedFunc(ActionEvent event) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/storage/BlobExplorerFileEditor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/storage/BlobExplorerFileEditor.java
@@ -220,7 +220,7 @@ public class BlobExplorerFileEditor implements FileEditor, TelemetryProperties {
         sorter.setSortKeys(sortKeys);
         sorter.sort();
 
-        backButton.setIcon(CommonIcons.INSTANCE.getOpenParent());
+        backButton.setIcon(CommonIcons.OpenParent);
         backButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
@@ -287,13 +287,13 @@ public class BlobExplorerFileEditor implements FileEditor, TelemetryProperties {
             }
         };
 
-        refreshButton.setIcon(CommonIcons.INSTANCE.getRefresh());
+        refreshButton.setIcon(CommonIcons.Refresh);
         refreshButton.addActionListener(queryAction);
 
-        queryButton.setIcon(CommonIcons.INSTANCE.getSearch());
+        queryButton.setIcon(CommonIcons.Search);
         queryButton.addActionListener(queryAction);
 
-        deleteButton.setIcon(CommonIcons.INSTANCE.getDiscard());
+        deleteButton.setIcon(CommonIcons.Discard);
         deleteButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
@@ -301,7 +301,7 @@ public class BlobExplorerFileEditor implements FileEditor, TelemetryProperties {
             }
         });
 
-        saveAsButton.setIcon(CommonIcons.INSTANCE.getSaveChanges());
+        saveAsButton.setIcon(CommonIcons.SaveChanges);
         saveAsButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
@@ -309,7 +309,7 @@ public class BlobExplorerFileEditor implements FileEditor, TelemetryProperties {
             }
         });
 
-        openButton.setIcon(CommonIcons.INSTANCE.getOpen());
+        openButton.setIcon(CommonIcons.Open);
         openButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
@@ -317,7 +317,7 @@ public class BlobExplorerFileEditor implements FileEditor, TelemetryProperties {
             }
         });
 
-        uploadButton.setIcon(CommonIcons.INSTANCE.getUpload());
+        uploadButton.setIcon(CommonIcons.Upload);
         uploadButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/storage/QueueFileEditor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/storage/QueueFileEditor.java
@@ -166,7 +166,7 @@ public class QueueFileEditor implements FileEditor {
             }
         });
 
-        refreshButton.setIcon(CommonIcons.INSTANCE.getRefresh());
+        refreshButton.setIcon(CommonIcons.Refresh);
         refreshButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
@@ -174,7 +174,7 @@ public class QueueFileEditor implements FileEditor {
             }
         });
 
-        dequeueMessageButton.setIcon(CommonIcons.INSTANCE.getOpen());
+        dequeueMessageButton.setIcon(CommonIcons.Open);
         dequeueMessageButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/storage/TableFileEditor.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/storage/TableFileEditor.java
@@ -95,10 +95,10 @@ public class TableFileEditor implements FileEditor {
             }
         };
 
-        queryButton.setIcon(CommonIcons.INSTANCE.getSearch());
+        queryButton.setIcon(CommonIcons.Search);
         queryButton.addActionListener(queryActionListener);
 
-        refreshButton.setIcon(CommonIcons.INSTANCE.getRefresh());
+        refreshButton.setIcon(CommonIcons.Refresh);
         refreshButton.addActionListener(queryActionListener);
 
         deleteButton.addActionListener(new ActionListener() {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/helpers/webapp/WebAppBasePropertyView.java
@@ -171,8 +171,8 @@ public abstract class WebAppBasePropertyView extends BaseEditor implements WebAp
         setTextFieldStyle();
 
         btnGetPublishFile.setIcon(AllIcons.Actions.Download);
-        btnSave.setIcon(CommonIcons.INSTANCE.getSaveChanges());
-        btnDiscard.setIcon(CommonIcons.INSTANCE.getDiscard());
+        btnSave.setIcon(CommonIcons.SaveChanges);
+        btnDiscard.setIcon(CommonIcons.Discard);
     }
 
     protected abstract String getId();

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/wizards/createarmvm/SubscriptionStep.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/wizards/createarmvm/SubscriptionStep.java
@@ -62,7 +62,7 @@ public class SubscriptionStep extends AzureWizardStep<VMWizardModel> implements 
 
         model.configStepList(createVmStepsList, 0);
 
-        buttonLogin.setIcon(CommonIcons.INSTANCE.getSubscriptions());
+        buttonLogin.setIcon(CommonIcons.Subscriptions);
 
         buttonLogin.addActionListener(new ActionListener() {
             @Override

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/icons/CommonIcons.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/icons/CommonIcons.kt
@@ -29,31 +29,31 @@ object CommonIcons {
 
     @JvmField val Azure = load("Azure.svg")
     @JvmField val AzureExplorer = load("AzureExplorer.svg")
-    val Subscriptions by lazy { load("Subscriptions.svg") }
-    val Database by lazy { load("Database.svg") }
-    val WebApp by lazy { load("WebApp.svg") }
-    val Firewall by lazy { load("Firewall.svg") }
+    @JvmField val Subscriptions = load("Subscriptions.svg")
+    @JvmField val Database = load("Database.svg")
+    @JvmField val WebApp = load("WebApp.svg")
+    @JvmField val Firewall = load("Firewall.svg")
 
-    val Warning by lazy { load("AzureWarning.svg") }
+    @JvmField val Warning = load("AzureWarning.svg")
 
-    val Search by lazy { load("Search.svg") }
-    val Refresh by lazy { load("refresh.svg") }
-    val OpenParent by lazy { load("AzureOpenParent.svg") }
-    val Discard by lazy { load("Discard.svg") }
-    val SaveChanges by lazy { load("SaveChanges.svg") }
-    val Open by lazy { load("AzureOpen.svg") }
-    val Upload by lazy { load("AzureUpload.svg") }
+    @JvmField val Search = load("Search.svg")
+    @JvmField val Refresh = load("refresh.svg")
+    @JvmField val OpenParent = load("AzureOpenParent.svg")
+    @JvmField val Discard = load("Discard.svg")
+    @JvmField val SaveChanges = load("SaveChanges.svg")
+    @JvmField val Open = load("AzureOpen.svg")
+    @JvmField val Upload = load("AzureUpload.svg")
 
     @JvmField val PublishAzure = load("publishAzure.svg")
     @JvmField val CodeSamples = load("CodeSamples.svg")
 
-    val Azurite by lazy { load("AzureStorageEmulator.svg") }
+    @JvmField val Azurite = load("AzureStorageEmulator.svg")
 
     @JvmField val AzureActiveDirectory = load("AzureActiveDirectory.svg")
 
     object OS {
-        val Windows by lazy { load("OSWindows.svg") }
-        val Linux by lazy { load("OSLinux.svg") }
+        @JvmField val Windows = load("OSWindows.svg")
+        @JvmField val Linux = load("OSLinux.svg")
     }
 
     object CloudShell {
@@ -67,17 +67,17 @@ object CommonIcons {
     }
 
     object AzureFunctions {
-        val FunctionApp by lazy { load("FunctionApp.svg") }
+        @JvmField val FunctionApp = load("FunctionApp.svg")
         @JvmField val FunctionAppRunConfiguration = load("FunctionAppRunConfiguration.svg")
-        val FunctionAppConfigurationType by lazy { load("FunctionApp.svg") }
-        val TemplateAzureFunc by lazy { load("TemplateAzureFunc.svg") }
+        @JvmField val FunctionAppConfigurationType = load("FunctionApp.svg")
+        @JvmField val TemplateAzureFunc = load("TemplateAzureFunc.svg")
     }
 
     @Suppress("unused")
     object ResourceManagement {
-        val ResourceManagement by lazy { load("AzureARM.svg") }
-        val ResourceGroup by lazy { load("AzureARMResourceGroup.svg") }
-        val Deployment by lazy { load("AzureARMDeployment.svg") }
+        @JvmField val ResourceManagement = load("AzureARM.svg")
+        @JvmField val ResourceGroup = load("AzureARMResourceGroup.svg")
+        @JvmField val Deployment = load("AzureARMDeployment.svg")
     }
 
     private fun load(path: String): Icon = IconLoader.getIcon("/icons/$path", this::class.java)


### PR DESCRIPTION
IconLoader has its own cache, so we don't really need `lazy {}` here.