### PR TITLE
Azure Toolkit for Rider: Deployment Slot setting is not saved #423

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -6,7 +6,7 @@
     <html>
       <h4>Bug fix:</h4>
       <ul>
-        <li>Fix Null Pointer Exception in Azurite panel in Rider Settings (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/415">#415</a>)</li>
+        <li>Fix Azure Toolkit for Rider: Deployment Slot setting is not saved (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/423">#423</a>)</li>
       </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -33,6 +33,8 @@
         <h4>Fixed bugs:</h4>
         <ul>
           <li>Azurite service should be stopped after closing the IDE <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/391">#391</a></li>
+          <li>Fix Null Pointer Exception in Azurite panel in Rider Settings (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/415">#415</a>)</li>
+          <li>Fix Azure Toolkit for Rider: Deployment Slot setting is not saved (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/423">#423</a>)</li>
         </ul>
         <p>[3.40.0-2020.2]</p>
         <ul>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/config/ui/FunctionAppPublishComponent.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/config/ui/FunctionAppPublishComponent.kt
@@ -44,6 +44,7 @@ import com.microsoft.intellij.ui.component.ExistingOrNewSelector
 import com.microsoft.intellij.ui.component.PublishableProjectComponent
 import com.microsoft.intellij.ui.component.appservice.AppAfterPublishSettingPanel
 import com.microsoft.intellij.ui.component.appservice.FunctionAppExistingComponent
+import com.microsoft.intellij.ui.component.appservice.InitialDeploymentSlotData
 import com.microsoft.intellij.ui.extension.getSelectedValue
 import com.microsoft.intellij.ui.extension.setComponentsVisible
 import net.miginfocom.swing.MigLayout
@@ -119,17 +120,8 @@ class FunctionAppPublishComponent(lifetime: Lifetime,
         else pnlCreateFunctionApp.pnlStorageAccount.rdoUseExisting.doClick()
 
         // Deployment Slots
-        val slotCheckBox = pnlExistingFunctionApp.pnlDeploymentSlotSettings.checkBoxIsEnabled
-        if (config.isDeployToSlot.xor(slotCheckBox.isSelected)) {
-            slotCheckBox.doClick()
-
-            val cbDeploymentSlots = pnlExistingFunctionApp.pnlDeploymentSlotSettings.cbDeploymentSlots
-            if (config.appId.isNotEmpty() && config.slotName.isNotEmpty() && cbDeploymentSlots.items.isNotEmpty()) {
-                val slotToSelect = cbDeploymentSlots.items.find { it.name() == config.slotName }
-                if (slotToSelect != null)
-                    cbDeploymentSlots.selectedItem = slotToSelect
-            }
-        }
+        pnlExistingFunctionApp.pnlDeploymentSlotSettings.initialData.set(
+                InitialDeploymentSlotData(config.appId, config.isDeployToSlot, config.slotName))
 
         // Settings
         val isOpenInBrowser = PropertiesComponent.getInstance().getBoolean(

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/model/FunctionAppPublishModel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/model/FunctionAppPublishModel.kt
@@ -29,7 +29,7 @@ import com.jetbrains.rd.platform.util.application
 import com.jetbrains.rider.model.PublishableProjectModel
 import com.jetbrains.rider.model.publishableProjectsModel
 import com.jetbrains.rider.projectView.solution
-import com.microsoft.azure.management.appservice.FunctionApp
+import com.microsoft.azure.management.appservice.FunctionDeploymentSlot
 import com.microsoft.azure.management.appservice.PricingTier
 import com.microsoft.azure.management.appservice.SkuDescription
 import com.microsoft.azure.management.appservice.WebAppBase
@@ -100,7 +100,11 @@ class FunctionAppPublishModel {
      */
     fun resetOnPublish(functionApp: WebAppBase) {
         isCreatingNewApp = false
-        appId = functionApp.id()
+        if (functionApp is FunctionDeploymentSlot) {
+            appId = functionApp.parent().id()
+        } else {
+            appId = functionApp.id()
+        }
         appName = ""
 
         isCreatingResourceGroup = false

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/ui/WebAppPublishComponent.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/ui/WebAppPublishComponent.kt
@@ -26,6 +26,7 @@ import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.reactive.adviseOnce
 import com.jetbrains.rider.model.PublishableProjectModel
 import com.jetbrains.rider.model.projectModelTasks
 import com.jetbrains.rider.projectView.solution
@@ -41,7 +42,6 @@ import com.microsoft.intellij.ui.component.AzureComponent
 import com.microsoft.intellij.ui.component.ExistingOrNewSelector
 import com.microsoft.intellij.ui.component.PublishableProjectComponent
 import com.microsoft.intellij.ui.component.appservice.AppAfterPublishSettingPanel
-import com.microsoft.intellij.ui.component.appservice.InitialDeploymentSlotData
 import com.microsoft.intellij.ui.component.appservice.WebAppExistingComponent
 import com.microsoft.intellij.ui.extension.getSelectedValue
 import com.microsoft.intellij.ui.extension.setComponentsVisible
@@ -49,7 +49,7 @@ import net.miginfocom.swing.MigLayout
 import org.jetbrains.plugins.azure.RiderAzureBundle.message
 import javax.swing.JPanel
 
-class WebAppPublishComponent(lifetime: Lifetime,
+class WebAppPublishComponent(private val lifetime: Lifetime,
                              private val project: Project,
                              private val model: WebAppPublishModel) :
         JPanel(MigLayout("novisualpadding, ins 0, fillx, wrap 1, hidemode 3")),
@@ -116,8 +116,18 @@ class WebAppPublishComponent(lifetime: Lifetime,
         else pnlCreateWebApp.pnlOperatingSystem.rdoOperatingSystemLinux.doClick()
 
         // Deployment Slot
-        pnlExistingWebApp.pnlDeploymentSlotSettings.initialData.set(
-                InitialDeploymentSlotData(config.appId, config.isDeployToSlot, config.slotName))
+        pnlExistingWebApp.pnlDeploymentSlotSettings.loadFinished.adviseOnce(lifetime.createNested()) { slotsData ->
+            val panel = pnlExistingWebApp.pnlDeploymentSlotSettings
+            if (config.isDeployToSlot.xor(panel.checkBoxIsEnabled.isSelected)) {
+                panel.checkBoxIsEnabled.doClick()
+
+                if (config.appId.isNotEmpty() && config.appId == slotsData.appId && config.slotName.isNotEmpty() && slotsData.slots.isNotEmpty()) {
+                    val slotToSelect = slotsData.slots.find { it.name() == config.slotName }
+                    if (slotToSelect != null)
+                        panel.cbDeploymentSlots.selectedItem = slotToSelect
+                }
+            }
+        }
 
         // Settings
         val isOpenInBrowser = PropertiesComponent.getInstance().getBoolean(

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/ui/WebAppPublishComponent.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/ui/WebAppPublishComponent.kt
@@ -41,6 +41,7 @@ import com.microsoft.intellij.ui.component.AzureComponent
 import com.microsoft.intellij.ui.component.ExistingOrNewSelector
 import com.microsoft.intellij.ui.component.PublishableProjectComponent
 import com.microsoft.intellij.ui.component.appservice.AppAfterPublishSettingPanel
+import com.microsoft.intellij.ui.component.appservice.InitialDeploymentSlotData
 import com.microsoft.intellij.ui.component.appservice.WebAppExistingComponent
 import com.microsoft.intellij.ui.extension.getSelectedValue
 import com.microsoft.intellij.ui.extension.setComponentsVisible
@@ -115,17 +116,8 @@ class WebAppPublishComponent(lifetime: Lifetime,
         else pnlCreateWebApp.pnlOperatingSystem.rdoOperatingSystemLinux.doClick()
 
         // Deployment Slot
-        val slotCheckBox = pnlExistingWebApp.pnlDeploymentSlotSettings.checkBoxIsEnabled
-        if (config.isDeployToSlot.xor(slotCheckBox.isSelected)) {
-            slotCheckBox.doClick()
-
-            val cbDeploymentSlots = pnlExistingWebApp.pnlDeploymentSlotSettings.cbDeploymentSlots
-            if (config.appId.isNotEmpty() && config.slotName.isNotEmpty() && cbDeploymentSlots.items.isNotEmpty()) {
-                val slotToSelect = cbDeploymentSlots.items.find { it.name() == config.slotName }
-                if (slotToSelect != null)
-                    cbDeploymentSlots.selectedItem = slotToSelect
-            }
-        }
+        pnlExistingWebApp.pnlDeploymentSlotSettings.initialData.set(
+                InitialDeploymentSlotData(config.appId, config.isDeployToSlot, config.slotName))
 
         // Settings
         val isOpenInBrowser = PropertiesComponent.getInstance().getBoolean(

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/model/WebAppPublishModel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/model/WebAppPublishModel.kt
@@ -94,7 +94,11 @@ class WebAppPublishModel {
      */
     fun resetOnPublish(app: WebAppBase) {
         isCreatingNewApp = false
-        appId = app.id()
+        if (app is DeploymentSlot) {
+            appId = app.parent().id()
+        } else {
+            appId = app.id()
+        }
         appName = ""
 
         isCreatingResourceGroup = false

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/ui/component/appservice/DeploymentSlotPublishSettingsPanel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/ui/component/appservice/DeploymentSlotPublishSettingsPanel.kt
@@ -72,6 +72,8 @@ class DeploymentSlotPublishSettingsPanel(lifetime: Lifetime) :
             )
 }
 
+data class InitialDeploymentSlotData(val appId: String, val isDeployToSlot: Boolean, val slotName: String)
+
 abstract class DeploymentSlotPublishSettingsPanelBase<T: DeploymentSlotBase<T>>(private val lifetime: Lifetime) :
         JPanel(MigLayout("novisualpadding, ins 0, fillx, wrap 2", "[min!][]")),
         AzureComponent {
@@ -79,6 +81,8 @@ abstract class DeploymentSlotPublishSettingsPanelBase<T: DeploymentSlotBase<T>>(
     private val appToSlotsMap = concurrentMapOf<WebAppBase, List<T>>()
 
     val appProperty: IProperty<WebAppBase?> = Property(null)
+
+    val initialData: IProperty<InitialDeploymentSlotData?> = Property(null)
 
     val checkBoxIsEnabled: JCheckBox = JCheckBox("Deploy to slot:", false)
 
@@ -105,6 +109,19 @@ abstract class DeploymentSlotPublishSettingsPanelBase<T: DeploymentSlotBase<T>>(
 
             checkBoxIsEnabled.isEnabled = slots.isNotEmpty()
             this.isEnabled = slots.isNotEmpty()
+
+            initialData.value?.let { init ->
+                if (init.isDeployToSlot.xor(checkBoxIsEnabled.isSelected)) {
+                    checkBoxIsEnabled.doClick()
+
+                    if (init.appId.isNotEmpty() && init.appId == app.id() && init.slotName.isNotEmpty() && slots.isNotEmpty()) {
+                        val slotToSelect = slots.find { it.name() == init.slotName }
+                        if (slotToSelect != null)
+                            this.selectedItem = slotToSelect
+                    }
+                }
+                initialData.set(null)
+            }
 
             return slots
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/com/microsoft/intellij/runner/functionapp/model/FunctionAppPublishModelTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/com/microsoft/intellij/runner/functionapp/model/FunctionAppPublishModelTest.kt
@@ -26,6 +26,7 @@ import com.jetbrains.rider.test.asserts.shouldBe
 import com.jetbrains.rider.test.asserts.shouldBeEmpty
 import com.jetbrains.rider.test.asserts.shouldBeFalse
 import org.jetbrains.mock.FunctionAppMock
+import org.jetbrains.mock.FunctionDeploymentSlotMock
 import org.testng.annotations.Test
 
 class FunctionAppPublishModelTest {
@@ -36,6 +37,28 @@ class FunctionAppPublishModelTest {
 
         val model = FunctionAppPublishModel()
         model.resetOnPublish(mockFunctionApp)
+
+        model.isCreatingNewApp.shouldBeFalse()
+        model.appId.shouldBe(mockFunctionApp.id())
+        model.appName.shouldBeEmpty()
+
+        model.isCreatingResourceGroup.shouldBeFalse()
+        model.resourceGroupName.shouldBeEmpty()
+
+        model.isCreatingAppServicePlan.shouldBeFalse()
+        model.appServicePlanName.shouldBeEmpty()
+
+        model.isCreatingStorageAccount.shouldBeFalse()
+        model.storageAccountName.shouldBeEmpty()
+    }
+
+    @Test(description = "https://github.com/JetBrains/azure-tools-for-intellij/issues/423")
+    fun testResetOnPublish_DeploymentSlot() {
+        val mockFunctionApp = FunctionAppMock(id = "test-function-app-id")
+        val mockDeploymentSlot = FunctionDeploymentSlotMock(parent = mockFunctionApp)
+
+        val model = FunctionAppPublishModel()
+        model.resetOnPublish(mockDeploymentSlot)
 
         model.isCreatingNewApp.shouldBeFalse()
         model.appId.shouldBe(mockFunctionApp.id())

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/com/microsoft/intellij/runner/webapp/model/WebAppPublishModelTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/com/microsoft/intellij/runner/webapp/model/WebAppPublishModelTest.kt
@@ -25,6 +25,7 @@ package com.microsoft.intellij.runner.webapp.model
 import com.jetbrains.rider.test.asserts.shouldBe
 import com.jetbrains.rider.test.asserts.shouldBeEmpty
 import com.jetbrains.rider.test.asserts.shouldBeFalse
+import org.jetbrains.mock.DeploymentSlotMock
 import org.jetbrains.mock.WebAppMock
 import org.testng.annotations.Test
 
@@ -36,6 +37,25 @@ class WebAppPublishModelTest {
 
         val model = WebAppPublishModel()
         model.resetOnPublish(mockWebApp)
+
+        model.isCreatingNewApp.shouldBeFalse()
+        model.appId.shouldBe(mockWebApp.id())
+        model.appName.shouldBeEmpty()
+
+        model.isCreatingResourceGroup.shouldBeFalse()
+        model.resourceGroupName.shouldBeEmpty()
+
+        model.isCreatingAppServicePlan.shouldBeFalse()
+        model.appServicePlanName.shouldBeEmpty()
+    }
+
+    @Test(description = "https://github.com/JetBrains/azure-tools-for-intellij/issues/423")
+    fun testResetOnPublish_DeploymentSlot() {
+        val mockWebApp = WebAppMock(id = "test-web-app-id")
+        val mockDeploymentSlot = DeploymentSlotMock(parent = mockWebApp)
+
+        val model = WebAppPublishModel()
+        model.resetOnPublish(mockDeploymentSlot)
 
         model.isCreatingNewApp.shouldBeFalse()
         model.appId.shouldBe(mockWebApp.id())

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/org/jetbrains/mock/DeploymentSlotMock.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/org/jetbrains/mock/DeploymentSlotMock.kt
@@ -32,15 +32,17 @@ import rx.Observable
 import java.io.File
 import java.io.InputStream
 
-class DeploymentSlotMock(private val name: String = "test-deployment-slot") : DeploymentSlot {
+class DeploymentSlotMock(
+        private val id: String = "test-deployment-slot-id",
+        private val name: String = "test-deployment-slot",
+        private val parent: WebApp? = null
+) : DeploymentSlot {
 
     override fun key(): String {
         TODO("Not yet implemented")
     }
 
-    override fun id(): String {
-        TODO("Not yet implemented")
-    }
+    override fun id(): String = id
 
     override fun name(): String = name
 
@@ -464,9 +466,7 @@ class DeploymentSlotMock(private val name: String = "test-deployment-slot") : De
         TODO("Not yet implemented")
     }
 
-    override fun parent(): WebApp {
-        TODO("Not yet implemented")
-    }
+    override fun parent(): WebApp = parent ?: throw Exception("No parent was provided for this mock.")
 
     override fun warDeploy(p0: File?) {
         TODO("Not yet implemented")

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/org/jetbrains/mock/FunctionDeploymentSlotMock.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/org/jetbrains/mock/FunctionDeploymentSlotMock.kt
@@ -10,15 +10,17 @@ import rx.Observable
 import java.io.File
 import java.io.InputStream
 
-class FunctionDeploymentSlotMock(private val name: String = "test-function-deployment-slot") : FunctionDeploymentSlot {
+class FunctionDeploymentSlotMock(
+        private val id: String = "test-function-deployment-slot-id",
+        private val name: String = "test-function-deployment-slot",
+        private val parent: FunctionApp? = null
+) : FunctionDeploymentSlot {
 
     override fun key(): String {
         TODO("Not yet implemented")
     }
 
-    override fun id(): String {
-        TODO("Not yet implemented")
-    }
+    override fun id(): String = id
 
     override fun name(): String = name
 
@@ -442,7 +444,5 @@ class FunctionDeploymentSlotMock(private val name: String = "test-function-deplo
         TODO("Not yet implemented")
     }
 
-    override fun parent(): FunctionApp {
-        TODO("Not yet implemented")
-    }
+    override fun parent(): FunctionApp = parent ?: throw Exception("No parent was provided for this mock.")
 }


### PR DESCRIPTION
Fixes #423

1) Slot settings were not displayed correctly when editing configuration
2) After publish, app id was overwritten by the slot id (added tests for these cases)