### PR TITLE
Use Gradle IntelliJ 1.7 stable version

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/gradle.properties
@@ -21,7 +21,7 @@ patchPluginXmlSinceBuild=222
 kotlin_version=1.6.20
 # note: jackson_kotlin_version also needs updating in Utils\azuretools-core\pom.xml
 jackson_kotlin_version=2.13.2
-gradle_plugin_version=1.7.0-SNAPSHOT
+gradle_plugin_version=1.7.0
 undercouch_version=4.0.4
 web_socket_version=1.5.1
 retrofit_version=2.9.0

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/settings.gradle
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/settings.gradle
@@ -1,12 +1,3 @@
-pluginManagement {
-    repositories {
-        maven {
-            url 'https://oss.sonatype.org/content/repositories/snapshots/'
-        }
-        gradlePluginPortal()
-    }
-}
-
 rootProject.name = 'azure-toolkit-for-intellij'
 
 include "idea"


### PR DESCRIPTION
Use the Gradle IntelliJ plugin version 1.7.0 stable.

This needs a fresh release of https://github.com/JetBrains/gradle-intellij-plugin first. Please follow up with @hsz before merging.