### PR TITLE
Retarget 2021.1 EAP 2

### DIFF
--- a/BuildDevint
+++ b/BuildDevint
@@ -110,7 +110,7 @@ if $BUILD_INTELLIJ; then
   tc_close "Building IDEA plugin"
 fi
 
-BUILD_NUMBER="3.40.0.$BUILD_COUNTER-2020.3"
+BUILD_NUMBER="3.40.0.$BUILD_COUNTER-2021.1"
 
 tc_open "Run Rider tests"
 {

--- a/BuildPlugin
+++ b/BuildPlugin
@@ -145,7 +145,7 @@ if $BUILD_INTELLIJ; then
 fi
 
 if $BUILD_RIDER; then
-    BUILD_NUMBER="3.46.0.$BUILD_COUNTER-2020.3"
+    BUILD_NUMBER="3.46.0.$BUILD_COUNTER-2021.1"
     BUILD_CONFIGURATION=Release
 
     tc_open "Building Rider plugin"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle
@@ -140,14 +140,6 @@ configure(mainProjects) {
         jvmArgs '-Xmx2048m'
     }
 
-    instrumentCode {
-        // javac2 is required to compile .form files from IntelliJ IDEA UI Designer
-        // Since Rider distribution does not contain it, take it from IDEA
-        javac2 {
-            "${project(":idea").extensions.getByName("intellij").ideaDependency.classes}/lib/javac2.jar"
-        }
-    }
-
     test {
         testLogging.showStandardStreams = true
         testLogging {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs='-Duser.language=en'
 sources=false
 
 intellij_version=IC-2020.3
-rider_version=RD-2020.3
+rider_version=RD-2021.1-SNAPSHOT
 build_common_code_with=rider
 
 rider_backend_build_configuration=Debug
@@ -25,7 +25,7 @@ retrofit_version=2.9.0
 assertj_version=3.15.0
 lombok_version=1.18.8
 
-rd_version=0.203.190
+rd_version=0.211.195
 rider_nuget_sdk_version=2020.3.0
 
 rider_test_local_env_run=true

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -1,4 +1,4 @@
-buildNumber=3.46.0.9999-2020.3
+buildNumber=3.46.0.9999-2021.1
 
 javaVersion=11
 org.gradle.jvmargs='-Duser.language=en'
@@ -17,7 +17,7 @@ updateVersionRange=false
 patchPluginXmlSinceBuild=211.4961.4
 
 kotlin_version=1.4.20
-jackson_kotlin_version=2.11.0
+jackson_kotlin_version=2.12.0
 gradle_plugin_version=0.6.5
 undercouch_version=4.0.4
 web_socket_version=1.5.1

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs='-Duser.language=en'
 sources=false
 
 intellij_version=IC-211.4961.30-EAP-SNAPSHOT
-rider_version=RD-2021.1-EAP1-SNAPSHOT
+rider_version=RD-2021.1-EAP2-SNAPSHOT
 build_common_code_with=rider
 
 rider_backend_build_configuration=Debug
@@ -26,6 +26,6 @@ assertj_version=3.15.0
 lombok_version=1.18.8
 
 rd_version=0.211.195
-rider_nuget_sdk_version=2021.1.0-eap01
+rider_nuget_sdk_version=2021.1.0-eap02
 
 rider_test_local_env_run=true

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -4,17 +4,17 @@ javaVersion=11
 org.gradle.jvmargs='-Duser.language=en'
 sources=false
 
-intellij_version=IC-2020.3
-rider_version=RD-2021.1-SNAPSHOT
+intellij_version=IC-211.4961.30-EAP-SNAPSHOT
+rider_version=RD-2021.1-EAP1-SNAPSHOT
 build_common_code_with=rider
 
 rider_backend_build_configuration=Debug
 
-dep_plugins=org.intellij.scala:2020.3.3
+dep_plugins=org.intellij.scala:2021.1.5
 applicationinsights.key=57cc111a-36a8-44b3-b044-25d293b8b77c
 
 updateVersionRange=false
-patchPluginXmlSinceBuild=203.3645.1
+patchPluginXmlSinceBuild=211.4961.4
 
 kotlin_version=1.4.20
 jackson_kotlin_version=2.11.0
@@ -26,6 +26,6 @@ assertj_version=3.15.0
 lombok_version=1.18.8
 
 rd_version=0.211.195
-rider_nuget_sdk_version=2020.3.0
+rider_nuget_sdk_version=2021.1.0-eap01
 
 rider_test_local_env_run=true

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Daemon/RunMarkers/FunctionAppRunMarkerProvider.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Daemon/RunMarkers/FunctionAppRunMarkerProvider.cs
@@ -49,9 +49,11 @@ namespace JetBrains.ReSharper.Azure.Daemon.RunMarkers
 
                 var range = declaration.GetNameDocumentRange();
 
-                var highlighting = new RunMarkerHighlighting(declaration,
-                    FunctionAppRunMarkerAttributeIds.FUNCTION_APP_RUN_METHOD_MARKER_ID, range,
-                    file.GetPsiModule().TargetFrameworkId);
+                var highlighting = new RunMarkerHighlighting(
+                    method: declaration.DeclaredElement,
+                    declaration: declaration,
+                    attributeId: FunctionAppRunMarkerAttributeIds.FUNCTION_APP_RUN_METHOD_MARKER_ID, range: range,
+                    targetFrameworkId: file.GetPsiModule().TargetFrameworkId);
 
                 consumer.AddHighlighting(highlighting, range);
             }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/LiveTemplates/RiderAzureFSharpFileTemplatesOptionPage.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/LiveTemplates/RiderAzureFSharpFileTemplatesOptionPage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 JetBrains s.r.o.
+﻿// Copyright (c) 2021 JetBrains s.r.o.
 // <p/>
 // All rights reserved.
 // <p/>
@@ -18,68 +18,24 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
-using System.Collections.Generic;
-using JetBrains.Application;
 using JetBrains.Application.UI.Options;
 using JetBrains.Application.UI.Options.OptionsDialog;
 using JetBrains.IDE.UI;
 using JetBrains.Lifetimes;
-using JetBrains.ProjectModel;
 using JetBrains.ProjectModel.Resources;
+using JetBrains.ReSharper.Azure.Intellisense.FunctionApp.LiveTemplates.Scope;
 using JetBrains.ReSharper.Feature.Services.LiveTemplates.Scope;
 using JetBrains.ReSharper.Feature.Services.LiveTemplates.Settings;
 using JetBrains.ReSharper.LiveTemplates.UI;
 
-namespace JetBrains.ReSharper.Azure.Intellisense.FunctionApp.LiveTemplates.Scope
+namespace JetBrains.ReSharper.Azure.Intellisense.FunctionApp.LiveTemplates
 {
-    public class InAzureFunctionsFSharpProject : InAzureFunctionsProject
-    {
-        private static readonly Guid ourDefaultGuid = new Guid("6EAE234E-60AA-410E-B021-D219A2478F98");
-
-        public override Guid GetDefaultUID() => ourDefaultGuid;
-        public override string PresentableShortName => "Azure Functions (F#) projects";
-    }
-
-    [ShellComponent]
-    public class AzureFSharpScopeProvider : AzureProjectScopeProvider
-    {
-        public AzureFSharpScopeProvider()
-        {
-            Creators.Add(TryToCreate<InAzureFunctionsFSharpProject>);
-        }
-
-        protected override IEnumerable<ITemplateScopePoint> GetLanguageSpecificScopePoints(IProject project)
-        {
-            var baseItems = base.GetLanguageSpecificScopePoints(project);
-            foreach (var item in baseItems) yield return item;
-            if (project.ProjectProperties.GetType().Name == "FSharpProjectProperties") // TODO: reconsider after possibly adding a direct dependency on F# plugin in #392
-                yield return new InAzureFunctionsFSharpProject();
-        }
-    }
-
-    [ScopeCategoryUIProvider(Priority = -41.0, ScopeFilter = ScopeFilter.Project)]
-    public class AzureFSharpProjectScopeCategoryUiProvider : ScopeCategoryUIProvider
-    {
-        public AzureFSharpProjectScopeCategoryUiProvider() : base(ProjectModelThemedIcons.Fsharp.Id)
-        {
-            MainPoint = new InAzureFunctionsFSharpProject();
-        }
-
-        public override IEnumerable<ITemplateScopePoint> BuildAllPoints()
-        {
-            yield return new InAzureFunctionsFSharpProject();
-        }
-
-        public override string CategoryCaption => "Azure (F#)";
-    }
-
     [OptionsPage("RiderAzureFSharpFileTemplatesSettings", "F#", typeof(ProjectModelThemedIcons.Fsharp))]
     public class RiderAzureFSharpFileTemplatesOptionPage : RiderFileTemplatesOptionPageBase
     {
         public RiderAzureFSharpFileTemplatesOptionPage(Lifetime lifetime, OptionsPageContext optionsPageContext,
             OptionsSettingsSmartContext settings, StoredTemplatesProvider storedTemplatesProvider,
-            AzureFSharpProjectScopeCategoryUiProvider uiProvider, ScopeCategoryManager scopeCategoryManager,
+            AzureFSharpProjectScopeCategoryUIProvider uiProvider, ScopeCategoryManager scopeCategoryManager,
             TemplatesUIFactory uiFactory, IconHostBase iconHost, IDialogHost dialogHost) : base(lifetime, uiProvider,
             optionsPageContext, settings,
             storedTemplatesProvider, scopeCategoryManager, uiFactory, iconHost, dialogHost,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/LiveTemplates/Scope/AzureCSharpProjectScopeProvider.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/LiveTemplates/Scope/AzureCSharpProjectScopeProvider.cs
@@ -22,44 +22,31 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Application;
 using JetBrains.ProjectModel;
-using JetBrains.ReSharper.Azure.Project.FunctionApp;
-using JetBrains.ReSharper.Feature.Services.LiveTemplates.Context;
+using JetBrains.ProjectModel.Properties;
 using JetBrains.ReSharper.Feature.Services.LiveTemplates.Scope;
 
 namespace JetBrains.ReSharper.Azure.Intellisense.FunctionApp.LiveTemplates.Scope
 {
-    public class InAzureFunctionsProject : InAnyProject
+    public class InAzureFunctionsCSharpProject : InAzureFunctionsProject
     {
-        private static readonly Guid DefaultGuid = new Guid("41A8B8D2-2DE7-43F8-A812-220E5BC95BEB");
+        private static readonly Guid DefaultGuid = new Guid("CF6B0FD8-3787-41DE-AD81-D0B5AE9CBFA3");
     
         public override Guid GetDefaultUID() => DefaultGuid;
-        public override string PresentableShortName => "Azure Functions projects";
+        public override string PresentableShortName => "Azure Functions (C#) projects";
     }
-    
+
     [ShellComponent]
-    public class AzureProjectScopeProvider : ScopeProvider
+    public class AzureCSharpProjectScopeProvider : AzureProjectScopeProvider
     {
-        public AzureProjectScopeProvider()
+        public AzureCSharpProjectScopeProvider()
         {
-            Creators.Add(TryToCreate<InAzureFunctionsProject>);
+            Creators.Add(TryToCreate<InAzureFunctionsCSharpProject>);
         }
 
-        public override IEnumerable<ITemplateScopePoint> ProvideScopePoints(TemplateAcceptanceContext context)
+        protected override IEnumerable<ITemplateScopePoint> GetLanguageSpecificScopePoints(IProject project)
         {
-            var project = context.GetProject();
-            if (project == null) yield break;
-            if (FunctionAppProjectDetector.IsAzureFunctionsProject(project)) 
-            {
-                yield return new InAzureFunctionsProject();
-        
-                foreach (var scope in GetLanguageSpecificScopePoints(project)) 
-                    yield return scope;
-            }
-        }
-
-        protected virtual IEnumerable<ITemplateScopePoint> GetLanguageSpecificScopePoints(IProject project)
-        {
-            yield break;
+            var language = project.ProjectProperties.DefaultLanguage;
+            if (language == ProjectLanguage.CSHARP) yield return new InAzureFunctionsCSharpProject();
         }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/LiveTemplates/Scope/AzureFSharpProjectScopeCategoryUIProvider.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/LiveTemplates/Scope/AzureFSharpProjectScopeCategoryUIProvider.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) 2021 JetBrains s.r.o.
+// <p/>
+// All rights reserved.
+// <p/>
+// MIT License
+// <p/>
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// <p/>
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+// the Software.
+// <p/>
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
+using JetBrains.ProjectModel.Resources;
+using JetBrains.ReSharper.Feature.Services.LiveTemplates.Scope;
+
+namespace JetBrains.ReSharper.Azure.Intellisense.FunctionApp.LiveTemplates.Scope
+{
+    [ScopeCategoryUIProvider(Priority = -41.0, ScopeFilter = ScopeFilter.Project)]
+    public class AzureFSharpProjectScopeCategoryUIProvider : ScopeCategoryUIProvider
+    {
+        public AzureFSharpProjectScopeCategoryUIProvider() : base(ProjectModelThemedIcons.Fsharp.Id)
+        {
+            MainPoint = new InAzureFunctionsFSharpProject();
+        }
+
+        public override IEnumerable<ITemplateScopePoint> BuildAllPoints()
+        {
+            yield return new InAzureFunctionsFSharpProject();
+        }
+
+        public override string CategoryCaption => "Azure (F#)";
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/LiveTemplates/Scope/AzureFSharpProjectScopeProvider.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/LiveTemplates/Scope/AzureFSharpProjectScopeProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 JetBrains s.r.o.
+// Copyright (c) 2021 JetBrains s.r.o.
 // <p/>
 // All rights reserved.
 // <p/>
@@ -22,44 +22,33 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Application;
 using JetBrains.ProjectModel;
-using JetBrains.ReSharper.Azure.Project.FunctionApp;
-using JetBrains.ReSharper.Feature.Services.LiveTemplates.Context;
 using JetBrains.ReSharper.Feature.Services.LiveTemplates.Scope;
 
 namespace JetBrains.ReSharper.Azure.Intellisense.FunctionApp.LiveTemplates.Scope
 {
-    public class InAzureFunctionsProject : InAnyProject
+    public class InAzureFunctionsFSharpProject : InAzureFunctionsProject
     {
-        private static readonly Guid DefaultGuid = new Guid("41A8B8D2-2DE7-43F8-A812-220E5BC95BEB");
-    
-        public override Guid GetDefaultUID() => DefaultGuid;
-        public override string PresentableShortName => "Azure Functions projects";
+        private static readonly Guid ourDefaultGuid = new Guid("6EAE234E-60AA-410E-B021-D219A2478F98");
+
+        public override Guid GetDefaultUID() => ourDefaultGuid;
+        public override string PresentableShortName => "Azure Functions (F#) projects";
     }
-    
+
     [ShellComponent]
-    public class AzureProjectScopeProvider : ScopeProvider
+    public class AzureFSharpScopeProvider : AzureCSharpProjectScopeProvider
     {
-        public AzureProjectScopeProvider()
+        public AzureFSharpScopeProvider()
         {
-            Creators.Add(TryToCreate<InAzureFunctionsProject>);
+            Creators.Add(TryToCreate<InAzureFunctionsFSharpProject>);
         }
 
-        public override IEnumerable<ITemplateScopePoint> ProvideScopePoints(TemplateAcceptanceContext context)
+        protected override IEnumerable<ITemplateScopePoint> GetLanguageSpecificScopePoints(IProject project)
         {
-            var project = context.GetProject();
-            if (project == null) yield break;
-            if (FunctionAppProjectDetector.IsAzureFunctionsProject(project)) 
-            {
-                yield return new InAzureFunctionsProject();
-        
-                foreach (var scope in GetLanguageSpecificScopePoints(project)) 
-                    yield return scope;
-            }
-        }
+            var baseItems = base.GetLanguageSpecificScopePoints(project);
+            foreach (var item in baseItems) yield return item;
 
-        protected virtual IEnumerable<ITemplateScopePoint> GetLanguageSpecificScopePoints(IProject project)
-        {
-            yield break;
+            if (project.ProjectProperties.GetType().Name == "FSharpProjectProperties") // TODO: reconsider after possibly adding a direct dependency on F# plugin in #392
+                yield return new InAzureFunctionsFSharpProject();
         }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Project/FunctionApp/FunctionAppProjectDetector.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Project/FunctionApp/FunctionAppProjectDetector.cs
@@ -25,6 +25,7 @@ using JetBrains.ProjectModel.Assemblies.Interfaces;
 using JetBrains.ProjectModel.MSBuild;
 using JetBrains.ProjectModel.Properties;
 using JetBrains.ProjectModel.Properties.Managed;
+using JetBrains.ReSharper.Host.Features.ProjectModel.TargetFrameworks;
 using JetBrains.Rider.Model;
 using JetBrains.Util;
 using JetBrains.Util.Dotnet.TargetFrameworkIds;
@@ -59,13 +60,14 @@ namespace JetBrains.ReSharper.Azure.Project.FunctionApp
                     continue;
                 }
 
-                var frameworkName = tfm.PresentableString;
                 var projectOutputPath = project.GetOutputFilePath(tfm);
-                projectOutputs.Add(new ProjectOutput(frameworkName,
-                    projectOutputPath.NormalizeSeparators(FileSystemPathEx.SeparatorStyle.Unix),
-                    new List<string>(),
-                    projectOutputPath.Directory.NormalizeSeparators(FileSystemPathEx.SeparatorStyle.Unix),
-                    string.Empty));
+                projectOutputs.Add(new ProjectOutput(
+                    tfm: tfm.ToRdTargetFrameworkInfo(),
+                    exePath: projectOutputPath.NormalizeSeparators(FileSystemPathEx.SeparatorStyle.Unix),
+                    defaultArguments: new List<string>(),
+                    workingDirectory: projectOutputPath.Directory.NormalizeSeparators(FileSystemPathEx.SeparatorStyle.Unix),
+                    dotNetCorePlatformRoot: string.Empty,
+                    configuration: null));
             }
 
             return projectOutputs;

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -24,7 +24,7 @@
       <html>
         <p>[3.40.0-2021.1]</p>
         <ul>
-          <li>Compatibility with Rider 2021.1 EAP 1</li>
+          <li>Compatibility with Rider 2021.1 EAP2</li>
         </ul>
         <h4>Fixed bugs:</h4>
         <ul>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -200,6 +200,10 @@
                          instance="org.jetbrains.plugins.azure.functions.settings.templates.RiderAzureCSharpFileTemplatesOptionPage"
                          groupWeight="-150" />
 
+    <projectConfigurable parentId="FileTemplatesSettingsId"
+                         instance="org.jetbrains.plugins.azure.functions.settings.templates.RiderAzureFSharpFileTemplatesOptionPage"
+                         groupWeight="-150" />
+
     <configurationType implementation="com.microsoft.intellij.runner.webapp.config.RiderWebAppConfigurationType"/>
     <programRunner implementation="com.microsoft.intellij.runner.webapp.config.RiderWebAppRunner"/>
     <rider.publishConfigurationProvider implementation="com.microsoft.intellij.runner.webapp.WebAppContextPublishProvider" order="last" />

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -24,7 +24,7 @@
       <html>
         <p>[3.40.0-2021.1]</p>
         <ul>
-          <li>Compatibility with Rider 2021.1 EAP</li>
+          <li>Compatibility with Rider 2021.1 EAP 1</li>
         </ul>
         <h4>Fixed bugs:</h4>
         <ul>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/icons/RiderIconsPatcher.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/icons/RiderIconsPatcher.kt
@@ -47,7 +47,7 @@ internal class RiderIconsPatcher : IconPathPatcher() {
         else originalClassLoader
 
     private val myIconsOverrideMap = mapOf(
-            "/resharper/FunctionAppRunMarkers/RunFunctionApp.svg" to "CommonIcons.AzureFunctions.FunctionAppRunConfiguration",
-            "/resharper/FunctionAppRunMarkers/Trigger.svg" to "RestClientIcons.Http_requests_filetype"
+            "resharper/FunctionAppRunMarkers/RunFunctionApp.svg" to "CommonIcons.AzureFunctions.FunctionAppRunConfiguration",
+            "resharper/FunctionAppRunMarkers/Trigger.svg" to "RestClientIcons.Http_requests_filetype"
     )
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/terminal/AzureCloudTerminalRunner.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/terminal/AzureCloudTerminalRunner.kt
@@ -37,6 +37,7 @@ import org.jetbrains.plugins.azure.cloudshell.controlchannel.CloudConsoleControl
 import org.jetbrains.plugins.azure.cloudshell.rest.CloudConsoleService
 import org.jetbrains.plugins.terminal.cloud.CloudTerminalProcess
 import org.jetbrains.plugins.terminal.cloud.CloudTerminalRunner
+import java.awt.Dimension
 import java.net.URI
 
 class AzureCloudTerminalRunner(project: Project,
@@ -79,14 +80,15 @@ class AzureCloudTerminalRunner(project: Project,
 
         // Build TTY
         val connector = object : AzureCloudProcessTtyConnector(process) {
-            override fun resizeImmediately() {
-                if (pendingTermSize != null) {
-                    val resizeResult = cloudConsoleService.resizeTerminal(
-                            resizeTerminalUrl, pendingTermSize.width, pendingTermSize.height).execute()
 
-                    if (!resizeResult.isSuccessful) {
-                        logger.error("Could not resize cloud terminal. Response received from API: ${resizeResult.code()} ${resizeResult.message()} - ${resizeResult.errorBody()?.string()}")
-                    }
+            override fun resize(termWinSize: Dimension) {
+                if (!this.isConnected) return
+
+                val resizeResult = cloudConsoleService.resizeTerminal(
+                        resizeTerminalUrl, termWinSize.width, termWinSize.height).execute()
+
+                if (!resizeResult.isSuccessful) {
+                    logger.error("Could not resize cloud terminal. Response received from API: ${resizeResult.code()} ${resizeResult.message()} - ${resizeResult.errorBody()?.string()}")
                 }
             }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/daemon/FunctionAppDaemonHost.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/daemon/FunctionAppDaemonHost.kt
@@ -160,7 +160,7 @@ class FunctionAppDaemonHost(project: Project) : LifetimedProjectComponent(projec
 
         configuration.parameters.projectFilePath = prjToConfigure.projectFilePath
         configuration.parameters.projectKind = prjToConfigure.kind
-        configuration.parameters.projectTfm = projectOutput?.tfm ?: ""
+        configuration.parameters.projectTfm = projectOutput?.tfm?.presentableName ?: ""
         configuration.parameters.exePath = projectOutput?.exePath ?: ""
         configuration.parameters.programParameters = ParametersListUtil.join(projectOutput?.defaultArguments
                 ?: listOf())

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/FunctionsCoreToolsTemplatesProvider.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/FunctionsCoreToolsTemplatesProvider.kt
@@ -58,7 +58,7 @@ class FunctionsCoreToolsTemplatesProvider : RiderProjectTemplateProvider {
 
     private class InstallTemplates : RiderProjectTemplate {
         override val group: String?
-            get() = ".NET Core"
+            get() = ".NET / .NET Core"
         override val name: String
             get() = "Azure Functions"
         override val icon: Icon

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsDotNetCoreDebugProfile.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsDotNetCoreDebugProfile.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2020 JetBrains s.r.o.
+ * Copyright (c) 2019-2021 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -38,9 +38,6 @@ import com.jetbrains.rider.model.debuggerWorker.DotNetCoreExeStartInfo
 import com.jetbrains.rider.model.debuggerWorker.DotNetCoreInfo
 import com.jetbrains.rider.run.*
 import com.jetbrains.rider.runtime.DotNetExecutable
-import org.jetbrains.concurrency.AsyncPromise
-import org.jetbrains.concurrency.Promise
-import org.jetbrains.concurrency.resolvedPromise
 
 class AzureFunctionsDotNetCoreDebugProfile(
         private val dotNetExecutable: DotNetExecutable,
@@ -88,19 +85,17 @@ class AzureFunctionsDotNetCoreDebugProfile(
         dotNetExecutable.validate()
     }
 
-    override fun createModelStartInfoAsync(lifetime: Lifetime): Promise<DebuggerStartInfoBase> {
-        return AsyncPromise<DebuggerStartInfoBase>().apply {
-            setResult(DotNetCoreExeStartInfo(
-                    DotNetCoreInfo(coreToolsExecutablePath, funcCoreToolsPath),
-                    dotNetExecutable.exePath, dotNetExecutable.workingDirectory,
-                    dotNetExecutable.programParameterString,
-                    dotNetExecutable.environmentVariables.toModelMap, dotNetExecutable.runtimeArguments,
-                    dotNetExecutable.executeAsIs, dotNetExecutable.useExternalConsole, false))
-        }
-    }
-
-    override fun createModelStartInfo(): DebuggerStartInfoBase {
-        throw IllegalStateException("Should not get there. Call async version.")
+    override suspend fun createModelStartInfo(lifetime: Lifetime): DebuggerStartInfoBase {
+        return DotNetCoreExeStartInfo(
+                DotNetCoreInfo(coreToolsExecutablePath),
+                dotNetExecutable.exePath,
+                dotNetExecutable.workingDirectory,
+                dotNetExecutable.programParameterString,
+                dotNetExecutable.environmentVariables.toModelMap,
+                dotNetExecutable.runtimeArguments,
+                dotNetExecutable.executeAsIs,
+                dotNetExecutable.useExternalConsole,
+                false)
     }
 
     override val attached: Boolean = false

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationParameters.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationParameters.kt
@@ -124,7 +124,7 @@ open class AzureFunctionsHostConfigurationParameters(
 
         return DotNetExecutable(
                 exePath = coreToolsInfo!!.coreToolsExecutable,
-                projectTfm = projectOutput?.tfm ?: projectTfm,
+                projectTfm = projectOutput?.tfm,
                 workingDirectory = effectiveWorkingDirectory,
                 programParameterString = effectiveArguments,
                 useMonoRuntime = useMonoRuntime,
@@ -172,7 +172,7 @@ open class AzureFunctionsHostConfigurationParameters(
     }
 
     private fun tryGetProjectOutput(runnableProject: RunnableProject): ProjectOutput? {
-        return runnableProject.projectOutputs.singleOrNull { it.tfm == projectTfm }
+        return runnableProject.projectOutputs.singleOrNull { it.tfm?.presentableName == projectTfm }
                 ?: runnableProject.projectOutputs.firstOrNull()
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationViewModel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationViewModel.kt
@@ -280,7 +280,7 @@ class AzureFunctionsHostConfigurationViewModel(
                     val fakeProject = RunnableProject(
                             fakeProjectName, fakeProjectName, projectFilePath, RunnableProjectKind.Unloaded,
                             listOf(ProjectOutput(RdTargetFrameworkId("", projectTfm, false, false), exePath,
-                                    ParametersListUtil.parse(programParameters), workingDirectory, "")),
+                                    ParametersListUtil.parse(programParameters), workingDirectory, "", null)),
                             envs.map { EnvironmentVariable(it.key, it.value) }.toList(), null, listOf()
                     )
                     projectSelector.projectList.apply {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationViewModel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostConfigurationViewModel.kt
@@ -113,7 +113,7 @@ class AzureFunctionsHostConfigurationViewModel(
 
     private fun handleChangeTfmSelection() {
         projectSelector.project.valueOrNull?.projectOutputs
-                ?.singleOrNull { it.tfm == tfmSelector.string.valueOrNull }
+                ?.singleOrNull { it.tfm?.presentableName == tfmSelector.string.valueOrNull }
                 ?.let { projectOutput ->
                     val shouldChangeExePath = trackProjectExePath
                     val shouldChangeWorkingDirectory = trackProjectWorkingDirectory
@@ -149,7 +149,7 @@ class AzureFunctionsHostConfigurationViewModel(
 
         val programParameters = programParametersEditor.parametersString.value
 
-        selectedProject.projectOutputs.singleOrNull { it.tfm == selectedTfm }?.let { projectOutput ->
+        selectedProject.projectOutputs.singleOrNull { it.tfm?.presentableName == selectedTfm }?.let { projectOutput ->
             trackProjectExePath = exePathSelector.path.value == projectOutput.exePath
 
             val defaultArguments = projectOutput.defaultArguments
@@ -195,7 +195,7 @@ class AzureFunctionsHostConfigurationViewModel(
 
     private fun reloadTfmSelector(runnableProject: RunnableProject) {
         tfmSelector.stringList.clear()
-        runnableProject.projectOutputs.map { it.tfm }.sorted().forEach {
+        runnableProject.projectOutputs.map { it.tfm?.presentableName ?: "" }.sorted().forEach {
             tfmSelector.stringList.add(it)
         }
         if (tfmSelector.stringList.isNotEmpty()) {
@@ -279,7 +279,8 @@ class AzureFunctionsHostConfigurationViewModel(
                     val fakeProjectName = File(projectFilePath).name
                     val fakeProject = RunnableProject(
                             fakeProjectName, fakeProjectName, projectFilePath, RunnableProjectKind.Unloaded,
-                            listOf(ProjectOutput(projectTfm, exePath, ParametersListUtil.parse(programParameters), workingDirectory, "")),
+                            listOf(ProjectOutput(RdTargetFrameworkId("", projectTfm, false, false), exePath,
+                                    ParametersListUtil.parse(programParameters), workingDirectory, "")),
                             envs.map { EnvironmentVariable(it.key, it.value) }.toList(), null, listOf()
                     )
                     projectSelector.projectList.apply {
@@ -301,12 +302,12 @@ class AzureFunctionsHostConfigurationViewModel(
 
                     // Set TFM
                     reloadTfmSelector(runnableProject)
-                    val projectTfmExists = runnableProject.projectOutputs.any { it.tfm == projectTfm }
-                    val selectedTfm = if (projectTfmExists) projectTfm else runnableProject.projectOutputs.firstOrNull()?.tfm ?: ""
+                    val projectTfmExists = runnableProject.projectOutputs.any { it.tfm?.presentableName == projectTfm }
+                    val selectedTfm = if (projectTfmExists) projectTfm else runnableProject.projectOutputs.firstOrNull()?.tfm?.presentableName ?: ""
                     tfmSelector.string.set(selectedTfm)
 
                     // Set Project Output
-                    val projectOutput = runnableProject.projectOutputs.singleOrNull { it.tfm == selectedTfm }
+                    val projectOutput = runnableProject.projectOutputs.singleOrNull { it.tfm?.presentableName == selectedTfm }
                     val effectiveExePath = if (trackProjectExePath && projectOutput != null) projectOutput.exePath else exePath
                     val effectiveProgramParameters =
                             if (trackProjectArguments && projectOutput != null && projectOutput.defaultArguments.isNotEmpty())

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostRunConfigurationProducer.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsHostRunConfigurationProducer.kt
@@ -76,7 +76,7 @@ class AzureFunctionsHostRunConfigurationProducer
         }
         configuration.parameters.apply {
             projectFilePath = selectedProjectFilePathInvariant
-            projectTfm = runnableProject.projectOutputs.firstOrNull()?.tfm ?: projectTfm
+            projectTfm = runnableProject.projectOutputs.firstOrNull()?.tfm?.presentableName ?: projectTfm
         }
 
         return true

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/settings/templates/RiderAzureFSharpFileTemplatesOptionPage.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/settings/templates/RiderAzureFSharpFileTemplatesOptionPage.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 JetBrains s.r.o.
+ * Copyright (c) 2021 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -25,7 +25,6 @@ package org.jetbrains.plugins.azure.functions.settings.templates
 import com.intellij.openapi.options.Configurable
 import com.jetbrains.rider.settings.simple.SimpleOptionsPage
 
-class RiderAzureCSharpFileTemplatesOptionPage: SimpleOptionsPage("Azure (C#)", "RiderAzureCSharpFileTemplatesSettings"), Configurable.NoScroll {
+class RiderAzureFSharpFileTemplatesOptionPage: SimpleOptionsPage("Azure (F#)", "RiderAzureFSharpFileTemplatesSettings"), Configurable.NoScroll {
     override fun getId() = pageId + "Id"
 }
-

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationTest.kt
@@ -32,7 +32,7 @@ import com.jetbrains.rider.model.runnableProjectsModel
 import com.jetbrains.rider.projectView.solution
 import com.jetbrains.rider.test.annotations.TestEnvironment
 import com.jetbrains.rider.test.asserts.shouldBe
-import com.jetbrains.rider.test.asserts.shouldContain
+import com.jetbrains.rider.test.asserts.shouldContains
 import com.jetbrains.rider.test.base.BaseTestWithSolution
 import com.jetbrains.rider.test.enums.CoreVersion
 import com.jetbrains.rider.test.scriptingApi.*
@@ -156,8 +156,8 @@ class FunctionHostConfigurationTest : BaseTestWithSolution() {
     }
 
     private fun assertBuildCompleteMessage(projectName: String, buildOutput: String) {
-        buildOutput.shouldContain("------- Started building project: $projectName")
-        buildOutput.shouldContain("------- Finished building project: $projectName. Succeeded: True.")
-        buildOutput.shouldContain("Build completed in")
+        buildOutput.shouldContains("------- Started building project: $projectName")
+        buildOutput.shouldContains("------- Finished building project: $projectName. Succeeded: True.")
+        buildOutput.shouldContains("Build completed in")
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test-integration/org/cases/runconfig/functionapp/FunctionHostConfigurationTest.kt
@@ -114,7 +114,7 @@ class FunctionHostConfigurationTest : BaseTestWithSolution() {
         configuration.parameters.projectFilePath = projectToRun.projectFilePath
         configuration.parameters.workingDirectory = projectToRun.projectOutputs.first().workingDirectory
         configuration.parameters.exePath = projectToRun.projectOutputs.first().exePath
-        configuration.parameters.projectTfm = projectToRun.projectOutputs.first().tfm
+        configuration.parameters.projectTfm = projectToRun.projectOutputs.first().tfm?.presentableName ?: ""
 
         configuration.beforeRunTasks.size.shouldBe(1)
         configuration.beforeRunTasks[0].providerId.shouldBe(BuildFunctionsProjectBeforeRunTaskProvider.providerId)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/org/jetbrains/plugins/azure/functions/run/AzureFunctionsRunnableProjectUtilTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/org/jetbrains/plugins/azure/functions/run/AzureFunctionsRunnableProjectUtilTest.kt
@@ -1,18 +1,18 @@
 /**
- * Copyright (c) 2020 JetBrains s.r.o.
- * <p/>
+ * Copyright (c) 2020-2021 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
@@ -23,6 +23,7 @@
 package org.jetbrains.plugins.azure.functions.run
 
 import com.jetbrains.rider.model.ProjectOutput
+import com.jetbrains.rider.model.RdTargetFrameworkId
 import com.jetbrains.rider.test.asserts.shouldBe
 import org.testng.annotations.Test
 import java.io.File
@@ -32,14 +33,19 @@ class AzureFunctionsRunnableProjectUtilTest {
     @Test
     fun testPatchProjectOutput_DefaultArguments_Defaults() {
         val projectOutput = ProjectOutput(
-                tfm = ".NetFramework 4.7.1",
+                tfm = RdTargetFrameworkId(
+                        shortName = "net471",
+                        presentableName = ".NetFramework 4.7.1",
+                        isNetCoreApp = false,
+                        isNetFramework = true),
                 exePath = "/path/to/executable",
                 defaultArguments = emptyList(),
                 workingDirectory = "/path/to/working/dir",
-                dotNetCorePlatformRoot = "/root")
+                dotNetCorePlatformRoot = "/root",
+                configuration = null)
 
         val patched = AzureFunctionsRunnableProjectUtil.patchProjectOutput(projectOutput)
-        patched.tfm.shouldBe(".NetFramework 4.7.1")
+        patched.tfm?.presentableName.shouldBe(".NetFramework 4.7.1")
         patched.exePath.shouldBe("/path/to/executable")
         patched.defaultArguments.shouldBe(listOf("host", "start", "--pause-on-error"))
         patched.workingDirectory.shouldBe("/path/to/working/dir")
@@ -49,11 +55,16 @@ class AzureFunctionsRunnableProjectUtilTest {
     @Test
     fun testPatchProjectOutput_DefaultArguments_SkipExistingArguments() {
         val projectOutput = ProjectOutput(
-                tfm = "",
+                tfm = RdTargetFrameworkId(
+                        shortName = "",
+                        presentableName = "",
+                        isNetCoreApp = false,
+                        isNetFramework = false),
                 exePath = "",
                 defaultArguments = listOf("customArgument"),
                 workingDirectory = "",
-                dotNetCorePlatformRoot = "")
+                dotNetCorePlatformRoot = "",
+                configuration = null)
 
         val patched = AzureFunctionsRunnableProjectUtil.patchProjectOutput(projectOutput)
         patched.defaultArguments.shouldBe(listOf("host", "start", "--pause-on-error"))
@@ -63,11 +74,16 @@ class AzureFunctionsRunnableProjectUtilTest {
     fun testPatchProjectOutput_WorkingDirectory_EndsWithBin() {
         val workingDir = File("this").resolve("is").resolve("working").resolve("dir").resolve("bin")
         val projectOutput = ProjectOutput(
-                tfm = "",
+                tfm = RdTargetFrameworkId(
+                        shortName = "",
+                        presentableName = "",
+                        isNetCoreApp = false,
+                        isNetFramework = false),
                 exePath = "",
                 defaultArguments = listOf(),
                 workingDirectory = workingDir.path,
-                dotNetCorePlatformRoot = "")
+                dotNetCorePlatformRoot = "",
+                configuration = null)
 
         val patched = AzureFunctionsRunnableProjectUtil.patchProjectOutput(projectOutput)
         patched.workingDirectory.shouldBe(workingDir.parent + File.separator)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/org/jetbrains/plugins/azure/functions/run/HostJsonPatcherTest.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/test/kotlin/org/jetbrains/plugins/azure/functions/run/HostJsonPatcherTest.kt
@@ -27,7 +27,7 @@ import com.jetbrains.rdclient.util.idea.toIOFile
 import com.jetbrains.rider.test.asserts.shouldBe
 import com.jetbrains.rider.test.asserts.shouldBeFalse
 import com.jetbrains.rider.test.asserts.shouldBeTrue
-import com.jetbrains.rider.test.asserts.shouldContain
+import com.jetbrains.rider.test.asserts.shouldContains
 import org.testng.annotations.AfterMethod
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -193,7 +193,7 @@ class HostJsonPatcherTest {
             val errorStream = ByteArrayOutputStream()
             System.setErr(PrintStream(errorStream))
             action()
-            errorStream.toString().shouldContain(warnMessage)
+            errorStream.toString().shouldContains(warnMessage)
         } finally {
             System.setErr(originErr)
         }


### PR DESCRIPTION
Not sure about the removal of `javac2` path in `build.gradle` (seems fine, @sdubov, not sure if it was still needed...)