### PR TITLE
Azure Functions Host version can be selected from new project dialog

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -8,6 +8,7 @@
         <ul>
           <li>Compatibility with Rider 2022.1 EAP6</li>
           <li>Azure Functions: Run project against a function core tool version defined in project file (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/294">#294</a>)</li>
+          <li>Azure Functions Host version can be selected from new project dialog (<a href="https://github.com/JetBrains/azure-tools-for-intellij/pull/568">#568</a>)</li>
         </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/ProjectTemplates/DotNetExtensions/Parameters/AzureFunctionsVersionParameterProvider.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/ProjectTemplates/DotNetExtensions/Parameters/AzureFunctionsVersionParameterProvider.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using JetBrains.Application;
+using JetBrains.Rider.Backend.Features.ProjectModel.ProjectTemplates.DotNetExtensions;
+using JetBrains.Rider.Backend.Features.ProjectModel.ProjectTemplates.DotNetTemplates;
+using JetBrains.Rider.Model;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Azure.Intellisense.FunctionApp.ProjectTemplates.DotNetExtensions.Parameters
+{
+    [ShellComponent]
+    public class AzureFunctionsVersionParameterProvider : IDotNetTemplateParameterProvider
+    {
+        public int Priority => 20;
+
+        public IReadOnlyCollection<DotNetTemplateParameter> Get()
+        {
+            return new[] {new AzureFunctionsVersionParameter()};
+        }
+
+        private class AzureFunctionsVersionParameter : DotNetTemplateParameter
+        {
+            public AzureFunctionsVersionParameter() : base(
+                    name: "AzureFunctionsVersion",
+                    presentableName: "Functions host", 
+                    tooltip: "The setting that determines the functions host target release")
+            {
+            }
+
+            public override RdProjectTemplateContent CreateContent(DotNetProjectTemplateExpander expander, IDotNetTemplateContentFactory factory, int index, IDictionary<string, string> context)
+            {
+                var parameter = expander.TemplateInfo.GetParameter(Name);
+                if (parameter == null)
+                {
+                    return factory.CreateNextParameters(new[] {expander}, index + 1, context);
+                }
+
+                var options = new List<RdProjectTemplateGroupOption>();
+                if (parameter.Choices != null && !parameter.Choices.IsEmpty())
+                {
+                    // Use from template if provided
+                    foreach (var parameterOptionFromTemplate in parameter.Choices)
+                    {
+                        var content = factory.CreateNextParameters(new[] {expander}, index + 1, context);
+                        options.Add(new RdProjectTemplateGroupOption(parameterOptionFromTemplate.Key, parameterOptionFromTemplate.Value, null, content));
+                    }
+                }
+                else
+                {
+                    // Use hardcoded list
+                    // REVIEW: Ideally this would be determined based on TFM and Functions runtime worker, but the new project dialog data does not seem to be exposed in this method?
+                    var content = factory.CreateNextParameters(new[] {expander}, index + 1, context);
+                    options.Add(new RdProjectTemplateGroupOption("V4", "V4", null, content));
+                    options.Add(new RdProjectTemplateGroupOption("V3", "V3", null, content));
+                }
+                
+                return new RdProjectTemplateGroupParameter(Name,PresentableName, parameter.DefaultValue, Tooltip, options);
+            }
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/ProjectTemplates/DotNetExtensions/Parameters/AzureFunctionsVersionParameterProvider.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/ProjectTemplates/DotNetExtensions/Parameters/AzureFunctionsVersionParameterProvider.cs
@@ -38,19 +38,29 @@ namespace JetBrains.ReSharper.Azure.Intellisense.FunctionApp.ProjectTemplates.Do
                 if (parameter.Choices != null && !parameter.Choices.IsEmpty())
                 {
                     // Use from template if provided
+                    var content = factory.CreateNextParameters(new[] {expander}, index + 1, context);
                     foreach (var parameterOptionFromTemplate in parameter.Choices)
                     {
-                        var content = factory.CreateNextParameters(new[] {expander}, index + 1, context);
-                        options.Add(new RdProjectTemplateGroupOption(parameterOptionFromTemplate.Key, parameterOptionFromTemplate.Value, null, content));
+                        var presentation = !parameterOptionFromTemplate.Value.DisplayName.IsNullOrWhitespace()
+                            ? parameterOptionFromTemplate.Value.DisplayName
+                            : parameterOptionFromTemplate.Value.Description;
+
+                        options.Add(new RdProjectTemplateGroupOption(parameterOptionFromTemplate.Key, presentation ?? parameterOptionFromTemplate.Key, null, content));
                     }
                 }
                 else
                 {
                     // Use hardcoded list
-                    // REVIEW: Ideally this would be determined based on TFM and Functions runtime worker, but the new project dialog data does not seem to be exposed in this method?
-                    var content = factory.CreateNextParameters(new[] {expander}, index + 1, context);
-                    options.Add(new RdProjectTemplateGroupOption("V4", "V4", null, content));
-                    options.Add(new RdProjectTemplateGroupOption("V3", "V3", null, content));
+                    var isNet6OrHigher = expander.Template.Sdk.Major >= 6 || expander.Template.Sdk.Major == 0; // The Azure Functions templates treat "0" as .NET 6 as well.
+                    var supportedAzureFunctionsVersions = isNet6OrHigher
+                        ? new[] { "V4" }
+                        : new[] { "V3", "V2" };
+                    
+                    foreach (var version in supportedAzureFunctionsVersions)
+                    {
+                        var content = factory.CreateNextParameters(new[] {expander}, index + 1, context);
+                        options.Add(new RdProjectTemplateGroupOption(version, version, null, content));
+                    }
                 }
                 
                 return new RdProjectTemplateGroupParameter(Name,PresentableName, parameter.DefaultValue, Tooltip, options);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -27,6 +27,7 @@
         <ul>
           <li>Compatibility with Rider 2022.1 EAP6</li>
           <li>Azure Functions: Run project against a function core tool version defined in project file (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/294">#294</a>)</li>
+          <li>Azure Functions Host version can be selected from new project dialog (<a href="https://github.com/JetBrains/azure-tools-for-intellij/pull/568">#568</a>)</li>
         </ul>
         <p>[3.50.0-2021.3]</p>
         <ul>


### PR DESCRIPTION
Small nice-to-have for Azure Functions to pick `V4` / `V3` in new project creation dialog.

![image](https://user-images.githubusercontent.com/485230/152351544-7f5c5cc3-5f8c-41d1-923c-e4cb69389c8d.png)
