### PR TITLE
Fix #380. Updated RiderIconPatcher map values to use reflective icons

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/icons/RiderIconsPatcher.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/icons/RiderIconsPatcher.kt
@@ -24,10 +24,6 @@ package org.jetbrains.icons
 
 import com.intellij.openapi.util.IconLoader
 import com.intellij.openapi.util.IconPathPatcher
-import com.intellij.ui.RetrievableIcon
-import icons.CommonIcons
-import icons.RestClientIcons
-import javax.swing.Icon
 
 /**
  * Icons Patcher for icons set from Rider backend (R#).
@@ -42,18 +38,6 @@ internal class RiderIconsPatcher : IconPathPatcher() {
         private val myInstallPatcher: Unit by lazy {
             IconLoader.installPathPatcher(RiderIconsPatcher())
         }
-
-        private fun path(icon: Icon): String {
-            val iconToProcess =
-                    if (icon is RetrievableIcon) icon.retrieveIcon()
-                    else icon
-
-            val cachedIcon = iconToProcess as? IconLoader.CachedImageIcon
-                    ?: throw RuntimeException("${icon.javaClass.simpleName} should be CachedImageIcon")
-
-            return cachedIcon.originalPath
-                    ?: throw RuntimeException("Unable to get original path for icon: ${cachedIcon.javaClass.simpleName}")
-        }
     }
 
     override fun patchPath(path: String, classLoader: ClassLoader?): String? = myIconsOverrideMap[path]
@@ -63,7 +47,7 @@ internal class RiderIconsPatcher : IconPathPatcher() {
         else originalClassLoader
 
     private val myIconsOverrideMap = mapOf(
-            "/resharper/FunctionAppRunMarkers/RunFunctionApp.svg" to path(CommonIcons.AzureFunctions.FunctionAppRunConfiguration),
-            "/resharper/FunctionAppRunMarkers/Trigger.svg" to path(RestClientIcons.Http_requests_filetype)
+            "/resharper/FunctionAppRunMarkers/RunFunctionApp.svg" to "CommonIcons.AzureFunctions.FunctionAppRunConfiguration",
+            "/resharper/FunctionAppRunMarkers/Trigger.svg" to "RestClientIcons.Http_requests_filetype"
     )
 }


### PR DESCRIPTION
<img width="368" alt="GutterIcons" src="https://user-images.githubusercontent.com/6064345/96973628-d44ec180-1520-11eb-9167-e0303888dff5.png">
