### PR TITLE
Fix RIDER-48182. Remove port argument from command line for running function app parameters

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -17,6 +17,7 @@
       </ul>
       <h4>Bug fix:</h4>
       <ul>
+        <li>Remove port argument from run/debug function app configuration (<a href="https://youtrack.jetbrains.com/issue/RIDER-48182">RIDER-48182</a>)</li>
         <li>Enhance error handling for azure cli token expires (<a href="https://github.com/microsoft/azure-tools-for-java/pull/4707">#4707</a>)</li>
       </ul>
     </html>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/messages/RiderAzureMessages.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/messages/RiderAzureMessages.properties
@@ -307,7 +307,7 @@ run_config.run_function_app.validation.invalid_working_directory=Invalid working
 run_config.run_function_app.validation.missing_core_tools_path=Path to Azure Functions core tools has not been configured. This can be done in the settings under Tools | Azure | Functions.
 run_config.run_function_app.validation.missing_mono_runtime=Mono runtime not found. Please setup Mono path in settings (File | Settings | Build, Execution, Deployment | Toolset and Build)
 
-run_config.run_function_app.form.function_app.function_host_args_label=Functions host arguments:
+run_config.run_function_app.form.function_app.function_host_args_label=Function host arguments:
 run_config.run_function_app.form.function_app.working_directory_label=Working directory:
 run_config.run_function_app.form.function_app.function_names_to_run_label=Function names to run
 run_config.run_function_app.form.function_app.use_external_console=Use external console

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationParameters.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationParameters.kt
@@ -1,18 +1,18 @@
 /**
  * Copyright (c) 2019-2020 JetBrains s.r.o.
- * <p/>
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsRunnableProjectUtil.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsRunnableProjectUtil.kt
@@ -1,18 +1,18 @@
 /**
- * Copyright (c) 2019 JetBrains s.r.o.
- * <p/>
+ * Copyright (c) 2019-2020 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
@@ -39,14 +39,16 @@ object AzureFunctionsRunnableProjectUtil {
                 runnableProject.customAttributes)
     }
 
-    fun patchProjectOutput(projectOutput: ProjectOutput): ProjectOutput = projectOutput.copy(
-            // Azure Functions host needs the tfm folder, not the bin folder
-            workingDirectory = if (projectOutput.workingDirectory.endsWith("bin", true)) {
-                projectOutput.workingDirectory.substringBeforeLast("bin")
-            } else {
-                projectOutput.workingDirectory
-            },
+    fun patchProjectOutput(projectOutput: ProjectOutput): ProjectOutput =
+            projectOutput.copy(
+                    // Azure Functions host needs the tfm folder, not the bin folder
+                    workingDirectory = if (projectOutput.workingDirectory.endsWith("bin", true)) {
+                        projectOutput.workingDirectory.substringBeforeLast("bin")
+                    } else {
+                        projectOutput.workingDirectory
+                    },
 
-            // Add default arguments to start host
-            defaultArguments = mutableListOf("host", "start", "--port", "7071", "--pause-on-error"))
+                    // Add default arguments to start host
+                    defaultArguments = mutableListOf("host", "start", "--pause-on-error")
+            )
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/localsettings/FunctionLocalSettings.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/localsettings/FunctionLocalSettings.kt
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2020 JetBrains s.r.o.
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jetbrains.plugins.azure.functions.run.localsettings
+
+data class FunctionLocalSettings(
+        val isEncrypted: Boolean?,
+        val values: FunctionValuesModel?,
+        val host: FunctionHostModel?,
+        val connectionStrings: Map<String, String>?)
+
+data class FunctionValuesModel(
+        val workerRuntime: String?,
+        val webJobsStorage: String?,
+        val webJobsDashboard: String?,
+        val webJobsHttpExampleDisabled: Boolean?,
+        val bindingConnection: String?)
+
+data class FunctionHostModel(val localHttpPort: Int?, val cors: String?, val corsCredentials: Boolean?)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/localsettings/FunctionLocalSettingsParser.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/localsettings/FunctionLocalSettingsParser.kt
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2020 JetBrains s.r.o.
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jetbrains.plugins.azure.functions.run.localsettings
+
+import com.intellij.json.JsonUtil
+import com.intellij.json.psi.*
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Computable
+import com.intellij.openapi.vfs.VirtualFile
+import org.jetbrains.plugins.azure.util.JsonParser.findBooleanProperty
+import org.jetbrains.plugins.azure.util.JsonParser.findNumberProperty
+import org.jetbrains.plugins.azure.util.JsonParser.findStringProperty
+import org.jetbrains.plugins.azure.util.JsonParser.jsonFileFromVirtualFile
+
+object FunctionLocalSettingsParser {
+
+    const val PROPERTY_IS_ENCRYPTED = "IsEncrypted"
+
+    const val OBJECT_VALUES = "Values"
+    const val PROPERTY_VALUES_RUNTIME = "FUNCTIONS_WORKER_RUNTIME"
+    const val PROPERTY_VALUES_WEB_JOBS_STORAGE = "AzureWebJobsStorage"
+    const val PROPERTY_VALUES_WEB_JOBS_DASHBOARD = "AzureWebJobsDashboard"
+    const val PROPERTY_VALUES_BINDING_CONNECTION = "MyBindingConnection"
+    const val PROPERTY_VALUES_WEB_JOBS_HTTP_EXAMPLE_DISABLED = "AzureWebJobs.HttpExample.Disabled"
+
+    const val OBJECT_HOST = "Host"
+    const val PROPERTY_HOST_LOCAL_HTTP_PORT = "LocalHttpPort"
+    const val PROPERTY_HOST_CORS = "CORS"
+    const val PROPERTY_HOST_CORS_CREDENTIALS = "CORSCredentials"
+
+    const val OBJECT_CONNECTION_STRINGS = "ConnectionStrings"
+
+    fun readLocalSettingsJsonFrom(virtualFile: VirtualFile, project: Project): FunctionLocalSettings? {
+        val jsonFile = ApplicationManager.getApplication().runReadAction(Computable {
+            jsonFileFromVirtualFile(virtualFile, project)
+        }) ?: return null
+
+        return readFunctionLocalSettingsFrom(jsonFile)
+    }
+
+    fun readFunctionLocalSettingsFrom(jsonFile: JsonFile): FunctionLocalSettings? {
+        val topLevelObject = JsonUtil.getTopLevelObject(jsonFile) ?: return null
+
+        val isEncrypted = findBooleanProperty(topLevelObject, PROPERTY_IS_ENCRYPTED)
+
+        val valuesObject = topLevelObject.findProperty(OBJECT_VALUES)?.value as? JsonObject
+        val runtime = findStringProperty(valuesObject, PROPERTY_VALUES_RUNTIME)
+        val webJobsStorage = findStringProperty(valuesObject, PROPERTY_VALUES_WEB_JOBS_STORAGE)
+        val webJobsDashboard = findStringProperty(valuesObject, PROPERTY_VALUES_WEB_JOBS_DASHBOARD)
+        val bindingConnection = findStringProperty(valuesObject, PROPERTY_VALUES_BINDING_CONNECTION)
+        val webJobsHttpExampleDisabled = findBooleanProperty(valuesObject, PROPERTY_VALUES_WEB_JOBS_HTTP_EXAMPLE_DISABLED)
+
+        val hostObject = topLevelObject.findProperty(OBJECT_HOST)?.value as? JsonObject
+        val localHttpPort = findNumberProperty(hostObject, PROPERTY_HOST_LOCAL_HTTP_PORT)?.toInt()
+        val cors = findStringProperty(hostObject, PROPERTY_HOST_CORS)
+        val corsCredentials = findBooleanProperty(hostObject, PROPERTY_HOST_CORS_CREDENTIALS)
+
+        val connectionStringsObject = topLevelObject.findProperty(OBJECT_CONNECTION_STRINGS)?.value as? JsonObject
+        val connectionStrings: Map<String, String>? =
+                connectionStringsObject?.propertyList?.mapNotNull { entry ->
+                    val value = entry?.value as? JsonStringLiteral ?: return@mapNotNull null
+                    entry.name to value.value
+                }?.toMap()
+
+        return FunctionLocalSettings(
+            isEncrypted       = isEncrypted,
+            values            = FunctionValuesModel(runtime, webJobsStorage, webJobsDashboard, webJobsHttpExampleDisabled, bindingConnection),
+            host              = FunctionHostModel(localHttpPort, cors, corsCredentials),
+            connectionStrings = connectionStrings
+        )
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/localsettings/FunctionLocalSettingsUtil.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/localsettings/FunctionLocalSettingsUtil.kt
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2020 JetBrains s.r.o.
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jetbrains.plugins.azure.functions.run.localsettings
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.jetbrains.rider.model.RunnableProject
+import java.io.File
+
+object FunctionLocalSettingsUtil {
+
+    fun readFunctionLocalSettings(project: Project, runnableProject: RunnableProject): FunctionLocalSettings? =
+            readFunctionLocalSettings(project, File(runnableProject.projectFilePath).parent)
+
+    fun readFunctionLocalSettings(project: Project, basePath: String): FunctionLocalSettings? {
+        val localSettingsFile = getLocalSettingsVirtualFile(basePath) ?: return null
+        return FunctionLocalSettingsParser.readLocalSettingsJsonFrom(localSettingsFile, project)
+    }
+
+    fun getLocalSettingsVirtualFile(basePath: String): VirtualFile? {
+        val localSettingsFile = getLocalSettingFile(basePath)
+        if (!localSettingsFile.exists()) return null
+
+        return VfsUtil.findFileByIoFile(localSettingsFile, true)
+    }
+
+    fun getLocalSettingFile(basePath: String): File = File(basePath).resolve("local.settings.json")
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/util/JsonParser.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/util/JsonParser.kt
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2020 JetBrains s.r.o.
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.jetbrains.plugins.azure.util
+
+import com.intellij.json.psi.*
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.util.containers.ContainerUtil
+
+object JsonParser {
+
+    fun jsonFileFromVirtualFile(virtualFile: VirtualFile, project: Project): JsonFile? {
+        val document = FileDocumentManager.getInstance().getDocument(virtualFile) ?: return null
+        val file = PsiDocumentManager.getInstance(project).getPsiFile(document) ?: return null
+        return file as? JsonFile
+    }
+
+    fun writeProperty(project: Project,
+                      jsonObject: JsonObject,
+                      propertyName: String,
+                      propertyValue: String,
+                      escapeValue: Boolean = true): JsonProperty? {
+        val generator = JsonElementGenerator(project)
+        val property =
+            if (escapeValue) {
+                generator.createProperty(propertyName, "\"" + StringUtil.escapeStringCharacters(propertyValue) + "\"")
+            } else {
+                generator.createProperty(propertyName, propertyValue)
+            }
+
+        val existingProperty = jsonObject.findProperty(propertyName)
+        if (existingProperty != null) {
+            existingProperty.replace(property)
+            return property
+        }
+
+        val list = jsonObject.propertyList
+        return if (list.isEmpty()) {
+            jsonObject.addAfter(property, jsonObject.firstChild)
+            property
+        } else {
+            val comma = jsonObject.addAfter(generator.createComma(), ContainerUtil.getLastItem(list))
+            jsonObject.addAfter(property, comma) as JsonProperty
+        }
+    }
+
+    fun findStringProperty(jsonObject: JsonObject?, propertyName: String): String? =
+        findProperty<JsonStringLiteral>(jsonObject, propertyName)?.value
+
+    fun findBooleanProperty(jsonObject: JsonObject?, propertyName: String): Boolean? =
+        findProperty<JsonBooleanLiteral>(jsonObject, propertyName)?.value
+
+    fun findNumberProperty(jsonObject: JsonObject?, propertyName: String): Number? =
+        findProperty<JsonNumberLiteral>(jsonObject, propertyName)?.value
+
+    private inline fun <reified T> findProperty(jsonObject: JsonObject?, propertyName: String): T? {
+        val property = jsonObject?.findProperty(propertyName) ?: return null
+        return property.value as? T
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationEditorTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationEditorTest.kt
@@ -1,18 +1,18 @@
 /**
  * Copyright (c) 2020 JetBrains s.r.o.
- * <p/>
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
@@ -26,11 +26,16 @@ import com.intellij.openapi.util.Disposer
 import com.jetbrains.rider.model.RunnableProjectKind
 import com.jetbrains.rider.model.runnableProjectsModel
 import com.jetbrains.rider.projectView.solution
+import com.jetbrains.rider.projectView.solutionDirectory
+import com.jetbrains.rider.run.configurations.controls.ProgramParametersEditor
+import com.jetbrains.rider.run.configurations.controls.TextEditor
 import com.jetbrains.rider.test.annotations.TestEnvironment
 import com.jetbrains.rider.test.asserts.*
 import com.jetbrains.rider.test.base.BaseTestWithSolution
 import com.jetbrains.rider.test.enums.CoreVersion
+import com.jetbrains.rider.test.scriptingApi.changeFileContent
 import com.jetbrains.rider.test.scriptingApi.createRunConfiguration
+import org.jetbrains.plugins.azure.RiderAzureBundle
 import org.jetbrains.plugins.azure.functions.run.AzureFunctionsHostConfiguration
 import org.jetbrains.plugins.azure.functions.run.AzureFunctionsHostConfigurationEditor
 import org.jetbrains.plugins.azure.functions.run.AzureFunctionsHostConfigurationType
@@ -57,9 +62,7 @@ class FunctionHostConfigurationEditorTest : BaseTestWithSolution() {
         Disposer.dispose(editor)
     }
 
-    private val type = AzureFunctionsHostConfigurationType()
-
-    @Test
+    @Test(description = "Read default parameters for function host run configuration.")
     fun testFunctionHost_DefaultParameters() {
         val configuration = createRunConfiguration(
                 name = "Run FunctionApp",
@@ -85,7 +88,7 @@ class FunctionHostConfigurationEditorTest : BaseTestWithSolution() {
         parameters.workingDirectory.shouldBe(projectOutput.workingDirectory)
         parameters.exePath.shouldBe(projectOutput.exePath)
 
-        parameters.programParameters.shouldBe("host start --port 7071 --pause-on-error")
+        parameters.programParameters.shouldBe("host start --pause-on-error")
         parameters.envs.size.shouldBe(0)
         parameters.isPassParentEnvs.shouldBeTrue()
         parameters.useExternalConsole.shouldBeFalse()
@@ -98,5 +101,87 @@ class FunctionHostConfigurationEditorTest : BaseTestWithSolution() {
         parameters.trackProjectArguments.shouldBeTrue()
         parameters.trackProjectExePath.shouldBeTrue()
         parameters.trackProjectWorkingDirectory.shouldBeTrue()
+    }
+
+    @Test(description = "Read port from command arguments first and use it in URL text field.")
+    fun testFunctionHost_PortInCommandlineArguments() {
+        val configuration = createRunConfiguration(
+            name = "Run FunctionApp",
+            configurationType = AzureFunctionsHostConfigurationType::class.java
+        ) as AzureFunctionsHostConfiguration
+
+        editor.component // to initialize viewModel
+        editor.resetFrom(configuration)
+        editor.applyTo(configuration)
+
+        val controls = editor.viewModel.controls
+        val browserUrlEditor = controls.filterIsInstance<TextEditor>()
+            .find { it.name == RiderAzureBundle.message("run_config.run_function_app.form.function_app.url") }
+            .shouldNotBeNull()
+        browserUrlEditor.text.value.shouldBe("http://localhost:7071")
+
+        val programParameters = controls.filterIsInstance<ProgramParametersEditor>().single()
+        programParameters.parametersString.set("host start --port 7072 --pause-on-error")
+
+        browserUrlEditor.text.value.shouldBe("http://localhost:7072")
+    }
+
+    // Note: We copy a new solution instance before a test in [org.cases.runconfig.functionapp.BaseTestWithSolution]
+    //  This means - we do not need to reset all changes in local.settings.json file.
+    @Test(description = "Read port value from local.settings.json file and set URL text field with a proper port value.")
+    fun testFunctionHost_PortInLocalSettingsJson() {
+        prepareLocalSettingsFile()
+
+        val configuration = createRunConfiguration(
+            name = "Run FunctionApp",
+            configurationType = AzureFunctionsHostConfigurationType::class.java
+        ) as AzureFunctionsHostConfiguration
+
+        editor.component // to initialize viewModel
+        editor.resetFrom(configuration)
+        editor.applyTo(configuration)
+
+        val controls = editor.viewModel.controls
+        val browserUrlEditor = controls.filterIsInstance<TextEditor>()
+                .find { it.name == RiderAzureBundle.message("run_config.run_function_app.form.function_app.url") }
+                .shouldNotBeNull()
+        browserUrlEditor.text.value.shouldBe("http://localhost:7072")
+    }
+
+    @Test(description = "Check the case when port is specified in both command arguments in configuration and in " +
+            "local.settings.json file. Command arguments port value wins the fight.")
+    fun testFunctionHost_PortInCommandLineAndLocalSettings() {
+        prepareLocalSettingsFile()
+
+        val configuration = createRunConfiguration(
+                name = "Run FunctionApp",
+                configurationType = AzureFunctionsHostConfigurationType::class.java
+        ) as AzureFunctionsHostConfiguration
+
+        editor.component // to initialize viewModel
+        editor.resetFrom(configuration)
+        editor.applyTo(configuration)
+
+        val controls = editor.viewModel.controls
+        val browserUrlEditor = controls.filterIsInstance<TextEditor>()
+                .find { it.name == RiderAzureBundle.message("run_config.run_function_app.form.function_app.url") }
+                .shouldNotBeNull()
+
+        val programParameters = controls.filterIsInstance<ProgramParametersEditor>().single()
+        programParameters.parametersString.set("host start --port 7073 --pause-on-error")
+
+        browserUrlEditor.text.value.shouldBe("http://localhost:7073")
+    }
+
+    private fun prepareLocalSettingsFile() {
+        val source = testCaseSourceDirectory.resolve("local.settings.json")
+        if (!source.exists()) return
+
+        val localSettingFile =
+                project.solutionDirectory.resolve("FunctionApp").resolve("local.settings.json")
+
+        changeFileContent(project, localSettingFile) {
+            source.readText()
+        }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationParametersTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationParametersTest.kt
@@ -341,7 +341,7 @@ class FunctionHostConfigurationParametersTest : BaseTestWithSolution() {
     private fun createParameters(
             project: Project = this.project,
             exePath: String = "",
-            programParameters: String = "host start --port 7071 --pause-on-error",
+            programParameters: String = "host start --pause-on-error",
             workingDirectory: String = File("/working/path").absolutePath,
             envs: Map<String, String> = emptyMap(),
             isPassParentEnvs: Boolean = true,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/org/jetbrains/plugins/azure/functions/run/AzureFunctionsRunnableProjectUtilTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/org/jetbrains/plugins/azure/functions/run/AzureFunctionsRunnableProjectUtilTest.kt
@@ -41,7 +41,7 @@ class AzureFunctionsRunnableProjectUtilTest {
         val patched = AzureFunctionsRunnableProjectUtil.patchProjectOutput(projectOutput)
         patched.tfm.shouldBe(".NetFramework 4.7.1")
         patched.exePath.shouldBe("/path/to/executable")
-        patched.defaultArguments.shouldBe(listOf("host", "start", "--port", "7071", "--pause-on-error"))
+        patched.defaultArguments.shouldBe(listOf("host", "start", "--pause-on-error"))
         patched.workingDirectory.shouldBe("/path/to/working/dir")
         patched.dotNetCorePlatformRoot.shouldBe("/root")
     }
@@ -56,7 +56,7 @@ class AzureFunctionsRunnableProjectUtilTest {
                 dotNetCorePlatformRoot = "")
 
         val patched = AzureFunctionsRunnableProjectUtil.patchProjectOutput(projectOutput)
-        patched.defaultArguments.shouldBe(listOf("host", "start", "--port", "7071", "--pause-on-error"))
+        patched.defaultArguments.shouldBe(listOf("host", "start", "--pause-on-error"))
     }
 
     @Test

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/runconfig/functionapp/FunctionHostConfigurationEditorTest/testFunctionHost_PortInCommandLineAndLocalSettings/source/local.settings.json
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/runconfig/functionapp/FunctionHostConfigurationEditorTest/testFunctionHost_PortInCommandLineAndLocalSettings/source/local.settings.json
@@ -1,0 +1,10 @@
+{
+    "IsEncrypted": false,
+    "Values": {
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet"
+    },
+    "Host": {
+        "LocalHttpPort": 7072
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/runconfig/functionapp/FunctionHostConfigurationEditorTest/testFunctionHost_PortInLocalSettingsJson/source/local.settings.json
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/testData/org/cases/runconfig/functionapp/FunctionHostConfigurationEditorTest/testFunctionHost_PortInLocalSettingsJson/source/local.settings.json
@@ -1,0 +1,10 @@
+{
+    "IsEncrypted": false,
+    "Values": {
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet"
+    },
+    "Host": {
+        "LocalHttpPort": 7072
+    }
+}


### PR DESCRIPTION
- Remove default port parameter from command arguments
- Add parser for local.settings.json file for a runnable project
- Update the logic to check and use port value in Function App runner dialog editor (browser text field)
- Update tests

Related ticket - [RIDER-48182](https://youtrack.jetbrains.com/issue/RIDER-48182)