### PR TITLE
[Functions] Project template support for default and isolated worker templates

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/ProjectTemplates/DotNetExtensions/Groups/FunctionAppRuntimeGroupProvider.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/ProjectTemplates/DotNetExtensions/Groups/FunctionAppRuntimeGroupProvider.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) 2021 JetBrains s.r.o.
+//
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+// the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using JetBrains.Application;
+using JetBrains.ReSharper.Host.Features.ProjectModel.ProjectTemplates.DotNetExtensions;
+using Microsoft.TemplateEngine.Edge.Settings;
+
+namespace JetBrains.ReSharper.Azure.Intellisense.FunctionApp.ProjectTemplates.DotNetExtensions.Groups
+{
+    [ShellComponent]
+    public class FunctionAppRuntimeGroupProvider : IDotNetTemplateGroupProvider
+    {
+        public int Priority => 40;
+        
+        public IReadOnlyCollection<DotNetTemplateGroup> Get()
+        {
+            return new[] {new FunctionAppRuntimeGroup()};
+        }
+
+        private class FunctionAppRuntimeGroup : DotNetTemplateGroup
+        {
+            public FunctionAppRuntimeGroup() : base("Functions runtime", null)
+            {
+            }
+            
+            protected override bool ShowIfSingleTemplate => false;
+
+            protected override string GetOption(TemplateInfo info)
+            {
+                if (info.GroupIdentity == "Microsoft.AzureFunctions.ProjectTemplates")
+                {
+                    // Isolated worker known template identities:
+                    // * Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x
+                    // * Microsoft.AzureFunctions.ProjectTemplate.FSharp.Isolated.3.x
+                    if (info.Identity == "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x" || 
+                        info.Identity == "Microsoft.AzureFunctions.ProjectTemplate.FSharp.Isolated.3.x")
+                    {
+                        return "Isolated worker (.NET 5+)";
+                    }
+                    
+                    // Default worker known template identities:
+                    // * Microsoft.AzureFunctions.ProjectTemplate.CSharp.3.x
+                    // * Microsoft.AzureFunctions.ProjectTemplate.FSharp.3.x
+                    if (info.Identity == "Microsoft.AzureFunctions.ProjectTemplate.CSharp.3.x" || 
+                        info.Identity == "Microsoft.AzureFunctions.ProjectTemplate.FSharp.3.x")
+                    {
+                        return "Default worker";
+                    }
+                }
+                
+                return null;
+            }
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/FunctionsCoreToolsTemplateManager.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/projectTemplating/FunctionsCoreToolsTemplateManager.kt
@@ -1,18 +1,18 @@
 /**
- * Copyright (c) 2019-2020 JetBrains s.r.o.
- * <p/>
+ * Copyright (c) 2019-2021 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
@@ -47,19 +47,23 @@ object FunctionsCoreToolsTemplateManager {
         }
 
         // Add available templates
-        val templatesToBeRegisteredFolder = File(coreToolsInfo.coreToolsPath).resolve("templates")
-        if (templatesToBeRegisteredFolder.exists()) {
+        val templateFolders = listOf(
+                File(coreToolsInfo.coreToolsPath).resolve("templates"), // Default worker
+                File(coreToolsInfo.coreToolsPath).resolve("templates").resolve("net5-isolated") // Isolated worker
+        ).filter { it.exists() }
+
+        for (templateFolder in templateFolders) {
             try {
-                val templateFiles = templatesToBeRegisteredFolder.listFiles { f: File? -> isFunctionsProjectTemplate(f) }
+                val templateFiles = templateFolder.listFiles { f: File? -> isFunctionsProjectTemplate(f) }
                         ?: emptyArray<File>()
 
-                logger.info("Found ${templateFiles.size} function template(s)")
+                logger.info("Found ${templateFiles.size} function template(s) in ${templateFolder.path}")
 
                 templateFiles.forEach { file ->
                     ReSharperProjectTemplateProvider.addUserTemplateSource(file)
                 }
             } catch (e: Exception) {
-                logger.error("Could not register project templates from ${templatesToBeRegisteredFolder.path}", e)
+                logger.error("Could not register project templates from ${templateFolder.path}", e)
             }
         }
     }


### PR DESCRIPTION
Part of #413, and provides:
* Project template support for both default and isolated worker templates.

If you have an existing Rider installation, you may need to reload project templates in the new solution/new project dialog to make sure the isolated worker templates are loaded.

![image](https://user-images.githubusercontent.com/485230/115515478-7576c480-a285-11eb-8adf-63fec1313383.png)
