### PR TITLE
Add external annotations for Microsoft.Azure.Functions.Worker.FunctionAttribute

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/dotnet/Extensions/com.intellij.resharper.azure/annotations/Microsoft.Azure.Functions.Worker.Extensions.Abstractions.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/dotnet/Extensions/com.intellij.resharper.azure/annotations/Microsoft.Azure.Functions.Worker.Extensions.Abstractions.xml
@@ -1,0 +1,5 @@
+<assembly name="Microsoft.Azure.Functions.Worker.Extensions.Abstractions">
+    <member name="T:Microsoft.Azure.Functions.Worker.FunctionAttribute">
+        <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+    </member>
+</assembly>


### PR DESCRIPTION
Minor thing, but marks isolated worker runtime functions as `[UsedImplicitly]` so Rider doesn't gray them out in the editor.