### PR TITLE
Fix RIDER-57482: enable common Rider build throttling

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -26,6 +26,7 @@
         <ul>
           <li>Compatibility with Rider 2021.1 EAP8</li>
           <li>Allow publishing to App Service with kind "API" (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/149">#149</a>)</li>
+          <li>Enable build-throttling and support compound run configurations (<a href="https://youtrack.jetbrains.com/issue/RIDER-57482">RIDER-57482</a>)</li>
         </ul>
         <h4>Fixed bugs:</h4>
         <ul>


### PR DESCRIPTION
Rider cannot run several builds simultaneously, so there's a special component that orchestrates the build throttling in pre-launch tasks. The plugin should call this component when scheduling a build task, otherwise, the builds started from plugin won't work well inside of a compound task.