### PR TITLE
Update plugin dockerfile to install dotnet-sdk 3.1 and 5.0 required for plugin build

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/buildspec/plugin/intellij/Dockerfile
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/buildspec/plugin/intellij/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install dotnet-sdk-5.0
+# Install dotnet-sdk 3.1. and 5.0
 RUN wget -O - https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg \
     && mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/ \
     && wget https://packages.microsoft.com/config/debian/9/prod.list \
@@ -24,6 +24,7 @@ RUN wget -O - https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor 
 
 RUN apt-get update \
     && apt-get update \
+    && apt-get install -y dotnet-sdk-3.1 \
     && apt-get install -y dotnet-sdk-5.0
 
 # Install Mono


### PR DESCRIPTION
Update plugin dockerfile to install dotnet-sdk 3.1 and 5.0 required for plugin build