### PR TITLE
Bugfix: DOM text reinterpreted as HTML

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-hdinsight/hdinsight_jobview_html/com.microsoft.hdinsight/hdinsight/job/html/js/tipsy.js
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-hdinsight/hdinsight_jobview_html/com.microsoft.hdinsight/hdinsight/job/html/js/tipsy.js
@@ -4,6 +4,18 @@
 // released under the MIT license
 
 (function($) {
+    function escapeHtml(text) {
+        return text.replace(/[&<>"']/g, function(match) {
+            const escapeMap = {
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            };
+            return escapeMap[match];
+        });
+    }
 
     function maybeCall(thing, ctx) {
         return (typeof thing == 'function') ? (thing.call(ctx)) : thing;
@@ -115,7 +127,7 @@
             }
             if (typeof $e.context.nearestViewportElement == 'object'){
                 if ($e.children('title').length){
-                    $e.append('<original-title>' + ($e.children('title').text() || '') + '</original-title>')
+                    $e.append('<original-title>' + escapeHtml($e.children('title').text() || '') + '</original-title>')
                         .children('title').remove();
                 }
             }


### PR DESCRIPTION
Fixes #1068 

Please see the fix when run on my fork of the repo.
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/6f64665a-b2dc-44be-9b62-43c04b249823" />

Please note that this bug does helps improve code quality and security posture for the repo. It is not a critical security vulnerability.