### PR TITLE
Initialize web applications list on a pooled thread

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzureActionsListener.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/intellij/AzureActionsListener.java
@@ -105,7 +105,7 @@ public abstract class AzureActionsListener implements AppLifecycleListener, Plug
             toolbarGroup.addAll((DefaultActionGroup) am.getAction("AzureToolbarGroup"));
 //            DefaultActionGroup popupGroup = (DefaultActionGroup) am.getAction(IdeActions.GROUP_PROJECT_VIEW_POPUP);
 //            popupGroup.add(am.getAction("AzurePopupGroup"));
-            loadWebApps();
+            DefaultLoader.getIdeHelper().executeOnPooledThread(this::loadWebApps);
         }
         try {
             PlatformDependent.isAndroid();


### PR DESCRIPTION
Noticed during debugging that the `loadWebApps()` call is slowing down startup quite a bit.

Since it's not yet needed during startup or on the welcome screen, decided to move it to a pooled thread.

Startup on my machine:
Before: 12 sec
After: 3 sec

I'd like to also backport this to `211`, what do you think?