### PR TITLE
Surface Better Error Messages When Auth Fails

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -31,6 +31,8 @@
         <h4>Fixed bugs:</h4>
         <ul>
           <li>TimerTrigger also support TimeSpan string (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/434">#434</a>)</li>
+          <li>Device login - Subscription lookup improvements (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/452">#452</a>)</li>
+          <li>Better error messages when auth fails (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/438">#438</a>)</li>
         </ul>
         <p>[3.40.0-2020.3]</p>
         <ul>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/AzureSignInAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/AzureSignInAction.java
@@ -140,7 +140,7 @@ public class AzureSignInAction extends AzureAnAction {
             }
         } catch (Exception ex) {
             ex.printStackTrace();
-            ErrorWindow.show(project, ex.getMessage(), "AzureSignIn Action Error");
+            ErrorWindow.show(project, ex, "AzureSignIn Action Error");
         }
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/SelectSubscriptionsAction.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/actions/SelectSubscriptionsAction.java
@@ -91,7 +91,7 @@ public class SelectSubscriptionsAction extends AzureAnAction {
         }, (ex) -> {
             ex.printStackTrace();
             //LOGGER.error("onShowSubscriptions", ex);
-            ErrorWindow.show(project, ex.getMessage(), "Select Subscriptions Action Error");
+            ErrorWindow.show(project, ex, "Select Subscriptions Action Error");
         });
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/ErrorWindow.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/ErrorWindow.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) 2021 jetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -23,6 +24,8 @@
 package com.microsoft.azuretools.ijidea.ui;
 
 import com.intellij.openapi.project.Project;
+import com.microsoft.azuretools.adauth.AuthException;
+import com.microsoft.azuretools.authmanage.AuthExceptionUtil;
 import com.microsoft.intellij.ui.components.AzureDialogWrapper;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,10 +41,25 @@ public class ErrorWindow extends AzureDialogWrapper {
         show(project, message, title, null, null);
     }
 
-    public static void show(@Nullable Project project, String message, String title, String okButtonText, Runnable okAction){
+    public static void show(@Nullable Project project, String message, String title, String okButtonText, Runnable okAction) {
         ErrorWindow w = new ErrorWindow(project, message, title, okButtonText, okAction);
         w.show();
+    }
 
+    public static void show(@Nullable Project project, Exception exception, String title) {
+        show(project, exception, title, null, null);
+    }
+
+    public static void show(@Nullable Project project, Exception exception, String title, String okButtonText, Runnable okAction) {
+        String message = exception.getMessage();
+
+        final AuthException authException = AuthExceptionUtil.GetUserRetryableAuthException(exception);
+        if (authException != null) {
+            message += "\n\n" + authException.getErrorMessage();
+        }
+
+        ErrorWindow w = new ErrorWindow(project, message, title, okButtonText, okAction);
+        w.show();
     }
 
     protected ErrorWindow(@Nullable Project project, String message, String title){

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/ErrorWindow.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/ErrorWindow.java
@@ -53,7 +53,7 @@ public class ErrorWindow extends AzureDialogWrapper {
     public static void show(@Nullable Project project, Exception exception, String title, String okButtonText, Runnable okAction) {
         String message = exception.getMessage();
 
-        final AuthException authException = AuthExceptionUtil.GetUserRetryableAuthException(exception);
+        final AuthException authException = AuthExceptionUtil.getUserRetryableAuthException(exception);
         if (authException != null) {
             message += "\n\n" + authException.getErrorMessage();
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/RemoteDebuggingClientDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/RemoteDebuggingClientDialog.java
@@ -362,7 +362,7 @@ public class RemoteDebuggingClientDialog extends AzureDialogWrapper {
                     ApplicationManager.getApplication().invokeLater(new Runnable() {
                         @Override
                         public void run() {
-                            ErrorWindow.show(project, ex.getMessage(), title + "Error");
+                            ErrorWindow.show(project, ex, title + "Error");
                         }
                     });
                     try {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/SignInWindow.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/SignInWindow.java
@@ -288,7 +288,7 @@ public class SignInWindow extends AzureDialogWrapper {
             return dcAuthManager;
         } catch (Exception ex) {
             ex.printStackTrace();
-            ErrorWindow.show(project, ex.getMessage(), SIGN_IN_ERROR);
+            ErrorWindow.show(project, ex, SIGN_IN_ERROR);
         }
 
         return null;
@@ -310,7 +310,7 @@ public class SignInWindow extends AzureDialogWrapper {
                         } catch (Exception ex) {
                             EventUtil.logError(operation, ErrorType.userError, ex, properties, null);
                             ApplicationManager.getApplication().invokeLater(
-                                () -> ErrorWindow.show(project, ex.getMessage(), SIGN_IN_ERROR));
+                                () -> ErrorWindow.show(project, ex, SIGN_IN_ERROR));
                         } finally {
                             EventUtil.logEvent(EventType.info, operation, Collections.singletonMap(
                                     AZURE_ENVIRONMENT, CommonSettings.getEnvironment().getName()));
@@ -327,7 +327,7 @@ public class SignInWindow extends AzureDialogWrapper {
             AuthMethod.DC.getAdAuthManager().signOut();
         } catch (Exception ex) {
             ex.printStackTrace();
-            ErrorWindow.show(project, ex.getMessage(), "Sign Out Error");
+            ErrorWindow.show(project, ex, "Sign Out Error");
         }
     }
 
@@ -361,7 +361,7 @@ public class SignInWindow extends AzureDialogWrapper {
                         ApplicationManager.getApplication().invokeLater(new Runnable() {
                             @Override
                             public void run() {
-                                ErrorWindow.show(project, ex.getMessage(), "Load Subscription Error");
+                                ErrorWindow.show(project, ex, "Load Subscription Error");
                             }
                         });
 
@@ -415,7 +415,7 @@ public class SignInWindow extends AzureDialogWrapper {
         } catch (Exception ex) {
             ex.printStackTrace();
             //LOGGER.error("doCreateServicePrincipal", ex);
-            ErrorWindow.show(project, ex.getMessage(), "Get Subscription Error");
+            ErrorWindow.show(project, ex, "Get Subscription Error");
 
         } finally {
             if (dcAuthManager != null) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/SubscriptionsDialog.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azuretools/ijidea/ui/SubscriptionsDialog.java
@@ -131,7 +131,7 @@ public class SubscriptionsDialog extends AzureDialogWrapper {
         }, (ex) -> {
                 ex.printStackTrace();
                 //LOGGER.error("refreshSubscriptions", ex);
-                ErrorWindow.show(project, ex.getMessage(), "Refresh Subscriptions Error");
+                ErrorWindow.show(project, ex, "Refresh Subscriptions Error");
             });
     }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzurePlugin.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzurePlugin.java
@@ -428,6 +428,10 @@ public class AzurePlugin implements StartupActivity.DumbAware {
         LOG.error(message, ex);
     }
 
+    public static void logWarning(String message, Throwable ex) {
+        LOG.warn(message, ex);
+    }
+
     public static void log(String message) {
         LOG.info(message);
     }

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/AuthExceptionUtil.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/AuthExceptionUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 JetBrains s.r.o.
+ *
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.azuretools.authmanage;
+
+import com.microsoft.azuretools.adauth.AuthError;
+import com.microsoft.azuretools.adauth.AuthException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+@SuppressWarnings("unused")
+public final class AuthExceptionUtil {
+
+    /**
+     * When a Throwable is an AuthException that requires the user to re-authenticate,
+     * such as the one described in https://github.com/JetBrains/azure-tools-for-intellij/issues/438,
+     * returns the AuthException.
+     *
+     * @param throwable Throwable to check.
+     * @return When a Throwable is an AuthException that requires the user to re-authenticate, returns the AuthException. Returns null otherwise.
+     */
+    public static AuthException GetUserRetryableAuthException(Throwable throwable) {
+
+        final Throwable rootCause = ExceptionUtils.getRootCause(throwable);
+        if (rootCause instanceof AuthException) {
+            final AuthException authException = (AuthException) rootCause;
+
+            // See com/microsoft/azuretools/authmanage/AdAuthManager.java:74
+            // and com/microsoft/azuretools/authmanage/DCAuthManager.java:97
+            // for similar logic.
+            if (AuthError.InvalidGrant.equalsIgnoreCase(authException.getError()) ||
+                    AuthError.InteractionRequired.equalsIgnoreCase(authException.getError())) {
+
+                return authException;
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/AuthExceptionUtil.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/authmanage/AuthExceptionUtil.java
@@ -37,7 +37,7 @@ public final class AuthExceptionUtil {
      * @param throwable Throwable to check.
      * @return When a Throwable is an AuthException that requires the user to re-authenticate, returns the AuthException. Returns null otherwise.
      */
-    public static AuthException GetUserRetryableAuthException(Throwable throwable) {
+    public static AuthException getUserRetryableAuthException(Throwable throwable) {
 
         final Throwable rootCause = ExceptionUtils.getRootCause(throwable);
         if (rootCause instanceof AuthException) {

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/sdkmanage/AzureManagerBase.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/sdkmanage/AzureManagerBase.java
@@ -140,7 +140,11 @@ public abstract class AzureManagerBase implements AzureManager {
             } catch (final Exception e) {
                 // just skip for cases user failing to get subscriptions of tenants he/she has no permission to get access token.
                 // "AADSTS50076" is the code of a weired error related to multi-tenant configuration.
-                final Predicate<Throwable> tenantError = (c) -> c instanceof AuthException && ((AuthException) c).getErrorMessage().contains("AADSTS50076");
+                // "AADSTS50057" is the code of an error related to having a disabled account in the tenant.
+                final Predicate<Throwable> tenantError = (c) -> c instanceof AuthException &&
+                        (((AuthException) c).getErrorMessage().contains("AADSTS50076") ||
+                                ((AuthException) c).getErrorMessage().contains("AADSTS50057"));
+
                 if (e instanceof AzureRuntimeException && ((AzureRuntimeException) e).getCode() == ErrorEnum.FAILED_TO_GET_ACCESS_TOKEN.getErrorCode() ||
                     Throwables.getCausalChain(e).stream().anyMatch(tenantError)) {
                     // TODO: @wangmi better to notify user


### PR DESCRIPTION
Fixes #438
Fixes #452
Upstream fix https://github.com/microsoft/azure-tools-for-java/pull/4991

This PR shows more detailed error messages, and makes the experience a bit nicer when a token is no longer valid.

@sdubov we discussed showing the login form when the latter happens, but for now decided to not do that yet (not forcing a modal dialog onto people)