### PR TITLE
Use the `AzureFunctionsVersion` MSBuild property value to choose the proper func cli

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-rider/CHANGELOG.md
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Option to disable authentication cache
 
+### Fixed
+
+- Plugin uses `v4` func cli even if the value of the MSBuild property is `v0`
+
 ## [4.0.1] - 2024-08-16
 
 ### Changed

--- a/PluginsAndFeatures/azure-toolkit-for-rider/azure-intellij-plugin-appservice-dotnet/src/main/kotlin/com/microsoft/azure/toolkit/intellij/legacy/function/coreTools/FunctionCoreToolsMsBuildService.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/azure-intellij-plugin-appservice-dotnet/src/main/kotlin/com/microsoft/azure/toolkit/intellij/legacy/function/coreTools/FunctionCoreToolsMsBuildService.kt
@@ -18,15 +18,9 @@ class FunctionCoreToolsMsBuildService {
         const val PROPERTY_AZURE_FUNCTIONS_VERSION = "AzureFunctionsVersion"
     }
 
-    suspend fun requestAzureFunctionsVersion(project: Project, projectFilePath: String): String? {
-        val functionVersion = project.solution.functionAppDaemonModel.getAzureFunctionsVersion
+    suspend fun requestAzureFunctionsVersion(project: Project, projectFilePath: String) =
+        project.solution
+            .functionAppDaemonModel
+            .getAzureFunctionsVersion
             .startSuspending(AzureFunctionsVersionRequest(projectFilePath))
-
-        //hack: sometimes we receive v0 even for v4 project
-        if (functionVersion == "v0") {
-            return "v4"
-        }
-
-        return functionVersion
-    }
 }


### PR DESCRIPTION
Fix #885