### PR TITLE
Fixed RIDER-65794. Fix Azure login failures

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs='-Duser.language=en'
 sources=false
 
 intellij_version=IC-212.4638.7-EAP-SNAPSHOT
-rider_version=RD-2021.2-EAP7-SNAPSHOT
+rider_version=RD-2021.2-EAP9-SNAPSHOT
 build_common_code_with=rider
 
 intellij_plugin_name=azure-toolkit-for-intellij
@@ -20,7 +20,7 @@ patchPluginXmlSinceBuild=212
 
 kotlin_version=1.4.32
 jackson_kotlin_version=2.12.0
-gradle_plugin_version=1.1.3
+gradle_plugin_version=1.1.4
 undercouch_version=4.0.4
 web_socket_version=1.5.1
 retrofit_version=2.9.0
@@ -28,7 +28,7 @@ assertj_version=3.15.0
 lombok_version=1.18.8
 aspectj_version=5.3.0
 
-rd_version=0.212.317
-rider_nuget_sdk_version=2021.2.0-eap07
+rd_version=0.212.318
+rider_nuget_sdk_version=2021.2.0-eap09
 
 rider_test_local_env_run=true

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -6,8 +6,11 @@
     <html>
         <h4>Added:</h4>
         <ul>
-          <li>Compatibility with Rider 2021.2 EAP 7</li>
-          <li>Show editor warning about missing NuGet Packages instead of installing them automatically (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/445">#445</a>)</li>
+          <li>Compatibility with Rider 2021.2 EAP 9</li>
+        </ul>
+        <h4>Fixed:</h4>
+        <ul>
+          <li>Failures on trying to login to Azure account (<a href="https://youtrack.jetbrains.com/issue/RIDER-65794">RIDER-65794</a>)</li>
         </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/build.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/build.gradle
@@ -81,21 +81,17 @@ patchPluginXml {
     untilBuild = untilBuildValue
 }
 
-// Add Temporary workaround to call ':rider:prepareTestingSandbox' task - https://github.com/JetBrains/gradle-intellij-plugin/issues/743
-// TODO: Remove this dependsOn task after 1.1.4 version of 'org.jetbrains.intellij' plugin is released
 test {
     description = "Rider unit tests."
-    dependsOn ':rider:buildPlugin', prepareTestingSandbox
+    dependsOn ':rider:buildPlugin'
 
     useTestNG()
 }
 
-// Add Temporary workaround to call ':rider:prepareTestingSandbox' task - https://github.com/JetBrains/gradle-intellij-plugin/issues/743
-// TODO: Remove this dependsOn task after 1.1.4 version of 'org.jetbrains.intellij' plugin is released
 task integrationTest(type: Test) {
     description = "Rider Azure integration tests based on Rider Test Framework."
     group = LifecycleBasePlugin.VERIFICATION_GROUP
-    dependsOn ':rider:buildPlugin', prepareTestingSandbox
+    dependsOn ':rider:buildPlugin'
 
     environment("LOCAL_ENV_RUN", rider_test_local_env_run)
     environment("NO_FS_ROOTS_ACCESS_CHECK", true)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/common/task/IntellijAzureTaskManager.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/src/com/microsoft/azure/toolkit/intellij/common/task/IntellijAzureTaskManager.java
@@ -78,16 +78,11 @@ public class IntellijAzureTaskManager extends AzureTaskManager {
 
     protected void doRunInBackgroundableModal(final Runnable runnable, final AzureTask<?> task) {
         final PerformInBackgroundOption foreground = PerformInBackgroundOption.DEAF;
-        // refer https://jetbrains.org/intellij/sdk/docs/basics/disposers.html
-        final Disposable disposable = Disposer.newDisposable();
-        // refer https://github.com/JetBrains/intellij-community/commit/077c5558993b97cfb6f68ccc3cbe13065ba3cba8
-        Registry.get("ide.background.tasks").setValue(false, disposable);
         final Task.Backgroundable modalTask = new Task.Backgroundable((Project) task.getProject(), task.getTitle().toString(), task.isCancellable(), foreground) {
             @Override
             public void run(@NotNull final ProgressIndicator progressIndicator) {
                 task.getContext().setBackgrounded(false);
                 runnable.run();
-                Disposer.dispose(disposable);
             }
 
             @Override


### PR DESCRIPTION
- Bump supported Rider SDK version and related dependencies
- Bump gradle plugin version to drop workarounds for tests Gradle tasks
- Fix the issue with Azure login by removing unused registry key (see IDEA-234632 for detailed)