### PR TITLE
Create correct debugger command line for debugging isolated workers on Mac M1

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -17,6 +17,7 @@
           <li>Azure Functions: Publish using wrong dotnet version (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/661">#661</a>)</li>
           <li>Rider 2023.1 EAP 1 makes corelibs.log grow infinitely (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/657">#657</a>)</li>
           <li>No icons shown for item templates in Rider 2023.1 (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/663">#663</a>)</li>
+          <li>Unable to debug Azure Function in an isolated worker launched under Rosetta (<a href="https://youtrack.jetbrains.com/issue/RIDER-92326">#RIDER-92326</a>)</li>
         </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -36,6 +36,7 @@
           <li>Azure Functions: Publish using wrong dotnet version (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/661">#661</a>)</li>
           <li>Rider 2023.1 EAP 1 makes corelibs.log grow infinitely (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/657">#657</a>)</li>
           <li>No icons shown for item templates in Rider 2023.1 (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/663">#663</a>)</li>
+          <li>Unable to debug Azure Function in an isolated worker launched under Rosetta (<a href="https://youtrack.jetbrains.com/issue/RIDER-92326">#RIDER-92326</a>)</li>
         </ul>
         <p>[3.50.0-2022.3]</p>
         <ul>


### PR DESCRIPTION
We have [an annoying issue](https://youtrack.jetbrains.com/issue/RIDER-92326/Azure-functions-debug-possibly-attaches-to-the-wrong-architecture) on Mac M1 where we can't properly debug isolated workers that are launched under Rosetta.
The debugger needs to be launched under the same conditions as the target process (x64 under Rosetta for x64 target process, aarch64 for an aarch64 target process.
Right now we always start the debugger using dotnet-arm64, so let's change that by trying to re-use the logic for attaching to basic .NET (Core) processes.