### PR TITLE
Add Azure Function run config priority

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-rider/azure-intellij-plugin-appservice-dotnet/src/main/kotlin/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localRun/FunctionRunConfiguration.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/azure-intellij-plugin-appservice-dotnet/src/main/kotlin/com/microsoft/azure/toolkit/intellij/legacy/function/runner/localRun/FunctionRunConfiguration.kt
@@ -7,6 +7,7 @@ package com.microsoft.azure.toolkit.intellij.legacy.function.runner.localRun
 import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.openapi.project.Project
 import com.jetbrains.rider.debugger.IRiderDebuggable
+import com.jetbrains.rider.run.configurations.IAutoSelectableRunConfiguration
 import com.jetbrains.rider.run.configurations.RiderAsyncRunConfiguration
 import com.jetbrains.rider.runtime.RiderDotNetActiveRuntimeHost
 import org.jdom.Element
@@ -22,7 +23,7 @@ class FunctionRunConfiguration(
     factory,
     { FunctionRunSettingsEditor(it) },
     FunctionRunExecutorFactory(parameters)
-), IRiderDebuggable {
+), IRiderDebuggable, IAutoSelectableRunConfiguration {
 
     private val riderDotNetActiveRuntimeHost = RiderDotNetActiveRuntimeHost.getInstance(project)
 
@@ -40,4 +41,6 @@ class FunctionRunConfiguration(
         super.writeExternal(element)
         parameters.writeExternal(element)
     }
+
+    override fun getAutoSelectPriority() = 10
 }


### PR DESCRIPTION
Without this, the `launchSettings.json` run configuration will be selected instead of our one