### PR TITLE
Improve "Trigger Function" logic for httpTrigger functions

### DIFF
--- a/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/SubFunctionNode.java
+++ b/Utils/azure-explorer-common/src/com/microsoft/tooling/msservices/serviceexplorer/azure/function/SubFunctionNode.java
@@ -31,6 +31,7 @@ import com.microsoft.tooling.msservices.serviceexplorer.Node;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionEvent;
 import com.microsoft.tooling.msservices.serviceexplorer.NodeActionListener;
 import com.microsoft.tooling.msservices.serviceexplorer.WrappedTelemetryNodeActionListener;
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -131,7 +132,7 @@ public class SubFunctionNode extends Node {
 
     private void triggerHttpTrigger(Map binding) {
         try {
-            final AuthorizationLevel authLevel = AuthorizationLevel.valueOf((String) binding.get("authLevel"));
+            final AuthorizationLevel authLevel = EnumUtils.getEnumIgnoreCase(AuthorizationLevel.class, (String)binding.get("authLevel"));
             String targetUrl;
             switch (authLevel) {
                 case ANONYMOUS:
@@ -187,9 +188,14 @@ public class SubFunctionNode extends Node {
             final List bindings = (List) ((Map) functionEnvelope.config()).get("bindings");
             return (Map) bindings.stream()
                     .filter(object -> object instanceof Map &&
-                            StringUtils.equalsIgnoreCase((CharSequence) ((Map) object).get("direction"), "in"))
-                    .filter(object ->
-                            StringUtils.containsIgnoreCase((CharSequence) ((Map) object).get("type"), "trigger"))
+                            // Get trigger bindings...
+                            StringUtils.containsIgnoreCase((CharSequence) ((Map) object).get("type"), "trigger") &&
+
+                                // ...that have "direction": "in"...
+                                (StringUtils.equalsIgnoreCase((CharSequence) ((Map) object).get("direction"), "in") ||
+
+                                // ...or are an http trigger (no direction specified there - http://json.schemastore.org/function)
+                                StringUtils.equalsIgnoreCase((CharSequence) ((Map) object).get("type"), "httpTrigger")))
                     .findFirst().orElse(null);
         } catch (ClassCastException | NullPointerException e) {
             // In case function.json lacks some parameters


### PR DESCRIPTION
This PR fixes two issues when triggering HTTP functions from Azure Explorer:

* Correctly detect HTTP trigger functions, as they do not have `"direction": "in"` in the function envelope
* Fix parsing enum value for HTTP trigger authorization (it may be lowercase in the envelope)

Contributed upstream to Microsoft as well - https://github.com/microsoft/azure-tools-for-java/pull/4796