### PR TITLE
MSBuildEvaluator timeout breaks right-click + publish #611

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -13,6 +13,7 @@
         <ul>
           <li>Azure Functions: Deployment slots not appearing in the IDE (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/596">#596</a>)</li>
           <li>Azure Functions: Can't debug from gutter mark in some v4 projects (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/602">#602</a> / <a href="https://youtrack.jetbrains.com/issue/RIDER-78053">RIDER-78053</a>)</li>
+          <li>MSBuildEvaluator timeout breaks right-click + publish (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/611">#611</a>)</li>
         </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/protocol/src/model/daemon/FunctionAppDaemonModel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/protocol/src/model/daemon/FunctionAppDaemonModel.kt
@@ -56,6 +56,10 @@ object FunctionAppDaemonModel : Ext(SolutionModel.Solution) {
         field("projectFilePath", string)
     }
 
+    private val AzureFunctionsVersionRequest = structdef {
+        field("projectFilePath", string)
+    }
+
     init {
         setting(Kotlin11Generator.Namespace, "com.jetbrains.rider.azure.model")
         setting(CSharp50Generator.Namespace, "JetBrains.Rider.Azure.Model")
@@ -73,5 +77,8 @@ object FunctionAppDaemonModel : Ext(SolutionModel.Solution) {
 
         sink("triggerFunctionApp", FunctionAppRequest)
                 .doc("Signal from backend to trigger a Function App.")
+
+        call("getAzureFunctionsVersion", AzureFunctionsVersionRequest, string.nullable)
+                .doc("Request from frontend to read the AzureFunctionsVersion MSBuild property.")
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -32,6 +32,7 @@
         <ul>
           <li>Azure Functions: Deployment slots not appearing in the IDE (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/596">#596</a>)</li>
           <li>Azure Functions: Can't debug from gutter mark in some v4 projects (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/602">#602</a> / <a href="https://youtrack.jetbrains.com/issue/RIDER-78053">RIDER-78053</a>)</li>
+          <li>MSBuildEvaluator timeout breaks right-click + publish (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/611">#611</a>)</li>
         </ul>
         <p>[3.50.0-2022.1]</p>
         <ul>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsMsBuild.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsMsBuild.kt
@@ -23,27 +23,16 @@
 package org.jetbrains.plugins.azure.functions.coreTools
 
 import com.intellij.openapi.project.Project
-import com.jetbrains.rdclient.util.idea.pumpMessages
-import com.jetbrains.rider.run.environment.MSBuildEvaluator
-import org.jetbrains.concurrency.isPending
-import java.time.Duration
+import com.jetbrains.rd.framework.impl.RpcTimeouts
+import com.jetbrains.rider.azure.model.AzureFunctionsVersionRequest
+import com.jetbrains.rider.azure.model.functionAppDaemonModel
+import com.jetbrains.rider.projectView.solution
 
 object FunctionsCoreToolsMsBuild {
 
     const val PROPERTY_AZURE_FUNCTIONS_VERSION = "AzureFunctionsVersion"
 
-    fun requestAzureFunctionsVersion(project: Project, projectFilePath: String): String? {
-
-        val msBuildEvaluator = MSBuildEvaluator.getInstance(project)
-
-        val msBuildPropertiesPromise = msBuildEvaluator.evaluateProperties(
-                MSBuildEvaluator.PropertyRequest(projectFilePath, null, listOf(PROPERTY_AZURE_FUNCTIONS_VERSION)))
-
-        pumpMessages(Duration.ofSeconds(15)) { !msBuildPropertiesPromise.isPending }
-
-        val msBuildProperties = msBuildPropertiesPromise.blockingGet(0)
-                ?: return null
-
-        return msBuildProperties[PROPERTY_AZURE_FUNCTIONS_VERSION]
-    }
+    fun requestAzureFunctionsVersion(project: Project, projectFilePath: String): String? = project.solution.functionAppDaemonModel
+            .getAzureFunctionsVersion
+            .sync(AzureFunctionsVersionRequest(projectFilePath), RpcTimeouts.default)
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsDotNetCoreAttachSuspendedProfileState.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsDotNetCoreAttachSuspendedProfileState.kt
@@ -29,8 +29,6 @@ import com.jetbrains.rider.model.debuggerWorker.DebuggerStartInfoBase
 import com.jetbrains.rider.model.debuggerWorker.DotNetCoreAttachSuspendedStartInfo
 import com.jetbrains.rider.run.dotNetCore.DotNetCoreAttachProfileState
 import com.jetbrains.rider.runtime.RunningAssemblyInfo
-import org.jetbrains.concurrency.Promise
-import org.jetbrains.concurrency.resolvedPromise
 
 class AzureFunctionsDotNetCoreAttachSuspendedProfileState(
         private val runtime: AzureFunctionsDotNetCoreRuntime,


### PR DESCRIPTION
Fixes #611

The `MSBuildEvaluator` times out on the right-click + publish scenario. 
The project property is there anyway, so fetching it directly over protocol now.

(targeting the `eap` branch until the IJ Gradle SDK is updated and build goes green again, will update before merge)