### PR TITLE
Add an option to disable authentication cache

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-rider/CHANGELOG.md
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Option to disable authentication cache
+
 ## [4.0.1] - 2024-08-16
 
 ### Changed

--- a/PluginsAndFeatures/azure-toolkit-for-rider/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.jetbrains
 pluginName = azure-toolkit-for-rider
 pluginRepositoryUrl = https://github.com/JetBrains/azure-tools-for-intellij
 # SemVer format -> https://semver.org
-pluginVersion = 4.0.1
+pluginVersion = 4.0.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 242


### PR DESCRIPTION
Unfortunately, the error `Unable to locate JNA native support library` occurs due to a third-party library that is used for authentication in Azure. As a workaround, it is possible to use `Azure CLI` login or disable the authentication cache in Settings.

![image](https://github.com/user-attachments/assets/ecf8a00c-f7ff-4b26-9806-28db56504dc6)

See #884
