### PR TITLE
Extend web app/function app publishing timeout

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -11,7 +11,7 @@
         <h4>Fixed:</h4>
         <ul>
           <li>Azure Functions debugging support on Apple Silicon / M1 / Rosetta <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/526">#526</a></li>
-          <li>Extend web app/function app publishing timeout <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/530">#530</a></li>
+          <li>Extend web app/function app publishing timeout <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/530">#530</a> / <a href="https://youtrack.jetbrains.com/issue/RIDER-68824">RIDER-68824</a></li>
         </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -11,6 +11,7 @@
         <h4>Fixed:</h4>
         <ul>
           <li>Azure Functions debugging support on Apple Silicon / M1 / Rosetta <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/526">#526</a></li>
+          <li>Extend web app/function app publishing timeout <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/530">#530</a></li>
         </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -30,7 +30,7 @@
         <h4>Fixed bugs:</h4>
         <ul>
           <li>Azure Functions debugging support on Apple Silicon / M1 / Rosetta <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/526">#526</a></li>
-          <li>Extend web app/function app publishing timeout <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/530">#530</a></li>
+          <li>Extend web app/function app publishing timeout <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/530">#530</a> / <a href="https://youtrack.jetbrains.com/issue/RIDER-68824">RIDER-68824</a></li>
         </ul>
         <p>[3.50.1-2021.2]</p>
         <ul>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -30,6 +30,7 @@
         <h4>Fixed bugs:</h4>
         <ul>
           <li>Azure Functions debugging support on Apple Silicon / M1 / Rosetta <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/526">#526</a></li>
+          <li>Extend web app/function app publishing timeout <a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/530">#530</a></li>
         </ul>
         <p>[3.50.1-2021.2]</p>
         <ul>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/messages/RiderAzureMessages.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/messages/RiderAzureMessages.properties
@@ -22,6 +22,8 @@ service.azurite.starting.check.table.storage=Starting Azurite Storage Emulator..
 # Settings
 settings.app_services.name=App Services
 settings.app_services.open_in_browser_after_publish=Open Azure Web App in browser after publish
+settings.app_services.deploy_collect_artifacts_timeout=Collect artifacts timeout in minutes
+
 settings.app_services.function_app.name=Functions
 settings.app_services.function_app.core_tools.path=Azure Functions Core Tools path:
 settings.app_services.function_app.core_tools.path_description=Path to Azure Functions Core Tools

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/AzureRiderSettings.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/AzureRiderSettings.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2020 JetBrains s.r.o.
+ * Copyright (c) 2018-2021 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -43,6 +43,10 @@ object AzureRiderSettings {
     const val PROPERTY_FUNCTIONS_CORETOOLS_PATH = "AzureFunctionsCoreToolsPath"
     const val PROPERTY_FUNCTIONS_CORETOOLS_ALLOW_PRERELEASE = "AzureFunctionsCoreToolsAllowPrerelease"
     const val PROPERTY_FUNCTIONS_CORETOOLS_CHECK_UPDATES = "AzureFunctionCoreToolsCheckUpdates"
+
+    // Web deploy
+    const val PROPERTY_COLLECT_ARTIFACTS_TIMEOUT_MINUTES_NAME = "AzureDeployCollectArtifactsTimeoutMinutes"
+    const val VALUE_COLLECT_ARTIFACTS_TIMEOUT_MINUTES_DEFAULT = 3
 
     // Azurite
     const val PROPERTY_AZURITE_NODE_INTERPRETER = "AzureAzuriteNodeInterpreter"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/ui/AzureAppServicesConfigurationPanel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/configuration/ui/AzureAppServicesConfigurationPanel.kt
@@ -1,18 +1,18 @@
 /**
- * Copyright (c) 2018-2020 JetBrains s.r.o.
- * <p/>
+ * Copyright (c) 2018-2021 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
@@ -23,6 +23,9 @@
 package com.microsoft.intellij.configuration.ui
 
 import com.intellij.ide.util.PropertiesComponent
+import com.intellij.ui.JBIntSpinner
+import com.intellij.ui.layout.panel
+import com.intellij.util.ui.FormBuilder
 import com.microsoft.intellij.configuration.AzureRiderSettings
 import net.miginfocom.swing.MigLayout
 import org.jetbrains.plugins.azure.RiderAzureBundle.message
@@ -33,32 +36,43 @@ class AzureAppServicesConfigurationPanel : AzureRiderAbstractConfigurablePanel {
 
     private val properties = PropertiesComponent.getInstance()
 
-    private val pnlRoot = JPanel(MigLayout("novisualpadding, ins 0, fillx, wrap 1"))
     private val checkBoxOpenInBrowser = JCheckBox(message("settings.app_services.open_in_browser_after_publish"))
+    private val collectArtifactsTimeoutMinutesSpinner = JBIntSpinner(AzureRiderSettings.VALUE_COLLECT_ARTIFACTS_TIMEOUT_MINUTES_DEFAULT, 1, 60)
 
     init {
-        initOpenInBrowserCheckBox()
+        checkBoxOpenInBrowser.isSelected = properties.getBoolean(
+            AzureRiderSettings.PROPERTY_WEB_APP_OPEN_IN_BROWSER_NAME,
+            AzureRiderSettings.OPEN_IN_BROWSER_AFTER_PUBLISH_DEFAULT_VALUE)
 
-        pnlRoot.apply {
-            add(checkBoxOpenInBrowser)
-        }
+        collectArtifactsTimeoutMinutesSpinner.number = properties.getInt(
+                AzureRiderSettings.PROPERTY_COLLECT_ARTIFACTS_TIMEOUT_MINUTES_NAME,
+                AzureRiderSettings.VALUE_COLLECT_ARTIFACTS_TIMEOUT_MINUTES_DEFAULT)
     }
 
-    override val panel: JPanel = pnlRoot
+    override val panel: JPanel =
+            panel {
+                row {
+                    val coreToolsPanel = FormBuilder
+                            .createFormBuilder()
+                            .addComponent(checkBoxOpenInBrowser)
+                            .addSeparator()
+                            .addLabeledComponent(message("settings.app_services.deploy_collect_artifacts_timeout"), collectArtifactsTimeoutMinutesSpinner)
+                            .panel
+                    component(coreToolsPanel)
+                }
+            }
 
     override val displayName: String = message("settings.app_services.name")
 
-    override fun doOKAction() =
-            properties.setValue(
-                    AzureRiderSettings.PROPERTY_WEB_APP_OPEN_IN_BROWSER_NAME,
-                    checkBoxOpenInBrowser.isSelected,
-                    AzureRiderSettings.OPEN_IN_BROWSER_AFTER_PUBLISH_DEFAULT_VALUE)
-
-    private fun initOpenInBrowserCheckBox() {
-        val currentValue = properties.getBoolean(
+    override fun doOKAction() {
+        properties.setValue(
                 AzureRiderSettings.PROPERTY_WEB_APP_OPEN_IN_BROWSER_NAME,
+                checkBoxOpenInBrowser.isSelected,
                 AzureRiderSettings.OPEN_IN_BROWSER_AFTER_PUBLISH_DEFAULT_VALUE)
 
-        checkBoxOpenInBrowser.isSelected = currentValue
+        properties.setValue(
+                AzureRiderSettings.PROPERTY_COLLECT_ARTIFACTS_TIMEOUT_MINUTES_NAME,
+                collectArtifactsTimeoutMinutesSpinner.number,
+                AzureRiderSettings.VALUE_COLLECT_ARTIFACTS_TIMEOUT_MINUTES_DEFAULT)
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/helpers/deploy/KuduClient.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/helpers/deploy/KuduClient.kt
@@ -36,13 +36,18 @@ object KuduClient {
 
     private val logger = Logger.getInstance(WebAppDeployStateUtil::class.java)
 
-    private const val URL_KUDU_ZIP_DEPLOY_SUFFIX = "/api/zipdeploy"
+    private const val URL_KUDU_ZIP_DEPLOY_SUFFIX = "/api/zipdeploy?isAsync=true"
     private const val URL_AZURE_BASE = ".azurewebsites.net"
     private const val URL_KUDU_BASE = ".scm$URL_AZURE_BASE"
     private const val URL_KUDU_ZIP_DEPLOY = "$URL_KUDU_BASE$URL_KUDU_ZIP_DEPLOY_SUFFIX"
 
     private const val SLEEP_TIME_MS = 5000L
-    private const val DEPLOY_TIMEOUT_MS = 180000L
+
+    // Per attempt to upload, the global timeout will be DEPLOY_POLLING_MAX_TRY * DEPLOY_POLLING_TIMEOUT_MS
+    private const val DEPLOY_REQUEST_TIMEOUT_MS = 300000L // How long can a request take?
+    private const val DEPLOY_POLLING_TIMEOUT_MS = 10000L  // How long do we wait between polls?
+    private const val DEPLOY_POLLING_MAX_TRY = 60         // How many times do we poll, maximum?
+
     private const val UPLOADING_MAX_TRY = 3
 
     /**
@@ -94,7 +99,9 @@ object KuduClient {
                     response = session.publishZip(
                             kuduBaseUrl ?: "https://" + appName.toLowerCase() + URL_KUDU_ZIP_DEPLOY,
                             zipFile,
-                            DEPLOY_TIMEOUT_MS)
+                            DEPLOY_REQUEST_TIMEOUT_MS,
+                            DEPLOY_POLLING_TIMEOUT_MS,
+                            DEPLOY_POLLING_MAX_TRY)
                     success = response.isSuccessful
                 } catch (e: Throwable) {
                     processHandler.setText("${message("process_event.publish.zip_deploy.fail")}: $e")

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/helpers/deploy/KuduClient.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/helpers/deploy/KuduClient.kt
@@ -91,13 +91,15 @@ object KuduClient {
         var uploadCount = 0
         var response: Response? = null
 
+        val kuduPublishUrl = kuduBaseUrl ?: "https://" + appName.toLowerCase() + URL_KUDU_ZIP_DEPLOY
+
         try {
             do {
                 processHandler.setText(message("process_event.publish.zip_deploy.start_publish", uploadCount + 1, UPLOADING_MAX_TRY))
 
                 try {
                     response = session.publishZip(
-                            kuduBaseUrl ?: "https://" + appName.toLowerCase() + URL_KUDU_ZIP_DEPLOY,
+                            kuduPublishUrl,
                             zipFile,
                             DEPLOY_REQUEST_TIMEOUT_MS,
                             DEPLOY_POLLING_TIMEOUT_MS,

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/appbase/config/runstate/AppDeployStateUtil.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/appbase/config/runstate/AppDeployStateUtil.kt
@@ -59,8 +59,6 @@ object AppDeployStateUtil {
 
     private val logger = Logger.getInstance(AppDeployStateUtil::class.java)
 
-    private const val COLLECT_ARTIFACTS_TIMEOUT_MS = 180000L
-
     private const val APP_START_TIMEOUT_MS = 20000L
     private const val APP_STOP_TIMEOUT_MS = 10000L
     private const val APP_LAUNCH_TIMEOUT_MS = 10000L
@@ -124,10 +122,11 @@ object AppDeployStateUtil {
      *
      * @param project IDEA [Project] instance
      * @param publishableProject contains information about project to be published (isDotNetCore, path to project file)
+     * @param timeoutMs timeout for collecting artifacts
      *
      * @return [File] to project content to be published
      */
-    fun collectProjectArtifacts(project: Project, publishableProject: PublishableProjectModel): File {
+    fun collectProjectArtifacts(project: Project, publishableProject: PublishableProjectModel, timeoutMs: Long): File {
         // Get out parameters
         val publishService = MsBuildPublishingService.getInstance(project)
         val (targetProperties, outPath) = publishService.getPublishToTempDirParameterAndPath()
@@ -152,7 +151,7 @@ object AppDeployStateUtil {
             }
         }
 
-        val buildResult = event.get(COLLECT_ARTIFACTS_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        val buildResult = event.get(timeoutMs, TimeUnit.MILLISECONDS)
         if (buildResult != BuildResultKind.Successful && buildResult != BuildResultKind.HasWarnings) {
             val errorMessage = message("process_event.publish.project.artifacts.collecting_failed")
             logger.error(errorMessage)

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/appbase/config/runstate/AppDeployStateUtil.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/appbase/config/runstate/AppDeployStateUtil.kt
@@ -25,11 +25,13 @@ package com.microsoft.intellij.runner.appbase.config.runstate
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.rd.util.launchIOBackground
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.wm.ToolWindowId
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.util.application
 import com.intellij.util.io.ZipUtil
+import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.spinUntil
 import com.jetbrains.rd.util.threading.SpinWait
 import com.jetbrains.rdclient.util.idea.toIOFile
@@ -141,10 +143,12 @@ object AppDeployStateUtil {
                 event.setResult(it)
             }
 
-            if (publishableProject.isDotNetCore) {
-                publishService.invokeMsBuild(publishableProject, listOf(targetProperties), false, true, true, onFinish)
-            } else {
-                publishService.webPublishToFileSystem(publishableProject.projectFilePath, outPath, false, true, onFinish)
+            Lifetime.Eternal.launchIOBackground {
+                if (publishableProject.isDotNetCore) {
+                    publishService.invokeMsBuild(publishableProject, listOf(targetProperties), false, true, true, onFinish)
+                } else {
+                    publishService.webPublishToFileSystem(publishableProject.projectFilePath, outPath, false, true, onFinish)
+                }
             }
         }
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/config/FunctionAppRunState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/config/FunctionAppRunState.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2020 JetBrains s.r.o.
+ * Copyright (c) 2019-2021 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -77,8 +77,12 @@ class FunctionAppRunState(project: Project, private val myModel: FunctionAppSett
         val subscriptionId = myModel.functionAppModel.subscription?.subscriptionId()
                 ?: throw RuntimeException(message("process_event.publish.subscription.not_defined"))
 
+        val collectArtifactsTimeoutMs = PropertiesComponent.getInstance().getInt(
+                AzureRiderSettings.PROPERTY_COLLECT_ARTIFACTS_TIMEOUT_MINUTES_NAME,
+                AzureRiderSettings.VALUE_COLLECT_ARTIFACTS_TIMEOUT_MINUTES_DEFAULT) * 60000L
+
         val app = getOrCreateFunctionAppFromConfiguration(myModel.functionAppModel, processHandler)
-        deployToAzureFunctionApp(project, publishableProject, app, processHandler)
+        deployToAzureFunctionApp(project, publishableProject, app, processHandler, collectArtifactsTimeoutMs)
 
         isFunctionAppCreated = true
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/config/runstate/FunctionAppDeployStateUtil.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/functionapp/config/runstate/FunctionAppDeployStateUtil.kt
@@ -160,19 +160,21 @@ object FunctionAppDeployStateUtil {
     fun deployToAzureFunctionApp(project: Project,
                                  publishableProject: PublishableProjectModel,
                                  app: WebAppBase,
-                                 processHandler: RunProcessHandler) {
+                                 processHandler: RunProcessHandler,
+                                 collectArtifactsTimeoutMs: Long) {
 
-        packAndDeploy(project, publishableProject, app, processHandler)
+        packAndDeploy(project, publishableProject, app, processHandler, collectArtifactsTimeoutMs)
         processHandler.setText(message("process_event.publish.deploy_succeeded"))
     }
 
     private fun packAndDeploy(project: Project,
                               publishableProject: PublishableProjectModel,
                               app: WebAppBase,
-                              processHandler: RunProcessHandler) {
+                              processHandler: RunProcessHandler,
+                              collectArtifactsTimeoutMs: Long) {
         try {
             processHandler.setText(message("process_event.publish.project.artifacts.collecting", publishableProject.projectName))
-            val outDir = collectProjectArtifacts(project, publishableProject)
+            val outDir = collectProjectArtifacts(project, publishableProject, collectArtifactsTimeoutMs)
             // Note: we need to do it only for Linux Azure instances (we might add this check to speed up)
             projectAssemblyRelativePath = getAssemblyRelativePath(publishableProject, outDir)
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/utils/AppDeploySession.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/utils/AppDeploySession.kt
@@ -1,18 +1,18 @@
 /**
- * Copyright (c) 2018-2019 JetBrains s.r.o.
- * <p/>
+ * Copyright (c) 2018-2021 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
@@ -22,15 +22,17 @@
 
 package com.microsoft.intellij.runner.utils
 
+import com.intellij.execution.ExecutionException
+import com.jetbrains.rd.util.threading.SpinWait
 import com.microsoft.azure.AzureEnvironment
 import com.microsoft.azure.AzureResponseBuilder
 import com.microsoft.azure.serializer.AzureJacksonAdapter
 import com.microsoft.rest.RestClient
 import com.microsoft.rest.credentials.BasicAuthenticationCredentials
-import okhttp3.MultipartBody
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
+import org.jetbrains.plugins.azure.util.waitForResponse
 import java.io.File
 import java.io.IOException
 import java.util.concurrent.TimeUnit
@@ -42,14 +44,24 @@ class AppDeploySession(username: String, password: String) {
     /**
      * Publish a ZIP file using Azure KUDU Service through REST API
      *
-     * @param connectUrl - URL for REST request
-     * @param zipFile    - file to publish on Azure
+     * More information: https://github.com/projectkudu/kudu/wiki/Deploying-from-a-zip-file-or-url#asynchronous-zip-deployment
+     *
+     * @param connectUrl           - URL for REST request
+     * @param zipFile              - file to publish on Azure
+     * @param readTimeoutMs        - timeout for reading from Kudu endpoint
+     * @param pollingTimeoutMs     - number of ms between polls to the Kudu endpoint
+     * @param pollingNumberOfTries - number of polling attempts before giving up
      *
      * @return {Response} object with publish response status
      * @throws IOException is throws for ZIP file IO exceptions
      */
     @Throws(IOException::class)
-    fun publishZip(connectUrl: String, zipFile: File, readTimeoutMs: Long): Response {
+    fun publishZip(
+            connectUrl: String,
+            zipFile: File,
+            readTimeoutMs: Long,
+            pollingTimeoutMs: Long,
+            pollingNumberOfTries: Int): Response {
 
         val client = RestClient.Builder()
                 .withCredentials(credentials)
@@ -66,6 +78,25 @@ class AppDeploySession(username: String, password: String) {
                 .post(requestBody)
                 .build()
 
-        client.newCall(request).execute().use { response -> return response }
+        client.newCall(request).execute().use { response ->
+            // If the initial async deploy fails, there is no use in polling.
+            if (!response.isSuccessful) return response
+
+            // If it succeeds, poll for a result
+            val pollingUrl = response.header("Location") ?: throw ExecutionException("The Azure KUDU Service did not return an URL to poll for deployment status.")
+            val maximumPollingDurationSeconds = (pollingTimeoutMs * pollingNumberOfTries) / 1000
+
+            return waitForResponse(pollingUrl, timeoutInSeconds = readTimeoutMs, client)
+                    .withRetries(pollingNumberOfTries,
+                    { _, _ -> },
+                    { pollingResponse ->
+                        if (pollingResponse.code() == 202) {
+                            SpinWait.spinUntil(pollingTimeoutMs) { false }
+                            false
+                        } else {
+                            true
+                        }
+                    }) ?: throw ExecutionException("The Azure KUDU Service did not return a valid deployment status polling result within $maximumPollingDurationSeconds seconds.")
+        }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/utils/AppDeploySession.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/utils/AppDeploySession.kt
@@ -32,7 +32,7 @@ import com.microsoft.rest.credentials.BasicAuthenticationCredentials
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
-import org.jetbrains.plugins.azure.util.waitForResponse
+import org.jetbrains.plugins.azure.util.WaitForResponse
 import java.io.File
 import java.io.IOException
 import java.util.concurrent.TimeUnit
@@ -86,7 +86,7 @@ class AppDeploySession(username: String, password: String) {
             val pollingUrl = response.header("Location") ?: throw ExecutionException("The Azure KUDU Service did not return an URL to poll for deployment status.")
             val maximumPollingDurationSeconds = (pollingTimeoutMs * pollingNumberOfTries) / 1000
 
-            return waitForResponse(pollingUrl, timeoutInSeconds = readTimeoutMs, client)
+            return WaitForResponse(pollingUrl, timeoutInSeconds = readTimeoutMs, client)
                     .withRetries(pollingNumberOfTries,
                     { _, _ -> },
                     { pollingResponse ->

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/RiderWebAppRunState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/RiderWebAppRunState.kt
@@ -89,8 +89,12 @@ class RiderWebAppRunState(project: Project,
         val subscriptionId = myModel.webAppModel.subscription?.subscriptionId()
                 ?: throw RuntimeException(message("process_event.publish.subscription.not_defined"))
 
+        val collectArtifactsTimeoutMs = PropertiesComponent.getInstance().getInt(
+                AzureRiderSettings.PROPERTY_COLLECT_ARTIFACTS_TIMEOUT_MINUTES_NAME,
+                AzureRiderSettings.VALUE_COLLECT_ARTIFACTS_TIMEOUT_MINUTES_DEFAULT) * 60000L
+
         val appTarget = getOrCreateWebAppFromConfiguration(myModel.webAppModel, processHandler)
-        deployToAzureWebApp(project, publishableProject, appTarget, processHandler)
+        deployToAzureWebApp(project, publishableProject, appTarget, processHandler, collectArtifactsTimeoutMs)
 
         if (myModel.webAppModel.isCreatingNewApp && myModel.webAppModel.operatingSystem == OperatingSystem.LINUX &&
                 publishableProject.isDotNetCore) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/runstate/WebAppDeployStateUtil.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/com/microsoft/intellij/runner/webapp/config/runstate/WebAppDeployStateUtil.kt
@@ -120,9 +120,10 @@ object WebAppDeployStateUtil {
     fun deployToAzureWebApp(project: Project,
                             publishableProject: PublishableProjectModel,
                             appTarget: WebAppBase,
-                            processHandler: RunProcessHandler) {
+                            processHandler: RunProcessHandler,
+                            collectArtifactsTimeoutMs: Long) {
 
-        packAndDeploy(project, publishableProject, appTarget, processHandler)
+        packAndDeploy(project, publishableProject, appTarget, processHandler, collectArtifactsTimeoutMs)
         processHandler.setText(message("process_event.publish.deploy_succeeded"))
     }
 
@@ -182,10 +183,11 @@ object WebAppDeployStateUtil {
     private fun packAndDeploy(project: Project,
                               publishableProject: PublishableProjectModel,
                               appTarget: WebAppBase,
-                              processHandler: RunProcessHandler) {
+                              processHandler: RunProcessHandler,
+                              collectArtifactsTimeoutMs: Long) {
         try {
             processHandler.setText(message("process_event.publish.project.artifacts.collecting", publishableProject.projectName))
-            val outDir = collectProjectArtifacts(project, publishableProject)
+            val outDir = collectProjectArtifacts(project, publishableProject, collectArtifactsTimeoutMs)
             // Note: we need to do it only for Linux Azure instances (we might add this check to speed up)
             projectAssemblyRelativePath = getAssemblyRelativePath(publishableProject, outDir)
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/controlchannel/UrlControlMessageHandler.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/controlchannel/UrlControlMessageHandler.kt
@@ -33,7 +33,7 @@ import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import org.jetbrains.plugins.azure.RiderAzureBundle
 import org.jetbrains.plugins.azure.AzureNotifications
-import org.jetbrains.plugins.azure.util.WaitForUrl
+import org.jetbrains.plugins.azure.util.waitForResponse
 
 class UrlControlMessageHandler(
         private val gson: Gson,
@@ -55,7 +55,7 @@ class UrlControlMessageHandler(
             ProgressManager.getInstance().run(object : Task.Backgroundable(project, waitingText, true, PerformInBackgroundOption.DEAF) {
                 override fun run(indicator: ProgressIndicator) {
                     try {
-                        WaitForUrl(message.url).withRetries(30,
+                        waitForResponse(message.url).withRetries(30,
                                 { attempt, of -> indicator.text = "$waitingText (attempt ${attempt + 1}/$of)" },
                                 { it.code() in 200..400 })
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/controlchannel/UrlControlMessageHandler.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/controlchannel/UrlControlMessageHandler.kt
@@ -33,7 +33,7 @@ import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import org.jetbrains.plugins.azure.RiderAzureBundle
 import org.jetbrains.plugins.azure.AzureNotifications
-import org.jetbrains.plugins.azure.util.waitForResponse
+import org.jetbrains.plugins.azure.util.WaitForResponse
 
 class UrlControlMessageHandler(
         private val gson: Gson,
@@ -55,7 +55,7 @@ class UrlControlMessageHandler(
             ProgressManager.getInstance().run(object : Task.Backgroundable(project, waitingText, true, PerformInBackgroundOption.DEAF) {
                 override fun run(indicator: ProgressIndicator) {
                     try {
-                        waitForResponse(message.url).withRetries(30,
+                        WaitForResponse(message.url).withRetries(30,
                                 { attempt, of -> indicator.text = "$waitingText (attempt ${attempt + 1}/$of)" },
                                 { it.code() in 200..400 })
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/util/WaitForResponse.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/util/WaitForResponse.kt
@@ -26,7 +26,7 @@ import okhttp3.Request
 import okhttp3.Response
 import java.util.concurrent.TimeUnit
 
-class waitForResponse(
+class WaitForResponse(
         private val url: String,
         private val timeoutInSeconds: Long = 2,
         private val client: OkHttpClient? = null

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/util/waitForResponse.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/util/waitForResponse.kt
@@ -1,18 +1,18 @@
 /**
- * Copyright (c) 2018 JetBrains s.r.o.
- * <p/>
+ * Copyright (c) 2018-2021 JetBrains s.r.o.
+ *
  * All rights reserved.
- * <p/>
+ *
  * MIT License
- * <p/>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
  * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * <p/>
+ *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
- * <p/>
+ *
  * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
@@ -26,12 +26,17 @@ import okhttp3.Request
 import okhttp3.Response
 import java.util.concurrent.TimeUnit
 
-class WaitForUrl(private val url: String, private val timeoutInSeconds: Long = 2) {
+class waitForResponse(
+        private val url: String,
+        private val timeoutInSeconds: Long = 2,
+        private val client: OkHttpClient? = null
+) {
+
     fun withRetries(numberOfAttempts: Int,
           attemptCallback: (Int, Int) -> Unit,
-          successCondition:(Response) -> Boolean) {
+          successCondition: (Response) -> Boolean) : Response? {
 
-        val httpClient = OkHttpClient()
+        val httpClient = client ?: OkHttpClient()
                 .newBuilder()
                 .connectTimeout(timeoutInSeconds, TimeUnit.SECONDS)
                 .readTimeout(timeoutInSeconds, TimeUnit.SECONDS)
@@ -49,7 +54,7 @@ class WaitForUrl(private val url: String, private val timeoutInSeconds: Long = 2
                 val response = httpClient.newCall(request).execute()
 
                 if (successCondition(response)) {
-                    return
+                    return response
                 }
             } catch (e: Exception) {
                 if (attempt >= numberOfAttempts) {
@@ -57,6 +62,8 @@ class WaitForUrl(private val url: String, private val timeoutInSeconds: Long = 2
                 }
             }
         }
+
+        return null
     }
 }
 


### PR DESCRIPTION
Fixes #437
Fixes #531

Before this PR:
1. Timeout for preparing publishable package from a selected project (3 mins)
2. Timeout for pushing prepared package over a network to Azure servers (3 mins) 

After this PR:
1. Timeout for preparing publishable package from a selected project **configurable, with 3min default**
![image](https://user-images.githubusercontent.com/485230/136533020-b1bcefc4-4dca-47ac-a49e-a6cb4f3d3aa9.png)

2. Timeout for pushing prepared package over a network to Azure servers
  * Digging through issues in the [Kudu repository](https://github.com/projectkudu/kudu/issues/), it seems 5 minutes is a better timeout for HTTP operations.
  * Switched to make use of async deploy (upload, then poll periodically to see if upload succeeded). Polling every 10 seconds during max. 10 minutes (not configurable)