### PR TITLE
Fixed RIDER-58297. Hide Azure logs tool windows until requested

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -9,6 +9,10 @@
         <li>Compatibility with Rider 2021.1 EAP4</li>
         <li>Allow publishing to App Service with kind "API" (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/149">#149</a>)</li>
       </ul>
+      <h4>Bug fixes:</h4>
+      <ul>
+        <li>Show Azure tool windows on-demand (<a href="https://youtrack.jetbrains.com/issue/RIDER-58297">RIDER-58297</a>)</li>
+      </ul>
     </html>
     ]]>
   </change-notes>
@@ -29,12 +33,7 @@
   </extensionPoints>
 
   <extensions defaultExtensionNs="com.intellij">
-    <toolWindow
-          anchor="bottom"
-          factoryClass="com.microsoft.intellij.activitylog.ActivityLogToolWindowFactory"
-          id="Azure Activity Log"
-          canCloseContents="true"
-          icon="CommonIcons.ToolWindow.AzureLog" />
+    <postStartupActivity implementation="com.microsoft.intellij.activitylog.RegisterDeploymentListenerActivity"/>
 
     <projectService serviceImplementation="com.microsoft.intellij.AzureSettings"/>
 
@@ -67,13 +66,6 @@
           canCloseContents="false"
           icon="CommonIcons.ToolWindow.Azure"
           order="after Project" />
-
-    <toolWindow
-            anchor="bottom"
-            factoryClass="com.microsoft.intellij.helpers.StreamingLogsToolWindowFactory"
-            id="Azure Streaming Log"
-            icon="CommonIcons.ToolWindow.AzureStreamingLog"
-            canCloseContents="true"/>
 
     <fileTypeFactory implementation="com.microsoft.intellij.language.arm.file.ARMFileTypeFactory"/>
     <lang.syntaxHighlighterFactory language="arm"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/storage/azurite/AzuriteService.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/storage/azurite/AzuriteService.kt
@@ -1,18 +1,18 @@
 /**
- * Copyright (c) 2020 JetBrains s.r.o.
- * <p/>
+ * Copyright (c) 2020-2021 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/activitylog/RegisterDeploymentListenerActivity.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/activitylog/RegisterDeploymentListenerActivity.kt
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2021 JetBrains s.r.o.
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.intellij.activitylog
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vcs.changes.shelf.ShelveChangesManager
+
+class RegisterDeploymentListenerActivity : ShelveChangesManager.PostStartupActivity() {
+
+    override fun runActivity(project: Project) {
+        ActivityLogToolWindowFactory().registerDeploymentListener(project)
+    }
+}


### PR DESCRIPTION
* Add post startup activity tio register deployment listeners
* Replace all static Azure tool windows with registering tool windows on-demand