### PR TITLE
Copy icons from azure-toolkit-for-intellij resource folder

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-rider/build.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/build.gradle.kts
@@ -157,6 +157,20 @@ tasks {
         }
     }
 
+    val copyIcons by registering(Copy::class) {
+        description = "Copies the icons directory of the base plugin."
+        from(projectDir.resolve("..").resolve("azure-toolkit-for-intellij").resolve("src").resolve("main").resolve("resources").resolve("icons"))
+        into(projectDir.resolve("src").resolve("main").resolve("resources").resolve("icons"))
+    }
+
+    buildPlugin  {
+        dependsOn(copyIcons)
+    }
+
+    processResources {
+        dependsOn(copyIcons)
+    }
+
     configure<com.jetbrains.rd.generator.gradle.RdGenExtension> {
         val modelDir = projectDir.resolve("protocol").resolve("src").resolve("main")
             .resolve("kotlin")
@@ -193,5 +207,9 @@ tasks {
 
     processResources {
         duplicatesStrategy = DuplicatesStrategy.WARN
+    }
+
+    buildSearchableOptions {
+        enabled = false
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-rider/settings.gradle.kts
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "Azure Toolkit for Rider"
+rootProject.name = "azure-toolkit-for-rider"
 
 pluginManagement {
     repositories {


### PR DESCRIPTION
I just copied the icons from the `PluginsAndFeatures\azure-toolkit-for-intellij\src\main\resources` folder. I haven't succeeded with any gradle configuration for this. Maybe you know a better way?