### PR TITLE
In CommandUtils.java, don't output error message when not needed

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -6,7 +6,7 @@
     <html>
       <h4>Bug fix:</h4>
       <ul>
-        <li>Fix Rider may hang on loading screen due to exception (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/459">#459</a>)</li>
+        <li>Don't output error message when not needed (<a href="https://github.com/JetBrains/azure-tools-for-intellij/pull/461">#461</a>)</li>
       </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -6,7 +6,7 @@
     <html>
       <h4>Bug fix:</h4>
       <ul>
-        <li>Fix Azure Toolkit for Rider: Deployment Slot setting is not saved (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/423">#423</a>)</li>
+        <li>Fix Rider may hang on loading screen due to exception (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/459">#459</a>)</li>
       </ul>
     </html>
     ]]>

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/utils/CommandUtils.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/utils/CommandUtils.java
@@ -120,7 +120,7 @@ public class CommandUtils {
         executor.setExitValues(null);
         try {
             executor.execute(commandLine);
-            if (!mergeErrorStream) {
+            if (!mergeErrorStream && err.size() > 0) {
                 logger.log(Level.SEVERE, err.toString());
             }
             return out.toString();


### PR DESCRIPTION
`211` version: https://github.com/JetBrains/azure-tools-for-intellij/pull/461
Upstream: https://github.com/microsoft/azure-tools-for-java/pull/5041