### PR TITLE
Switch to release IDEA SDK and Eap 10 Rider SDK

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -4,8 +4,8 @@ javaVersion=11
 org.gradle.jvmargs='-Duser.language=en'
 sources=false
 
-intellij_version=IC-203.5600-EAP-CANDIDATE-SNAPSHOT
-rider_version=RD-2020.3-EAP8-SNAPSHOT
+intellij_version=IC-2020.3
+rider_version=RD-2020.3-EAP10-SNAPSHOT
 build_common_code_with=rider
 
 rider_backend_build_configuration=Debug
@@ -16,16 +16,16 @@ applicationinsights.key=57cc111a-36a8-44b3-b044-25d293b8b77c
 updateVersionRange=false
 patchPluginXmlSinceBuild=203.3645.1
 
-kotlin_version=1.4.0
+kotlin_version=1.4.20
 jackson_kotlin_version=2.11.0
-gradle_plugin_version=0.6.3
+gradle_plugin_version=0.6.5
 undercouch_version=4.0.4
-web_socket_version=1.3.9
-retrofit_version=2.8.1
+web_socket_version=1.5.1
+retrofit_version=2.9.0
 assertj_version=3.15.0
 lombok_version=1.18.8
 
-rd_version=0.203.184
-rider_nuget_sdk_version=2020.3.0-eap08
+rd_version=0.203.190
+rider_nuget_sdk_version=2020.3.0-eap10
 
 rider_test_local_env_run=true

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -6,7 +6,7 @@
     <html>
       <h4>Features:</h4>
       <ul>
-        <li>Compatibility with Rider 2020.3 EAP8</li>
+        <li>Compatibility with Rider 2020.3 EAP10</li>
         <li>Add Function Deployment Slots in Azure Explorer (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/401">#401</a>)</li>
         <li>Add ability to deploy to Web/Function App Deployment Slots (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/72">#72</a>)</li>
         <li>Add ability to create Web/Function App Deployment Slots from Azure Explorer node (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/397">#397</a>, <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/401">#401</a>)</li>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Daemon/RunMarkers/FunctionAppRunMarkerAttributeIds.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Daemon/RunMarkers/FunctionAppRunMarkerAttributeIds.cs
@@ -1,17 +1,17 @@
 // Copyright (c) 2020 JetBrains s.r.o.
-// <p/>
+//
 // All rights reserved.
-// <p/>
+//
 // MIT License
-// <p/>
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 // documentation files (the "Software"), to deal in the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
 // to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// <p/>
+//
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of
 // the Software.
-// <p/>
+//
 // THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
 // THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Daemon/RunMarkers/FunctionAppRunMarkerGutterMark.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Daemon/RunMarkers/FunctionAppRunMarkerGutterMark.cs
@@ -1,17 +1,17 @@
 // Copyright (c) 2020 JetBrains s.r.o.
-// <p/>
+//
 // All rights reserved.
-// <p/>
+//
 // MIT License
-// <p/>
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 // documentation files (the "Software"), to deal in the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
 // to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// <p/>
+//
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of
 // the Software.
-// <p/>
+//
 // THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
 // THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
@@ -79,17 +79,20 @@ namespace JetBrains.ReSharper.Azure.Daemon.RunMarkers
             yield return new BulbMenuItem(
                 new ExecutableItem(() => { functionAppDaemonHost.RunFunctionApp(methodName, functionName, projectFilePath); }),
                 new RichText(javaPropertiesLoader.GetLocalizedString("gutter.function_app.run", functionName)),
-                FunctionAppRunMarkersThemedIcons.RunThis.Id, BulbMenuAnchors.PermanentBackgroundItems);
+                RunMarkersThemedIcons.RunThis.Id,
+                BulbMenuAnchors.PermanentBackgroundItems);
 
             yield return new BulbMenuItem(
                 new ExecutableItem(() => { functionAppDaemonHost.DebugFunctionApp(methodName, functionName, projectFilePath); }),
                 new RichText(javaPropertiesLoader.GetLocalizedString("gutter.function_app.debug", functionName)),
-                FunctionAppRunMarkersThemedIcons.DebugThis.Id, BulbMenuAnchors.PermanentBackgroundItems);
+                RunMarkersThemedIcons.DebugThis.Id,
+                BulbMenuAnchors.PermanentBackgroundItems);
 
             yield return new BulbMenuItem(
                 new ExecutableItem(() => { functionAppDaemonHost.TriggerFunctionApp(methodName, functionName, projectFilePath); }),
                 new RichText(javaPropertiesLoader.GetLocalizedString("gutter.function_app.trigger", functionName)),
-                FunctionAppRunMarkersThemedIcons.Trigger.Id, BulbMenuAnchors.PermanentBackgroundItems);
+                FunctionAppRunMarkersThemedIcons.Trigger.Id,
+                BulbMenuAnchors.PermanentBackgroundItems);
         }
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Daemon/RunMarkers/FunctionAppRunMarkerProvider.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Daemon/RunMarkers/FunctionAppRunMarkerProvider.cs
@@ -1,17 +1,17 @@
 // Copyright (c) 2020 JetBrains s.r.o.
-// <p/>
+//
 // All rights reserved.
-// <p/>
+//
 // MIT License
-// <p/>
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 // documentation files (the "Software"), to deal in the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
 // to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// <p/>
+//
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of
 // the Software.
-// <p/>
+//
 // THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
 // THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Daemon/RunMarkers/FunctionAppRunMarkersThemedIcons.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Daemon/RunMarkers/FunctionAppRunMarkersThemedIcons.cs
@@ -48,6 +48,7 @@ namespace JetBrains.UI.ThemedIcons
 	public sealed class FunctionAppRunMarkersThemedIcons
 	{
 		#region RunFunctionApp
+		
 		[global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsAttribute()]
 		public sealed class RunFunctionApp : global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsClass
 		{
@@ -85,249 +86,11 @@ namespace JetBrains.UI.ThemedIcons
 						new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.ThemedIconThemeImage("GrayDark", new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.LoadImageDelegate(this.Load_GrayDark))};
 			}
 		}
-		#endregion
 		
-		#region RunThis
-		/// <summary>
-		///	<para>
-		///		<para>RunThis Themed Icon generated identifiers:</para>
-		///		<para>— <see cref="RunThis"></see> identifier class, for use in attributes, XAML, and generic parameters;</para>
-		///		<para>— <see cref="Id"></see> identifier object, as a field in the identifier class, for use where an <see cref="JetBrains.UI.Icons.IconId"></see> value is expected.</para>
-		///		<para>
-		///			<code>
-		///
-		///       ;;;,'
-		///       ++`_^+^_`
-		///       **    '~+;:-
-		///       \\       '"+*^'
-		///       LL          .:;L=_`
-		///       ??`````````````-_;r*".
-		///       TT`````````````````_=L?=
-		///       JJ-----------------'^*J*
-		///       ||'''''''''''''':;?)!_`
-		///       FF''''''''''_^*sT='
-		///       CC_______,;?Cr~-
-		///       [[____^\it/:`
-		///       55,;TYF!_
-		///       2227=.
-		///
-		///</code>
-		///		</para>
-		///	</para>
-		///</summary>
-		///<remarks>
-		///	<para>For details on Themed Icons and their use, see Remarks on the outer class.</para>
-		///</remarks>
-		///<example>
-		///	<code>&lt;Image Source="{icons:ThemedIcon myres:PohequkThemedIconsThemedIcons+RunThis}" /&gt;        &lt;!-- XAML --&gt;</code>
-		///</example>
-		///<example>
-		///	<code>[Item(Name="Sample", Icon=typeof(PohequkThemedIconsThemedIcons.RunThis))]        // C# Type attribute</code>
-		///</example>
-		///<example>
-		///	<code>IconId iconid = PohequkThemedIconsThemedIcons.RunThis.Id;        // IconId identifier object</code>
-		///</example>
-		///<example>
-		///	<code>themediconmanager.GetIcon&lt;PohequkThemedIconsThemedIcons.RunThis&gt;()        // Icon image for rendering</code>
-		///</example>
-		[global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsAttribute()]
-		public sealed class RunThis : global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsClass
-		{
-
-			/// <inheritdoc cref="RunThis">identifier class</inheritdoc>
-			public static global::JetBrains.UI.Icons.IconId Id = new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsId(typeof(RunThis));
-
-			/// <summary>Loads the image for Themed Icon RunThis theme aspect Color.</summary>
-			public global::JetBrains.Util.Icons.TiImage Load_Color()
-			{
-				return global::JetBrains.Util.Icons.TiImageConverter.FromTiSvg(@"<svg ti:v='1' width='16' height='16' viewBox='0,0,16,16' xmlns='http://www.w3.org/2000/svg' xmlns:ti='urn:schemas-jetbrains-com:tisvg'><g><path d='M0,0L16,0L16,16L0,16Z' fill='#FFFFFF' opacity='0'/><linearGradient id='F1' x1='0.5' y1='0.0064999999999999919' x2='0.5' y2='1.0135'><stop offset='0' stop-color='#38AC0E'/><stop offset='1' stop-color='#007034'/></linearGradient><path fill-rule='evenodd' d='M3,1L3,15L4.278,15L15,8.566L15,7.434L4.278,1L3,1Z' fill='url(#F1)'/><linearGradient id='F2' x1='0.5' y1='-0.015166666666666662' x2='0.5' y2='1.0075833333333331'><stop offset='0' stop-color='#8CFF63'/><stop offset='1' stop-color='#2AC672'/></linearGradient><path fill-rule='evenodd' d='M4,14L14,8L4,2L4,14Z' fill='url(#F2)'/></g></svg>");
-			}
-
-			/// <summary>Loads the image for Themed Icon RunThis theme aspect Gray.</summary>
-			public global::JetBrains.Util.Icons.TiImage Load_Gray()
-			{
-				return global::JetBrains.Util.Icons.TiImageConverter.FromTiSvg("<svg ti:v=\'1\' width=\'16\' height=\'16\' viewBox=\'0,0,16,16\' xmlns=\'http://www.w3.org" +
-						"/2000/svg\' xmlns:ti=\'urn:schemas-jetbrains-com:tisvg\'><g><path d=\'M0,0L16,0L16,1" +
-						"6L0,16Z\' fill=\'#FFFFFF\' opacity=\'0\'/><path d=\'M4,14L14,8L4,2L4,14Z\' fill=\'#59A86" +
-						"9\'/></g></svg>");
-			}
-
-			/// <summary>Loads the image for Themed Icon RunThis theme aspect GrayDark.</summary>
-			public global::JetBrains.Util.Icons.TiImage Load_GrayDark()
-			{
-				return global::JetBrains.Util.Icons.TiImageConverter.FromTiSvg("<svg ti:v=\'1\' width=\'16\' height=\'16\' viewBox=\'0,0,16,16\' xmlns=\'http://www.w3.org" +
-						"/2000/svg\' xmlns:ti=\'urn:schemas-jetbrains-com:tisvg\'><g><path d=\'M0,0L16,0L16,1" +
-						"6L0,16Z\' fill=\'#FFFFFF\' opacity=\'0\'/><path d=\'M4,14L14,8L4,2L4,14Z\' fill=\'#499C5" +
-						"4\'/></g></svg>");
-			}
-
-			/// <summary>Returns the set of theme images for Themed Icon RunThis.</summary>
-			public override global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.ThemedIconThemeImage[] GetThemeImages()
-			{
-				return new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.ThemedIconThemeImage[] {
-						new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.ThemedIconThemeImage("Color", new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.LoadImageDelegate(this.Load_Color)),
-						new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.ThemedIconThemeImage("Gray", new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.LoadImageDelegate(this.Load_Gray)),
-						new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.ThemedIconThemeImage("GrayDark", new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.LoadImageDelegate(this.Load_GrayDark))};
-			}
-		}
-		#endregion
-
-		#region DebugThis
-		/// <summary>
-		///	<para>
-		///		<para>DebugThis Themed Icon generated identifiers:</para>
-		///		<para>— <see cref="DebugThis"></see> identifier class, for use in attributes, XAML, and generic parameters;</para>
-		///		<para>— <see cref="Id"></see> identifier object, as a field in the identifier class, for use where an <see cref="JetBrains.UI.Icons.IconId"></see> value is expected.</para>
-		///		<para>
-		///			<code>
-		///          "{a1_    '(a5^
-		///        "{Z^`;e1__(y+-"Y5^
-		///       '1aL`  `;ey*`  `+a1'
-		///         ^ay;   ``   "ea\
-		///   \\\\\cy1_          .*ai\\\\\
-		///   aa"""":`             '""""aa
-		///   aa````````````````````````aa
-		///   aaaaa^````\SSSSSS\````.aaaaa
-		///   aaLLL_````,;;;;;;,````-LLLaa
-		///   aa````````````````````````aa
-		///   aaIII~````caaaaaac````'IIIaa
-		///   aa|||;----~++++++~----_|||aa
-		///   aa........................aa
-		///   aarrrrr+_..........'=rrrrraa
-		///   """"""^vS?;:_____^\Yx!""""""
-		///           '^?{YYYYY|+_
-		///</code>
-		///		</para>
-		///	</para>
-		///</summary>
-		///<remarks>
-		///	<para>For details on Themed Icons and their use, see Remarks on the outer class.</para>
-		///</remarks>
-		///<example>
-		///	<code>&lt;Image Source="{icons:ThemedIcon myres:PohequkThemedIconsThemedIcons+DebugThis}" /&gt;        &lt;!-- XAML --&gt;</code>
-		///</example>
-		///<example>
-		///	<code>[Item(Name="Sample", Icon=typeof(PohequkThemedIconsThemedIcons.DebugThis))]        // C# Type attribute</code>
-		///</example>
-		///<example>
-		///	<code>IconId iconid = PohequkThemedIconsThemedIcons.DebugThis.Id;        // IconId identifier object</code>
-		///</example>
-		///<example>
-		///	<code>themediconmanager.GetIcon&lt;PohequkThemedIconsThemedIcons.DebugThis&gt;()        // Icon image for rendering</code>
-		///</example>
-		[global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsAttribute()]
-		public sealed class DebugThis : global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsClass
-		{
-
-			/// <inheritdoc cref="DebugThis">identifier class</inheritdoc>
-			public static global::JetBrains.UI.Icons.IconId Id = new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsId(typeof(DebugThis));
-
-			/// <summary>Loads the image for Themed Icon DebugThis theme aspect Color.</summary>
-			public global::JetBrains.Util.Icons.TiImage Load_Color()
-			{
-				return global::JetBrains.Util.Icons.TiImageConverter.FromTiSvg("<svg ti:v=\'1\' width=\'16\' height=\'16\' viewBox=\'0,0,16,16\' xmlns=\'http://www.w3.org" +
-						"/2000/svg\' xmlns:ti=\'urn:schemas-jetbrains-com:tisvg\'><g><path d=\'M0,0L16,0L16,1" +
-						"6L0,16Z\' fill=\'#FFFFFF\' opacity=\'0\'/><path fill-rule=\'evenodd\' d=\'M15,14.385L15," +
-						"4.308L12.347,4.308C12.114154949744872,3.99775376586475,11.848257147593641,3.7137" +
-						"494298974212,11.554,3.4610000000000003L12.89,2.143L10.719,0L9.9,0L8,1.877L6.1,0L" +
-						"5.281,0L3.11,2.143L4.51,3.5189999999999997C4.240791833361822,3.7568209812411988," +
-						"3.9962231740886711,4.02115614859259,3.7800000000000002,4.308L1,4.308L1,14.385L4." +
-						"241,14.385C4.9044355615133295,15.068127871642393,5.7391275238630373,15.560948831" +
-						"975564,6.6577335158113069,15.811893975088371C7.5763395077595765,16.0628391182011" +
-						"79,8.5456604922404225,16.062839118201179,9.4642664841886912,15.811893975088371C1" +
-						"0.38287247613696,15.560948831975564,11.21756443848667,15.068127871642393,11.881," +
-						"14.385ZM15,14.385\' fill=\'#293D00\' opacity=\'0.74901960784313726\'/><linearGradient" +
-						" id=\'F2\' x1=\'0.5\' y1=\'0\' x2=\'0.5\' y2=\'1.0000051027032557\'><stop offset=\'0\' stop-" +
-						"color=\'#BBFF61\'/><stop offset=\'1\' stop-color=\'#BCD100\'/></linearGradient><path f" +
-						"ill-rule=\'evenodd\' d=\'M9.977,3.613L11.466000000000001,2.143L10.308,1L8.12,3.17C8" +
-						".0989999999999984,3.17,8.02,3.16,7.9999999999999991,3.16C7.9419999999999993,3.16" +
-						",7.948999999999999,3.169,7.8909999999999991,3.1710000000000003L5.692,1L4.534,2.1" +
-						"43L6.067,3.655C5.3364909117040122,4.029290841654487,4.72631480107167,4.602371018" +
-						"2881592,4.307,5.3079999999999989L2,5.3079999999999989L2,6.923L3.753,6.923C3.7230" +
-						"0187244563,7.1012843897325979,3.7046297608820238,7.2813310830559388,3.6980000000" +
-						"000013,7.462L3.6980000000000013,8.538L2,8.538L2,10.154L3.7,10.154L3.7,10.692C3.7" +
-						"048005678728435,11.05626599221125,3.7572462375444964,11.418342827059778,3.856000" +
-						"0000000016,11.769L2,11.769L2,13.385L4.687,13.385C5.2300321490649608,14.059331369" +
-						"401214,5.96295264087832,14.555628763076555,6.790689805050051,14.80951436275792C7" +
-						".6184269692217823,15.063399962439284,8.50357303077822,15.063399962439284,9.33131" +
-						"01949499515,14.80951436275792C10.159047359121681,14.555628763076555,10.891967850" +
-						"935039,14.059331369401214,11.434999999999999,13.385L14,13.385L14,11.769L12.269,1" +
-						"1.769C12.36726448907206,11.418239066076533,12.419700826147956,11.05622666203333," +
-						"12.425,10.692L12.425,10.154L14,10.154L14,8.538L12.425,8.538L12.425,7.462C12.4180" +
-						"39479361761,7.2813092475768668,12.39933331444052,7.10126241020991,12.36900000000" +
-						"0003,6.923L14,6.923L14,5.308L11.815,5.308C11.381178971736929,4.5756159850921456," +
-						"10.7420490794503,3.9862116502576312,9.977,3.6129999999999991ZM9.977,3.613\' fill=" +
-						"\'url(#F2)\'/><path fill-rule=\'evenodd\' d=\'M9.8,11.5L6.2,11.5L6.2,10L9.8,10ZM9.8,1" +
-						"1.5M9.8,8.5L6.2,8.5L6.2,7L9.8,7ZM9.8,8.5\' fill=\'#293D00\' opacity=\'0.749019607843" +
-						"13726\'/></g></svg>");
-			}
-
-			/// <summary>Loads the image for Themed Icon DebugThis theme aspect Gray.</summary>
-			public global::JetBrains.Util.Icons.TiImage Load_Gray()
-			{
-				return global::JetBrains.Util.Icons.TiImageConverter.FromTiSvg("<svg ti:v=\'1\' width=\'16\' height=\'16\' viewBox=\'0,0,16,16\' xmlns=\'http://www.w3.org" +
-						"/2000/svg\' xmlns:ti=\'urn:schemas-jetbrains-com:tisvg\'><g><path d=\'M0,0L16,0L16,1" +
-						"6L0,16Z\' fill=\'#FFFFFF\' opacity=\'0\'/><path d=\'M9.977,3.613L11.466000000000001,2." +
-						"143L10.308,1L8.12,3.17C8.0989999999999984,3.17,8.02,3.16,7.9999999999999991,3.16" +
-						"C7.9419999999999993,3.16,7.948999999999999,3.169,7.8909999999999991,3.1710000000" +
-						"000003L5.692,1L4.534,2.143L6.067,3.655C5.3364909117040122,4.029290841654487,4.72" +
-						"631480107167,4.6023710182881592,4.307,5.3079999999999989L2,5.3079999999999989L2," +
-						"6.923L3.753,6.923C3.72300187244563,7.1012843897325979,3.7046297608820238,7.28133" +
-						"10830559388,3.6980000000000013,7.462L3.6980000000000013,8.538L2,8.538L2,10.154L3" +
-						".7,10.154L3.7,10.692C3.7048005678728435,11.05626599221125,3.7572462375444964,11." +
-						"418342827059778,3.8560000000000016,11.769L2,11.769L2,13.385L4.687,13.385C5.23003" +
-						"21490649608,14.059331369401214,5.96295264087832,14.555628763076555,6.79068980505" +
-						"0051,14.80951436275792C7.6184269692217823,15.063399962439284,8.50357303077822,15" +
-						".063399962439284,9.3313101949499515,14.80951436275792C10.159047359121681,14.5556" +
-						"28763076555,10.891967850935039,14.059331369401214,11.434999999999999,13.385L14,1" +
-						"3.385L14,11.769L12.269,11.769C12.36726448907206,11.418239066076533,12.4197008261" +
-						"47956,11.05622666203333,12.425,10.692L12.425,10.154L14,10.154L14,8.538L12.425,8." +
-						"538L12.425,7.462C12.418039479361761,7.2813092475768668,12.39933331444052,7.10126" +
-						"241020991,12.369000000000003,6.923L14,6.923L14,5.308L11.815,5.308C11.38117897173" +
-						"6929,4.5756159850921456,10.7420490794503,3.9862116502576312,9.977,3.612999999999" +
-						"9991ZM9.977,3.613M9.8,11.5L6.2,11.5L6.2,10L9.8,10ZM9.8,11.5M9.8,8.5L6.2,8.5L6.2," +
-						"7L9.8,7ZM9.8,8.5\' fill=\'#59A869\'/></g></svg>");
-			}
-
-			/// <summary>Loads the image for Themed Icon DebugThis theme aspect GrayDark.</summary>
-			public global::JetBrains.Util.Icons.TiImage Load_GrayDark()
-			{
-				return global::JetBrains.Util.Icons.TiImageConverter.FromTiSvg("<svg ti:v=\'1\' width=\'16\' height=\'16\' viewBox=\'0,0,16,16\' xmlns=\'http://www.w3.org" +
-						"/2000/svg\' xmlns:ti=\'urn:schemas-jetbrains-com:tisvg\'><g><path d=\'M0,0L16,0L16,1" +
-						"6L0,16Z\' fill=\'#FFFFFF\' opacity=\'0\'/><path d=\'M9.977,3.613L11.466000000000001,2." +
-						"143L10.308,1L8.12,3.17C8.0989999999999984,3.17,8.02,3.16,7.9999999999999991,3.16" +
-						"C7.9419999999999993,3.16,7.948999999999999,3.169,7.8909999999999991,3.1710000000" +
-						"000003L5.692,1L4.534,2.143L6.067,3.655C5.3364909117040122,4.029290841654487,4.72" +
-						"631480107167,4.6023710182881592,4.307,5.3079999999999989L2,5.3079999999999989L2," +
-						"6.923L3.753,6.923C3.72300187244563,7.1012843897325979,3.7046297608820238,7.28133" +
-						"10830559388,3.6980000000000013,7.462L3.6980000000000013,8.538L2,8.538L2,10.154L3" +
-						".7,10.154L3.7,10.692C3.7048005678728435,11.05626599221125,3.7572462375444964,11." +
-						"418342827059778,3.8560000000000016,11.769L2,11.769L2,13.385L4.687,13.385C5.23003" +
-						"21490649608,14.059331369401214,5.96295264087832,14.555628763076555,6.79068980505" +
-						"0051,14.80951436275792C7.6184269692217823,15.063399962439284,8.50357303077822,15" +
-						".063399962439284,9.3313101949499515,14.80951436275792C10.159047359121681,14.5556" +
-						"28763076555,10.891967850935039,14.059331369401214,11.434999999999999,13.385L14,1" +
-						"3.385L14,11.769L12.269,11.769C12.36726448907206,11.418239066076533,12.4197008261" +
-						"47956,11.05622666203333,12.425,10.692L12.425,10.154L14,10.154L14,8.538L12.425,8." +
-						"538L12.425,7.462C12.418039479361761,7.2813092475768668,12.39933331444052,7.10126" +
-						"241020991,12.369000000000003,6.923L14,6.923L14,5.308L11.815,5.308C11.38117897173" +
-						"6929,4.5756159850921456,10.7420490794503,3.9862116502576312,9.977,3.612999999999" +
-						"9991ZM9.977,3.613M9.8,11.5L6.2,11.5L6.2,10L9.8,10ZM9.8,11.5M9.8,8.5L6.2,8.5L6.2," +
-						"7L9.8,7ZM9.8,8.5\' fill=\'#499C54\'/></g></svg>");
-			}
-
-			/// <summary>Returns the set of theme images for Themed Icon DebugThis.</summary>
-			public override global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.ThemedIconThemeImage[] GetThemeImages()
-			{
-				return new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.ThemedIconThemeImage[] {
-						new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.ThemedIconThemeImage("Color", new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.LoadImageDelegate(this.Load_Color)),
-						new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.ThemedIconThemeImage("Gray", new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.LoadImageDelegate(this.Load_Gray)),
-						new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.ThemedIconThemeImage("GrayDark", new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.LoadImageDelegate(this.Load_GrayDark))};
-			}
-		}
 		#endregion
 
 		#region Trigger
+		
 		[global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsAttribute()]
 		public sealed class Trigger : global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsClass
 		{
@@ -365,6 +128,7 @@ namespace JetBrains.UI.ThemedIcons
 						new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.ThemedIconThemeImage("GrayDark", new global::JetBrains.Application.Icons.CompiledIconsCs.CompiledIconCsIdOwner.LoadImageDelegate(this.Load_GrayDark))};
 			}
 		}
+		
 		#endregion
 	}
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/icons/RiderIconsPatcherRegistrar.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/icons/RiderIconsPatcherRegistrar.kt
@@ -1,18 +1,18 @@
 /**
  * Copyright (c) 2020 JetBrains s.r.o.
- * <p/>
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,


### PR DESCRIPTION
- Bump RIDER SDK version to EAP 10
- Bump IDEA SDK version to release 203
- Bump RdGen and Kotlin version
- Bump retrofit and web client libs version
- Fix icons for Rider gutter mark for function apps

<img width="343" alt="GutterMark_RunDebug" src="https://user-images.githubusercontent.com/6064345/101287606-4b56c580-3802-11eb-9862-23a97bf92dca.png">
