### PR TITLE
Docs: fix build instruction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@
     ```
 * Use Gradle to build the plugin
     ```
-    $ ./gradlew -b PluginsAndFeatures/azure-toolkit-for-intellij/build.gradle buildPlugin
+    $ cd PluginsAndFeatures/azure-toolkit-for-intellij
+    $ ./gradlew buildPlugin
     ```
     You can find the outputs under ```PluginsAndFeatures/azure-toolkit-for-intellij/build/distributions```
     


### PR DESCRIPTION
For me, current instructions don't work, because the root `gradlew` script is outdated.