### PR TITLE
RIDER-98036 Azure Functions project template `AzureFunctionsVersion` has incorrect casing

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -8,6 +8,10 @@
         <ul>
           <li>Compatibility with Rider 2023.3</li>
         </ul>
+        <h4>Fixed bugs:</h4>
+        <ul>
+          <li>Azure Functions: Fix casing for the `AzureFunctionsVersion` project property (<a href="https://youtrack.jetbrains.com/issue/RIDER-98036">RIDER-98036</a>)</li>
+        </ul>
     </html>
     ]]>
   </change-notes>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/ProjectTemplates/DotNetExtensions/Parameters/AzureFunctionsVersionParameter.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Intellisense/FunctionApp/ProjectTemplates/DotNetExtensions/Parameters/AzureFunctionsVersionParameter.cs
@@ -62,8 +62,8 @@ namespace JetBrains.ReSharper.Azure.Intellisense.FunctionApp.ProjectTemplates.Do
                 // Use hardcoded list
                 var isNet6OrHigher = expander.Template.Sdk.Major >= 6 || expander.Template.Sdk.Major == 0; // The Azure Functions templates treat "0" as .NET 6 as well.
                 var supportedAzureFunctionsVersions = isNet6OrHigher
-                    ? new[] { "V4" }
-                    : new[] { "V3", "V2" };
+                    ? new[] { "v4" }
+                    : new[] { "v3", "v2" };
                 
                 foreach (var version in supportedAzureFunctionsVersions)
                 {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -27,6 +27,10 @@
         <ul>
           <li>Compatibility with Rider 2023.3</li>
         </ul>
+        <h4>Fixed bugs:</h4>
+        <ul>
+          <li>Azure Functions: Fix casing for the `AzureFunctionsVersion` project property (<a href="https://youtrack.jetbrains.com/issue/RIDER-98036">RIDER-98036</a>)</li>
+        </ul>
         <p>[3.50.0-2023.2]</p>
         <ul>
           <li>Compatibility with Rider 2023.2</li>


### PR DESCRIPTION
Fix casing for `AzureFunctionsVersion`.

[RIDER-98036](https://youtrack.jetbrains.com/issue/RIDER-98036)