### PR TITLE
Remove the locked 4.99.0 release of the core tools

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-rider/CHANGELOG.md
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Fixed
 
+- Remove the locked 4.99.0 release of the core tools as the archive can be unzipped without problems
+
+## 4.2.5 - 2024-11-11
+
+### Fixed
+
 - Fix DEXP-832012: Error while extracting a file
 
 ## 4.2.4 - 2024-10-28

--- a/PluginsAndFeatures/azure-toolkit-for-rider/azure-intellij-plugin-appservice-dotnet/src/main/kotlin/com/microsoft/azure/toolkit/intellij/legacy/function/coreTools/FunctionCoreToolsManager.kt
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/azure-intellij-plugin-appservice-dotnet/src/main/kotlin/com/microsoft/azure/toolkit/intellij/legacy/function/coreTools/FunctionCoreToolsManager.kt
@@ -30,8 +30,7 @@ class FunctionCoreToolsManager {
         private val LOG = logger<FunctionCoreToolsManager>()
     }
 
-    private val fixedReleases = mapOf(
-        "v4" to "4.99.0"
+    private val fixedReleases = mapOf<String, String>(
     )
 
     private val releaseCache = concurrentMapOf<String, FunctionCoreToolsRelease>()

--- a/PluginsAndFeatures/azure-toolkit-for-rider/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.jetbrains
 pluginName = azure-toolkit-for-rider
 pluginRepositoryUrl = https://github.com/JetBrains/azure-tools-for-intellij
 # SemVer format -> https://semver.org
-pluginVersion = 4.2.5
+pluginVersion = 4.2.6
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 242


### PR DESCRIPTION
Remove the locked 4.99.0 release of the core tools as the archive can be unzipped without problems