### PR TITLE
func.exe passed as argument to func.exe #646

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -11,6 +11,7 @@
         </ul>
         <h4>Fixed bugs:</h4>
         <ul>
+          <li>Azure Functions: func.exe passed as argument to func.exe (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/646">#646</a>)</li>
           <li>No F1 tier on Web API with linux (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/638">#638</a>)</li>
         </ul>
     </html>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -30,6 +30,7 @@
         </ul>
         <h4>Fixed bugs:</h4>
         <ul>
+          <li>Azure Functions: func.exe passed as argument to func.exe (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/646">#646</a>)</li>
           <li>No F1 tier on Web API with linux (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/638">#638</a>)</li>
         </ul>
         <p>[3.50.0-2022.2]</p>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsDotNetCoreRuntime.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/AzureFunctionsDotNetCoreRuntime.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2021 JetBrains s.r.o.
+ * Copyright (c) 2019-2022 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -26,15 +26,18 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.impl.ConsoleViewImpl
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.util.SystemInfo
 import com.jetbrains.rider.run.DotNetProcessRunProfileState
 import com.jetbrains.rider.run.IDotNetDebugProfileState
 import com.jetbrains.rider.run.dotNetCore.DotNetCoreDebugProfile
+import com.jetbrains.rider.run.msNet.MsNetDebugProfileState
 import com.jetbrains.rider.runtime.DotNetExecutable
 import com.jetbrains.rider.runtime.DotNetRuntime
 import com.jetbrains.rider.runtime.RunningAssemblyInfo
 import com.jetbrains.rider.runtime.SuspendedAttachableDotNetRuntime
 import com.jetbrains.rider.runtime.dotNetCore.DotNetCoreRuntime
 import com.jetbrains.rider.runtime.dotNetCore.DotNetCoreRuntimeType
+import com.jetbrains.rider.runtime.msNet.MsNetRuntime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.jetbrains.plugins.azure.functions.coreTools.FunctionsCoreToolsInfo
 import org.jetbrains.plugins.azure.functions.run.localsettings.FunctionsWorkerRuntime
@@ -57,11 +60,11 @@ class AzureFunctionsDotNetCoreRuntime(val coreToolsInfo: FunctionsCoreToolsInfo,
     override fun patchRunCommandLine(commandLine: GeneralCommandLine, runtimeArguments: List<String>) {
         if (commandLine.exePath.endsWith(".dll", true)) {
             val exePath = commandLine.exePath
-            commandLine.parametersList.addAt(0, exePath)
-            for (arg in runtimeArguments.reversed()) {
-                commandLine.parametersList.addAt(0, arg)
+            if (commandLine.parametersList.parametersCount > 0 &&
+                    commandLine.parametersList[0] != exePath) {
+                commandLine.parametersList.prepend(exePath)
             }
-            commandLine.withExePath(coreToolsInfo.coreToolsExecutable)
+            commandLine.exePath = coreToolsInfo.coreToolsExecutable
         }
     }
 


### PR DESCRIPTION
Fixes #646 - We were currently adding the exe path twice, which is not intended.

Root cause: we should use MsNet for v1 functions instead of .NET Core.