### PR TITLE
IDE overwrites the original uppercased runtime value with the lowercased version during deployment

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -15,6 +15,7 @@
           <li>Azure Functions: Default run configuration is no longer Azure Functions run configuration (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/746">#746</a>)</li>
           <li>Azure Functions: Fix casing for the `AzureFunctionsVersion` project property (<a href="https://youtrack.jetbrains.com/issue/RIDER-98036">RIDER-98036</a>)</li>
           <li>Azure Functions: Fix Azure Functions tool paths configuration (<a href="https://youtrack.jetbrains.com/issue/RIDER-98014">RIDER-98014</a>)</li>
+          <li>IDE overwrites the original uppercased runtime value with the lowercased version during deployment (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/752">#752</a>)</li>
         </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -34,6 +34,7 @@
           <li>Azure Functions: Default run configuration is no longer Azure Functions run configuration (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/746">#746</a>)</li>
           <li>Azure Functions: Fix casing for the `AzureFunctionsVersion` project property (<a href="https://youtrack.jetbrains.com/issue/RIDER-98036">RIDER-98036</a>)</li>
           <li>Azure Functions: Fix Azure Functions tool paths configuration (<a href="https://youtrack.jetbrains.com/issue/RIDER-98014">RIDER-98014</a>)</li>
+          <li>IDE overwrites the original uppercased runtime value with the lowercased version during deployment (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/752">#752</a>)</li>
         </ul>
         <p>[3.50.0-2023.2]</p>
         <ul>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/localsettings/FunctionLocalSettings.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/localsettings/FunctionLocalSettings.kt
@@ -39,5 +39,5 @@ data class FunctionHostModel(val localHttpPort: Int?, val cors: String?, val cor
 
 enum class FunctionsWorkerRuntime(val value: String) {
     DotNetDefault("dotnet"),
-    DotNetIsolated("dotnet-isolated")
+    DotNetIsolated("DOTNET-ISOLATED")
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/localsettings/FunctionLocalSettings.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/run/localsettings/FunctionLocalSettings.kt
@@ -38,6 +38,6 @@ data class FunctionValuesModel(
 data class FunctionHostModel(val localHttpPort: Int?, val cors: String?, val corsCredentials: Boolean?)
 
 enum class FunctionsWorkerRuntime(val value: String) {
-    DotNetDefault("dotnet"),
+    DotNetDefault("DOTNET"),
     DotNetIsolated("DOTNET-ISOLATED")
 }


### PR DESCRIPTION
Fixes #752