### PR TITLE
Rename AzureFunctions notifications group

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -229,7 +229,7 @@
     <editorNotificationProvider implementation="org.jetbrains.plugins.azure.identity.ad.notifications.DefaultAzureAdApplicationRegistrationNotificationProvider"/>
 
     <notificationGroup id="Azure" displayType="BALLOON" isLogByDefault="true"/>
-    <notificationGroup id="AzureFunctions" displayType="BALLOON" isLogByDefault="true"/>
+    <notificationGroup id="Azure Functions" displayType="BALLOON" isLogByDefault="true"/>
     <notificationGroup id="Azure Web App Publish Message" displayType="BALLOON" isLogByDefault="true" toolWindowId="Run"/>
   </extensions>
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/AzureCoreToolsNotification.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/AzureCoreToolsNotification.kt
@@ -41,7 +41,7 @@ import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsManager
 // TODO: FIX_VERSION: Replace with [SolutionLoadNotification] when async notifications are merged into 202
 class AzureCoreToolsNotification : StartupActivity {
     companion object {
-        private const val notificationGroupName = "AzureFunctions"
+        private const val notificationGroupName = "Azure Functions"
     }
 
     override fun runActivity(project: Project) {


### PR DESCRIPTION
Make this entry a bit nicer:

![image](https://user-images.githubusercontent.com/485230/103269948-33183780-49b7-11eb-800c-26da6faeeafd.png)
