### PR TITLE
Fix IDEA plugin build errors in buildPlugin gradle task

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -18,7 +18,7 @@ patchPluginXmlSinceBuild=203.3645.1
 
 kotlin_version=1.4.0
 jackson_kotlin_version=2.11.0
-gradle_plugin_version=0.6.1
+gradle_plugin_version=0.6.3
 undercouch_version=4.0.4
 web_socket_version=1.3.9
 retrofit_version=2.8.1


### PR DESCRIPTION
- Intellij Gradle plugin had a race while composing classpath. Updated to a plugin version with fix.