### PR TITLE
Improve "Trigger HTTP function" action

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/resources/META-INF/platformPlugin.xml
@@ -10,6 +10,7 @@
           <li>Enable "Start Azurite" task for all run configurations (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/780">#780</a>)</li>
           <li>New Azure Explorer icon</li>
           <li>Support for the New Solution dialog (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/793">#793</a>)</li>
+          <li>Improve "Trigger HTTP function" action (<a href="https://github.com/JetBrains/azure-tools-for-intellij/pull/831">#831</a>)</li>
         </ul>
     </html>
     ]]>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Daemon/FunctionApp/FunctionAppDaemonHost.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Daemon/FunctionApp/FunctionAppDaemonHost.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 JetBrains s.r.o.
+// Copyright (c) 2020-2024 JetBrains s.r.o.
 //
 // All rights reserved.
 //
@@ -70,11 +70,13 @@ namespace JetBrains.ReSharper.Azure.Daemon.FunctionApp
                 methodName: methodName, 
                 functionName: functionName));
 
-        public void TriggerFunctionApp([NotNull] string projectFilePath, [NotNull] string methodName, [NotNull] string functionName) => _model.TriggerFunctionApp(
+        public void TriggerFunctionApp([NotNull] string projectFilePath, [NotNull] string methodName, [NotNull] string functionName, FunctionAppTriggerType triggerType, [CanBeNull] FunctionAppHttpTriggerAttribute httpTriggerAttribute) => _model.TriggerFunctionApp(
             new FunctionAppTriggerRequest(
                 projectFilePath: projectFilePath, 
                 methodName: methodName, 
-                functionName: functionName));
+                functionName: functionName,
+                triggerType: triggerType,
+                httpTriggerAttribute: httpTriggerAttribute));
 
         private RdTask<string> GetAzureFunctionsVersionHandler(Lifetime lifetime, AzureFunctionsVersionRequest request)
         {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Psi/FunctionApp/HttpTriggerAttributeProperties.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Psi/FunctionApp/HttpTriggerAttributeProperties.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) 2024 JetBrains s.r.o.
+//
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+// the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using JetBrains.Annotations;
+
+namespace JetBrains.ReSharper.Azure.Psi.FunctionApp
+{
+    /// <summary>
+    /// Properties commonly found on an Azure Functions HttpTriggerAttribute
+    /// </summary>
+    public class HttpTriggerAttributeProperties
+    {
+        /// <summary>
+        /// Gets or sets the route template for the function. Can include
+        /// route parameters using ASP.NET Core supported syntax. If not specified,
+        /// will default to the function name.
+        /// </summary>
+        [CanBeNull]
+        public string Route { get; set; }
+
+        /// <summary>
+        /// Gets the HTTP methods that are supported for the function.
+        /// </summary>
+        [CanBeNull]
+        public string[] Methods { get; set; }
+
+        /// <summary>
+        /// Gets the authorization level for the function.
+        /// </summary>
+        [CanBeNull]
+        public string AuthLevel { get; set; }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Psi/FunctionApp/Routing/HttpTriggerAttributePropertiesExtensions.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Psi/FunctionApp/Routing/HttpTriggerAttributePropertiesExtensions.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) 2024 JetBrains s.r.o.
+//
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+// the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using JetBrains.Annotations;
+using JetBrains.ReSharper.Psi.AspRouteTemplates.Util;
+using JetBrains.ReSharper.Psi.CSharp.Util.Literals;
+
+namespace JetBrains.ReSharper.Azure.Psi.FunctionApp.Routing
+{
+    public static class HttpTriggerAttributePropertiesExtensions
+    {
+        [CanBeNull]
+        public static string GetRouteForHttpClient(
+            [CanBeNull] this HttpTriggerAttributeProperties httpTriggerAttributeProperties)
+        {
+            if (httpTriggerAttributeProperties == null) return null;
+            
+            var routeTemplateFile = RouteTemplateFileProvider.GetFile(httpTriggerAttributeProperties.Route, CSharpLiteralType.RegularString);
+            if (routeTemplateFile == null) return null;
+            
+            var context = new RouteTemplateToHttpClientContext();
+            routeTemplateFile.Accept(new RouteTemplateToHttpClientVisitor(), context);
+            return context.Builder.ToString();
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Psi/FunctionApp/Routing/RouteTemplateToHttpClientContext.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Psi/FunctionApp/Routing/RouteTemplateToHttpClientContext.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) 2024 JetBrains s.r.o.
+//
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+// the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Text;
+
+namespace JetBrains.ReSharper.Azure.Psi.FunctionApp.Routing
+{
+    internal class RouteTemplateToHttpClientContext
+    {
+        public StringBuilder Builder { get; set; } = new StringBuilder();
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Psi/FunctionApp/Routing/RouteTemplateToHttpClientVisitor.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/ReSharper.Azure/src/Azure.Psi/FunctionApp/Routing/RouteTemplateToHttpClientVisitor.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) 2024 JetBrains s.r.o.
+//
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+// the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using JetBrains.ReSharper.Psi.AspRouteTemplates.Impl.Tree;
+using JetBrains.ReSharper.Psi.AspRouteTemplates.Parsing;
+using JetBrains.ReSharper.Psi.AspRouteTemplates.Tree;
+
+namespace JetBrains.ReSharper.Azure.Psi.FunctionApp.Routing
+{
+    internal class RouteTemplateToHttpClientVisitor : RouteTemplateTreeVisitorBase<RouteTemplateToHttpClientContext, RouteTemplateToHttpClientContext>
+    {
+        public override RouteTemplateToHttpClientContext Visit(IRouteSegmentTreeNode segment, RouteTemplateToHttpClientContext context)
+        {
+            foreach (var part in segment.Parts)
+            {
+                part.Accept(this, context);
+            }
+            return context;
+        }
+
+        public override RouteTemplateToHttpClientContext Visit(IRouteDelimiterTreeNode delimiter, RouteTemplateToHttpClientContext context)
+        {
+            context.Builder.Append(delimiter.GetText());
+            return context;
+        }
+
+        public override RouteTemplateToHttpClientContext Visit(IStaticTextRoutePartTreeNode staticText, RouteTemplateToHttpClientContext context)
+        {
+            context.Builder.Append(staticText.GetText());
+            return context;
+        }
+
+        public override RouteTemplateToHttpClientContext Visit(IRouteParameterTreeNode parameter, RouteTemplateToHttpClientContext context)
+        {
+            if (parameter.Name != null)
+            {
+                context.Builder.Append("{{");
+                context.Builder.Append(parameter.Name.NameValue);
+                context.Builder.Append("}}");
+            }
+            
+            return context;
+        }
+
+        public override RouteTemplateToHttpClientContext Visit(IRouteTemplateFile file, RouteTemplateToHttpClientContext context)
+        {
+            foreach (var part in file.Parts)
+            {
+                part.Accept(this, context);
+            }
+            return context;
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/protocol/src/model/daemon/FunctionAppDaemonModel.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/protocol/src/model/daemon/FunctionAppDaemonModel.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 JetBrains s.r.o.
+ * Copyright (c) 2020-2024 JetBrains s.r.o.
  *
  * All rights reserved.
  *
@@ -50,6 +50,18 @@ object DaemonCSharpGenerator : ExternalGenerator(
 @Suppress("unused")
 object FunctionAppDaemonModel : Ext(SolutionModel.Solution) {
 
+    private val FunctionAppTriggerType = enum {
+        +"HttpTrigger"
+        +"Other"
+    }
+
+    private val FunctionAppHttpTriggerAttribute = structdef {
+        field("authLevel", string.nullable)
+        field("methods", immutableList(string))
+        field("route", string.nullable)
+        field("routeForHttpClient", string.nullable)
+    }
+
     private val FunctionAppRunDebugRequest = structdef {
         field("projectFilePath", string)
         field("methodName", string.nullable)
@@ -60,6 +72,8 @@ object FunctionAppDaemonModel : Ext(SolutionModel.Solution) {
         field("projectFilePath", string)
         field("methodName", string)
         field("functionName", string)
+        field("triggerType", FunctionAppTriggerType)
+        field("httpTriggerAttribute", FunctionAppHttpTriggerAttribute.nullable)
     }
 
     private val AzureFunctionsVersionRequest = structdef {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/META-INF/plugin.xml
@@ -29,6 +29,7 @@
           <li>Enable "Start Azurite" task for all run configurations (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/780">#780</a>)</li>
           <li>New Azure Explorer icon</li>
           <li>Support for the New Solution dialog (<a href="https://github.com/JetBrains/azure-tools-for-intellij/issues/793">#793</a>)</li>
+          <li>Improve "Trigger HTTP function" action (<a href="https://github.com/JetBrains/azure-tools-for-intellij/pull/831">#831</a>)</li>
         </ul>
         <p>[3.50.0-2023.3]</p>
         <ul>
@@ -375,6 +376,7 @@
                      groupName="Azure"
                      implementationClass="org.jetbrains.plugins.azure.functions.codeInspection.msbuild.AzureFunctionsVersionInspection"/>
 
+    <internalFileTemplate name="Trigger Azure HTTP Function"/>
     <internalFileTemplate name="Trigger Azure Function"/>
 
     <completion.contributor language="C#"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/fileTemplates/internal/Trigger Azure HTTP Function.http.ft
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/fileTemplates/internal/Trigger Azure HTTP Function.http.ft
@@ -7,9 +7,6 @@ ${comment} https://learn.microsoft.com/en-us/azure/azure-functions/functions-man
 ${comment}
 ${comment} Make sure to update the below calls to suit your function host and port.
 ${comment}
-${comment} Call the following administrative endpoint to trigger non-HTTP functions:
+${comment} Call the following endpoint to locally run HTTP and webhook-triggered functions:
 
-${requestMethod.toUpperCase()} http://localhost:7071/admin/functions/${functionName}
-Content-Type: application/json
-
-{}
+${requestMethod.toUpperCase()} http://localhost:7071/api/${urlPath}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/messages/RiderAzureMessages.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/resources/messages/RiderAzureMessages.properties
@@ -451,7 +451,8 @@ action.cloud_shell.add_firewall_rule.sql_db.name=Add firewall rule for my IP
 
 action.function_app.trigger_function_app.name=Trigger ''{0}''...
 action.function_app.trigger_function_app.description=Create trigger function HTTP request...
-action.function_app.trigger_function_app.template.name=Trigger Azure Function
+action.function_app.trigger_function_app.template.http.name=Trigger Azure HTTP Function
+action.function_app.trigger_function_app.template.other.name=Trigger Azure Function
 
 action.azurite.start.name=Start Azurite
 action.azurite.start.description=Start Azurite Storage Emulator

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/daemon/FunctionAppDaemonHost.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/rider/src/org/jetbrains/plugins/azure/functions/daemon/FunctionAppDaemonHost.kt
@@ -76,7 +76,10 @@ class FunctionAppDaemonHost(project: Project) : LifetimedProjectComponent(projec
 
     private fun initTriggerFunctionAppHandler() {
         model.triggerFunctionApp.advise(componentLifetime) { triggerFunctionRequest ->
-            val triggerAction = TriggerAzureFunctionAction(functionName = triggerFunctionRequest.functionName)
+            val triggerAction = TriggerAzureFunctionAction(
+                functionName = triggerFunctionRequest.functionName,
+                triggerType = triggerFunctionRequest.triggerType,
+                httpTriggerAttribute = triggerFunctionRequest.httpTriggerAttribute)
 
             ActionUtil.invokeAction(
                     triggerAction,


### PR DESCRIPTION
Improve "Trigger HTTP function" action:

* Distinguish between HTTP and other bindings
* Parse route template if available and use it as a generated URL in HTTP client

![image](https://github.com/JetBrains/azure-tools-for-intellij/assets/485230/df280661-df9e-43fc-9359-67547ae3dad8)

Some example use cases (left: function, right: generated HTTP client code):

![image](https://github.com/JetBrains/azure-tools-for-intellij/assets/485230/ef95b1f6-3053-45ec-8a7f-8e987b594d3c)
![image](https://github.com/JetBrains/azure-tools-for-intellij/assets/485230/8357d2f1-9ce0-4c19-b106-e6cc00d818b7)
![image](https://github.com/JetBrains/azure-tools-for-intellij/assets/485230/92e3f358-3134-4824-b2b6-216c22a423c2)
![image](https://github.com/JetBrains/azure-tools-for-intellij/assets/485230/db88b74b-c948-4b2c-a63e-014b20557f60)
![image](https://github.com/JetBrains/azure-tools-for-intellij/assets/485230/0b961407-c986-417f-bed6-0d3f27343569)
![image](https://github.com/JetBrains/azure-tools-for-intellij/assets/485230/c9047d49-8c77-4bf2-bef2-b70055f5c537)
