### PR TITLE
F# template support

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/LiveTemplates/Scope/FSharp.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/LiveTemplates/Scope/FSharp.cs
@@ -1,0 +1,90 @@
+// Copyright (c) 2021 JetBrains s.r.o.
+// <p/>
+// All rights reserved.
+// <p/>
+// MIT License
+// <p/>
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// <p/>
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+// the Software.
+// <p/>
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Application;
+using JetBrains.Application.UI.Options;
+using JetBrains.Application.UI.Options.OptionsDialog;
+using JetBrains.IDE.UI;
+using JetBrains.Lifetimes;
+using JetBrains.ProjectModel;
+using JetBrains.ProjectModel.Resources;
+using JetBrains.ReSharper.Feature.Services.LiveTemplates.Scope;
+using JetBrains.ReSharper.Feature.Services.LiveTemplates.Settings;
+using JetBrains.ReSharper.LiveTemplates.UI;
+
+namespace JetBrains.ReSharper.Azure.Intellisense.FunctionApp.LiveTemplates.Scope
+{
+    public class InAzureFunctionsFSharpProject : InAzureFunctionsProject
+    {
+        private static readonly Guid ourDefaultGuid = new Guid("6EAE234E-60AA-410E-B021-D219A2478F98");
+
+        public override Guid GetDefaultUID() => ourDefaultGuid;
+        public override string PresentableShortName => "Azure Functions (F#) projects";
+    }
+
+    [ShellComponent]
+    public class AzureFSharpScopeProvider : AzureProjectScopeProvider
+    {
+        public AzureFSharpScopeProvider()
+        {
+            Creators.Add(TryToCreate<InAzureFunctionsFSharpProject>);
+        }
+
+        protected override IEnumerable<ITemplateScopePoint> GetLanguageSpecificScopePoints(IProject project)
+        {
+            var baseItems = base.GetLanguageSpecificScopePoints(project);
+            foreach (var item in baseItems) yield return item;
+            if (project.ProjectProperties.GetType().Name == "FSharpProjectProperties") // TODO: reconsider after possibly adding a direct dependency on F# plugin in #392
+                yield return new InAzureFunctionsFSharpProject();
+        }
+    }
+
+    [ScopeCategoryUIProvider(Priority = -41.0, ScopeFilter = ScopeFilter.Project)]
+    public class AzureFSharpProjectScopeCategoryUiProvider : ScopeCategoryUIProvider
+    {
+        public AzureFSharpProjectScopeCategoryUiProvider() : base(ProjectModelThemedIcons.Fsharp.Id)
+        {
+            MainPoint = new InAzureFunctionsFSharpProject();
+        }
+
+        public override IEnumerable<ITemplateScopePoint> BuildAllPoints()
+        {
+            yield return new InAzureFunctionsFSharpProject();
+        }
+
+        public override string CategoryCaption => "Azure (F#)";
+    }
+
+    [OptionsPage("RiderAzureFSharpFileTemplatesSettings", "F#", typeof(ProjectModelThemedIcons.Fsharp))]
+    public class RiderAzureFSharpFileTemplatesOptionPage : RiderFileTemplatesOptionPageBase
+    {
+        public RiderAzureFSharpFileTemplatesOptionPage(Lifetime lifetime, OptionsPageContext optionsPageContext,
+            OptionsSettingsSmartContext settings, StoredTemplatesProvider storedTemplatesProvider,
+            AzureFSharpProjectScopeCategoryUiProvider uiProvider, ScopeCategoryManager scopeCategoryManager,
+            TemplatesUIFactory uiFactory, IconHostBase iconHost, IDialogHost dialogHost) : base(lifetime, uiProvider,
+            optionsPageContext, settings,
+            storedTemplatesProvider, scopeCategoryManager, uiFactory, iconHost, dialogHost,
+            "F#" /* TODO: consider using FSharpProjectFileType.Name after migration to a direct dependency on F# plugin in #392 */)
+        {
+        }
+    }
+}


### PR DESCRIPTION
This is a direct translation from [that code in F# plugin](https://github.com/JetBrains/fsharp-support/blob/97df5d74b3a34d6e38736789521913c3d29fdc6d/ReSharper.FSharp/src/FSharp.Psi.Features/src/FileTemplates/AzureFSharpScopeProvider.fs).

Since the relevant classes are already removed from the Rider SDK 2021.1 in scope of #422, this created a problem for building the F# plugin itself.

Thus, I believe the best course of action is to migrate this code to the Azure Toolkit plugin — for now, at least.

A couple of notes:
1. ~~The target branch still targets 2020.3 SDK (I guess, the migration to 20201.1 SDK is blocked by #422); we'll have to either update this code in #422 (fix the namespaces), or wait for #422 being merged, and then rebase this code on top of that (which I'm okay with).~~

   It has been rebased on top of `net211`, the issue is resolved.
2. I've decided to not dive into depending on F# plugin; the use case is simple enough to rely on a type name and a constant. We could reconsider the approach after finishing with #392, though.
3. These changes are completely untested; I wasn't able to build the plugin frontend on my machine (the backend is buildable, though).