### PR TITLE
Update usages of IdeUiService.getInstance()

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/StartAzureCloudShellAction.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/actions/StartAzureCloudShellAction.kt
@@ -165,7 +165,7 @@ class StartAzureCloudShellAction : AnAction() {
                         CloudConsoleService::class.java,
                         tokenCredentials) { httpClientBuilder ->
 
-                    IdeUiService.getInstance()?.sslSocketFactory?.let {
+                    IdeUiService.getInstance().sslSocketFactory?.let {
                         // Inject IDEA SSL socket factory and trust manager
                         httpClientBuilder.sslSocketFactory(it, CertificateManager.getInstance().trustManager)
                     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/terminal/AzureCloudTerminalFactory.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/cloudshell/terminal/AzureCloudTerminalFactory.kt
@@ -38,7 +38,7 @@ class AzureCloudTerminalFactory {
             // Connect terminal web socket
             val terminalSocketClient = CloudConsoleTerminalWebSocket(socketUri)
 
-            IdeUiService.getInstance()?.sslSocketFactory?.let {
+            IdeUiService.getInstance().sslSocketFactory?.let {
                 // Inject IDEA SSL socket factory
                 terminalSocketClient.setSocketFactory(it)
             }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsReleaseFeedService.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/coreTools/FunctionsCoreToolsReleaseFeedService.kt
@@ -25,6 +25,7 @@ package org.jetbrains.plugins.azure.functions.coreTools
 import com.google.gson.annotations.SerializedName
 import com.intellij.ide.ui.IdeUiService
 import com.intellij.util.net.ssl.CertificateManager
+import com.jetbrains.rd.platform.util.applicationOrNull
 import okhttp3.OkHttpClient
 import retrofit2.Call
 import retrofit2.Retrofit
@@ -46,12 +47,14 @@ interface FunctionsCoreToolsReleaseFeedService {
 
         private fun createHttpClient(): OkHttpClient {
             val httpClientBuilder = OkHttpClient.Builder()
-            runCatching { // For unit tests - IdeUiService.getInstance() throws NullReferenceException
-                IdeUiService.getInstance()?.sslSocketFactory?.let {
+
+            if (applicationOrNull != null) { // For unit tests - IdeUiService.getInstance() throws NullReferenceException
+                IdeUiService.getInstance().sslSocketFactory?.let {
                     // Inject IDEA SSL socket factory and trust manager
                     httpClientBuilder.sslSocketFactory(it, CertificateManager.getInstance().trustManager)
                 }
             }
+
             return httpClientBuilder.build()
         }
     }


### PR DESCRIPTION
* Check `applicationOrNull` to make test pass without needing `runCatching`
* Reverted other occurrences to what was there before https://github.com/JetBrains/azure-tools-for-intellij/commit/050ff71bba6b02c30899648da267d1254a1f480a