### PR TITLE
In CommandUtils.java, don't output error message when not needed

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -12,9 +12,9 @@
       </ul>
       <h4>Fixed bugs:</h4>
       <ul>
-        <li>TimerTrigger also support TimeSpan string (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/434">#434</a>)</li>
-        <li>Fix Rider may hang on loading screen due to exception (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/459">#459</a>)</li>
         <li>Show Azure tool windows on-demand (<a href="https://youtrack.jetbrains.com/issue/RIDER-58297">RIDER-58297</a>)</li>
+        <li>TimerTrigger also support TimeSpan string (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/434">#434</a>)</li>
+        <li>Don't output error message when not needed (<a href="https://github.com/JetBrains/azure-tools-for-intellij/pull/461">#461</a>)</li>
       </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -11,11 +11,9 @@
         <li>Enable build-throttling and support compound run configurations (<a href="https://youtrack.jetbrains.com/issue/RIDER-57482">RIDER-57482</a>)</li>
       </ul>
       <h4>Fixed bugs:</h4>
-        <ul>
-          <li>TimerTrigger also support TimeSpan string (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/434">#434</a>)</li>
-        </ul>
-      <h4>Bug fixes:</h4>
       <ul>
+        <li>TimerTrigger also support TimeSpan string (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/434">#434</a>)</li>
+        <li>Fix Rider may hang on loading screen due to exception (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/459">#459</a>)</li>
         <li>Show Azure tool windows on-demand (<a href="https://youtrack.jetbrains.com/issue/RIDER-58297">RIDER-58297</a>)</li>
       </ul>
     </html>

--- a/Utils/azuretools-core/src/com/microsoft/azuretools/utils/CommandUtils.java
+++ b/Utils/azuretools-core/src/com/microsoft/azuretools/utils/CommandUtils.java
@@ -120,7 +120,7 @@ public class CommandUtils {
         executor.setExitValues(null);
         try {
             executor.execute(commandLine);
-            if (!mergeErrorStream) {
+            if (!mergeErrorStream && err.size() > 0) {
                 logger.log(Level.SEVERE, err.toString());
             }
             return out.toString();


### PR DESCRIPTION
`203` version: https://github.com/JetBrains/azure-tools-for-intellij/pull/460
Upstream: https://github.com/microsoft/azure-tools-for-java/pull/5041