### PR TITLE
RIDER-98014 Fix Azure Functions tool paths configuration

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -11,6 +11,7 @@
         <h4>Fixed bugs:</h4>
         <ul>
           <li>Azure Functions: Fix casing for the `AzureFunctionsVersion` project property (<a href="https://youtrack.jetbrains.com/issue/RIDER-98036">RIDER-98036</a>)</li>
+          <li>Azure Functions: Fix Azure Functions tool paths configuration (<a href="https://youtrack.jetbrains.com/issue/RIDER-98014">RIDER-98014</a>)</li>
         </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -30,6 +30,7 @@
         <h4>Fixed bugs:</h4>
         <ul>
           <li>Azure Functions: Fix casing for the `AzureFunctionsVersion` project property (<a href="https://youtrack.jetbrains.com/issue/RIDER-98036">RIDER-98036</a>)</li>
+          <li>Azure Functions: Fix Azure Functions tool paths configuration (<a href="https://youtrack.jetbrains.com/issue/RIDER-98014">RIDER-98014</a>)</li>
         </ul>
         <p>[3.50.0-2023.2]</p>
         <ul>


### PR DESCRIPTION
Before the fix, the function's path table did not store the path properly. If you select a path, do not move to another cell, and click `Save` button, the value won't be saved. 

![image](https://github.com/JetBrains/azure-tools-for-intellij/assets/16965141/5d3fd4f5-2656-45fc-b43d-3af6deec6de7)
