### PR TITLE
Fixed RIDER-53160. Update DotNetExecutable API call used in plugin

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -4,8 +4,8 @@ javaVersion=1.8
 org.gradle.jvmargs='-Duser.language=en'
 sources=false
 
-intellij_version=IC-203.3645-EAP-CANDIDATE-SNAPSHOT
-rider_version=RD-2020.3-EAP4-SNAPSHOT
+intellij_version=IC-203.5600-EAP-CANDIDATE-SNAPSHOT
+rider_version=RD-2020.3-EAP6-SNAPSHOT
 build_common_code_with=rider
 
 rider_backend_build_configuration=Debug
@@ -18,13 +18,13 @@ patchPluginXmlSinceBuild=203.3645.1
 
 kotlin_version=1.4.0
 jackson_kotlin_version=2.11.0
-gradle_plugin_version=0.4.26
+gradle_plugin_version=0.6.1
 undercouch_version=4.0.4
 web_socket_version=1.3.9
 retrofit_version=2.8.1
 assertj_version=3.15.0
 
 rd_version=0.203.161
-rider_nuget_sdk_version=2020.3.0-eap04
+rider_nuget_sdk_version=2020.3.0-eap06
 
 rider_test_local_env_run=true

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -6,7 +6,13 @@
     <html>
       <h4>Features:</h4>
       <ul>
+        <li>Compatibility with Rider 2020.3 EAP6</li>
         <li>Add Run/Debug Function App actions into Project context menu if applicable (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/382">#382</a></li>)</li>
+      </ul>
+      <h4>Bug fix:</h4>
+      <ul>
+        <li>Fix missing icons for Function App gutter mark (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/380">#380</a>)</li>
+        <li>Fix an error while running a Function App debug (<a href="https://youtrack.jetbrains.com/issue/RIDER-53160">RIDER-53160</a>)</li>
       </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsDotNetCoreDebugProfile.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsDotNetCoreDebugProfile.kt
@@ -79,7 +79,7 @@ class AzureFunctionsDotNetCoreDebugProfile(
         val useExternalConsole = consoleKind == ConsoleKind.ExternalConsole
         val console = createConsole(useExternalConsole, workerProcessHandler.debuggerWorkerRealHandler,
                 workerProcessHandler.presentableCommandLine, executionEnvironment.project)
-        dotNetExecutable.onProcessStarter(executionEnvironment.runProfile, workerProcessHandler)
+        dotNetExecutable.onBeforeProcessStarted(executionEnvironment.runProfile, workerProcessHandler)
         return DefaultExecutionResult(console, workerProcessHandler)
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationParameters.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationParameters.kt
@@ -131,7 +131,7 @@ open class AzureFunctionsHostConfigurationParameters(
                 useExternalConsole = useExternalConsole,
                 environmentVariables = envs,
                 isPassParentEnvs = isPassParentEnvs,
-                onProcessStarter = startBrowserAction,
+                onBeforeProcessStarted = startBrowserAction,
                 assemblyToDebug = coreToolsInfo.coreToolsExecutable,
                 runtimeArguments = runtimeArguments,
                 executeAsIs = true)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationTest.kt
@@ -85,7 +85,7 @@ class FunctionHostConfigurationTest : BaseTestWithSolution() {
 
     @Test(description = "Verifies Function Host run configuration has Build Function App before run task by default.")
     fun testFunctionHost_BeforeRunTasks_Defaults() {
-        val configuration  = createRunConfiguration(
+        val configuration = createRunConfiguration(
                 name = "Run Function App: ${project.name}",
                 configurationType = AzureFunctionsHostConfigurationType::class.java
         ) as AzureFunctionsHostConfiguration
@@ -103,7 +103,7 @@ class FunctionHostConfigurationTest : BaseTestWithSolution() {
 
         val configuration = createRunConfiguration(
                 name = "Run Function App: ${project.name}",
-                type = AzureFunctionsHostConfigurationType::class.java
+                configurationType = AzureFunctionsHostConfigurationType::class.java
         ) as AzureFunctionsHostConfiguration
 
         val projectToRun = project.solution.runnableProjectsModel.projects.valueOrNull?.find { it.name == "FunctionApp" }


### PR DESCRIPTION
- Bump to Rider SNAPSHOT SDK (EAP5 SDK contains an issue with running tests. Should be fixed in EAP6)
- Bump intellij gradle plugin version
- Fix the breaking change between EAP4 and EAP5 and updated to new DotNetExecutable API call when initializing a debugger for function apps
- Update change-notes for Azure plugin