### PR TITLE
Improve Azure Function project detection

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-rider/CHANGELOG.md
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Changed
 
+- Unify logic to detect Azure Function projects by using `AzureFunctionsVersion` MSBuild property ([RIDER-131333](https://youtrack.jetbrains.com/issue/RIDER-131333))
+
+## [4.6.0] - 2025-10-21
+
+### Changed
+
 - Support for Rider 2025.3 EAP 6
 
 ## [4.5.5] - 2025-10-09
@@ -365,7 +371,8 @@
 - Reimplement Azure Functions Core Tools integration
 - Reimplement Azure Functions templates
 
-[Unreleased]: https://github.com/JetBrains/azure-tools-for-intellij/compare/4.5.5...HEAD
+[Unreleased]: https://github.com/JetBrains/azure-tools-for-intellij/compare/4.6.0...HEAD
+[4.6.0]: https://github.com/JetBrains/azure-tools-for-intellij/compare/4.5.5...4.6.0
 [4.5.5]: https://github.com/JetBrains/azure-tools-for-intellij/compare/4.5.4...4.5.5
 [4.5.4]: https://github.com/JetBrains/azure-tools-for-intellij/compare/4.5.3...4.5.4
 [4.5.3]: https://github.com/JetBrains/azure-tools-for-intellij/compare/v4.5.2...v4.5.3

--- a/PluginsAndFeatures/azure-toolkit-for-rider/gradle.properties
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.jetbrains
 pluginName = Azure Toolkit for Rider
 pluginRepositoryUrl = https://github.com/JetBrains/azure-tools-for-intellij
 # SemVer format -> https://semver.org
-pluginVersion = 4.6.0
+pluginVersion = 4.6.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 253

--- a/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Daemon/RunMarkers/FunctionAppRunMarkerProvider.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Daemon/RunMarkers/FunctionAppRunMarkerProvider.cs
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the MIT license.
 
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Azure.Project.FunctionApp;
+using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Azure.Psi.FunctionApp;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi;
@@ -26,7 +26,7 @@ public class FunctionAppRunMarkerProvider : IRunMarkerProvider
 
         var project = file.GetProject();
         if (project == null || !project.IsValid()) return;
-        if (!project.IsAzureFunctionsProject()) return;
+        if (!project.IsAzureFunctionProject()) return;
 
         foreach (var declaration in CachedDeclarationsCollector.Run<IMethodDeclaration>(csharpFile))
         {

--- a/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Intellisense/FunctionApp/LiveTemplates/Scope/AzureProjectScopeProvider.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Intellisense/FunctionApp/LiveTemplates/Scope/AzureProjectScopeProvider.cs
@@ -39,7 +39,7 @@ public class AzureProjectScopeProvider : ScopeProvider
     public override IEnumerable<ITemplateScopePoint> ProvideScopePoints(TemplateAcceptanceContext context)
     {
         var project = context.GetProject();
-        if (project == null || !project.IsAzureFunctionsProject()) yield break;
+        if (project == null || !project.IsAzureFunctionProject()) yield break;
 
         yield return new InAzureFunctionsProject();
 

--- a/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Project/Dockerfile/AzureFunctionsProjectDockerfileContentGenerator.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Project/Dockerfile/AzureFunctionsProjectDockerfileContentGenerator.cs
@@ -19,7 +19,7 @@ public class AzureFunctionsProjectDockerfileContentGenerator(ILogger logger) : I
 {
     public int Priority => 10;
 
-    public bool IsApplicable(IProject project) => project.IsAzureFunctionsProject();
+    public bool IsApplicable(IProject project) => project.IsAzureFunctionProject();
 
     public string Generate(
         IProject project,

--- a/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Project/FunctionApp/FunctionAppProjectDetector.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Project/FunctionApp/FunctionAppProjectDetector.cs
@@ -1,172 +1,33 @@
 // Copyright 2018-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the MIT license.
 
-using System.Collections.Generic;
-using JetBrains.Application.Threading;
 using JetBrains.ProjectModel;
 using JetBrains.ProjectModel.Assemblies.Interfaces;
-using JetBrains.ProjectModel.MSBuild;
 using JetBrains.ProjectModel.NuGet.Packaging;
-using JetBrains.ProjectModel.Properties;
-using JetBrains.ProjectModel.Properties.Managed;
-using JetBrains.ReSharper.Features.Running;
-using JetBrains.Rider.Model;
-using JetBrains.Util;
-using JetBrains.Util.Dotnet.TargetFrameworkIds;
 
 namespace JetBrains.ReSharper.Azure.Project.FunctionApp;
 
 public static class FunctionAppProjectDetector
 {
-    private static class DefaultWorker
-    {
-        private static readonly NugetId ExpectedFunctionsNuGetPackageId = new("Microsoft.NET.Sdk.Functions");
+    private static readonly NugetId DefaultWorkerNuGetId = new("Microsoft.NET.Sdk.Functions");
+    private static readonly NugetId IsolatedWorkerNuGetId = new("Microsoft.Azure.Functions.Worker.Sdk");
 
-        internal static bool HasFunctionsPackageReference(IProject project)
-        {
-            var checker = project.GetComponent<NuGetInstalledPackageChecker>();
-            return checker.IsPackageInstalled(project, ExpectedFunctionsNuGetPackageId.ID);
-        }
+    public static bool HasDefaultWorkerPackageReference(this IProject project)
+    {
+        var checker = project.GetComponent<NuGetInstalledPackageChecker>();
+        return checker.IsPackageInstalled(project, DefaultWorkerNuGetId.ID);
     }
 
-    public static bool HasDefaultWorkerPackageReference(this IProject project) =>
-        DefaultWorker.HasFunctionsPackageReference(project);
-
-    private static class IsolatedWorker
+    public static bool HasIsolatedWorkerPackageReference(this IProject project)
     {
-        private static readonly NugetId ExpectedFunctionsNuGetPackageId = new("Microsoft.Azure.Functions.Worker.Sdk");
-
-        internal static bool HasFunctionsPackageReference(IProject project)
-        {
-            var checker = project.GetComponent<NuGetInstalledPackageChecker>();
-            return checker.IsPackageInstalled(project, ExpectedFunctionsNuGetPackageId.ID);
-        }
-    }
-
-    public static bool HasIsolatedWorkerPackageReference(this IProject project) =>
-        IsolatedWorker.HasFunctionsPackageReference(project);
-
-    internal static List<ProjectOutput> GetAzureFunctionsCompatibleProjectOutputs(
-        this IProject project,
-        out string? problems,
-        ILogger? logger = null)
-    {
-        problems = null;
-        var projectOutputs = new List<ProjectOutput>();
-
-        foreach (var tfm in project.TargetFrameworkIds)
-        {
-            if (!IsAzureFunctionsProject(project, tfm, out problems, logger))
-            {
-                logger?.Trace(
-                    $"Configuration for target framework does not have \"AzureFunctionsVersion\" property set: ${tfm.PresentableString}");
-                continue;
-            }
-
-            var configuration = project.ProjectProperties.TryGetConfiguration<IManagedProjectConfiguration>(tfm);
-            if (configuration == null || (configuration.OutputType != ProjectOutputType.LIBRARY &&
-                                          configuration.OutputType != ProjectOutputType.CONSOLE_EXE))
-            {
-                logger?.Trace($"Project OutputType = {configuration?.OutputType}, skip configuration");
-                continue;
-            }
-
-            var projectOutputPath = project.GetOutputFilePath(tfm);
-            projectOutputs.Add(
-                new ProjectOutput(
-                    tfm.ToRdTargetFrameworkInfo(),
-                    projectOutputPath.NormalizeSeparators(FileSystemPathEx.SeparatorStyle.Unix),
-                    ["host", "start", "--pause-on-error"],
-                    // Azure Functions host needs the tfm folder, not the bin folder
-                    projectOutputPath.Directory
-                        .NormalizeSeparators(FileSystemPathEx.SeparatorStyle.Unix)
-                        .TrimFromEnd("/bin"),
-                    string.Empty,
-                    null,
-                    []
-                )
-            );
-        }
-
-        return projectOutputs;
-    }
-
-    public static bool IsAzureFunctionsProject(this IProject project)
-    {
-        foreach (var tfm in project.TargetFrameworkIds)
-        {
-            var configuration = project.ProjectProperties.TryGetConfiguration<IManagedProjectConfiguration>(tfm);
-            if (configuration == null || (configuration.OutputType != ProjectOutputType.LIBRARY &&
-                                          configuration.OutputType != ProjectOutputType.CONSOLE_EXE))
-                return false;
-
-            if (IsAzureFunctionsProject(project, tfm, out _, null))
-                return true;
-        }
-
-        return false;
-    }
-
-    private static bool IsAzureFunctionsProject(
-        IProject project,
-        TargetFrameworkId targetFrameworkId,
-        out string? problems,
-        ILogger? logger)
-    {
-        // Support .NET Core/Standard, NetCoreApp, NetFx
-        if (!(targetFrameworkId.IsNetCore ||
-              targetFrameworkId.IsNetStandard ||
-              targetFrameworkId.IsNetCoreApp ||
-              targetFrameworkId.IsNetFramework))
-        {
-            logger?.Trace($"Target framework not supported by Azure Functions: ${targetFrameworkId.PresentableString}");
-            problems = null;
-            return false;
-        }
-
-        // 1) Check MSBuild properties. When the property is defined but is empty, this will yield false.
-        bool hasMsBuildProperty;
-        using (project.Locks.UsingReadLock())
-        {
-            var propertyValue = project
-                .GetRequestedProjectProperty(targetFrameworkId, MSBuildProjectUtil.AzureFunctionsVersionProperty);
-            hasMsBuildProperty = !string.IsNullOrEmpty(propertyValue);
-        }
-
-        // 2) Check expected package reference.
-        //
-        //    Azure Functions has two types of runtimes for .NET:
-        //    * Default worker, which has a package reference to Microsoft.NET.Sdk.Functions
-        //    * Isolated worker, which has a package reference to Microsoft.Azure.Functions.Worker
-        //
-        //    The default worker runs your application in the Azure Functions host process,
-        //    the isolated worker runs your application in a separate process that is spawned by
-        //    the Azure Functions host.
-        var hasExpectedPackageReference =
-            IsolatedWorker.HasFunctionsPackageReference(project) ||
-            DefaultWorker.HasFunctionsPackageReference(project);
-
-        // 3) Check the existence of host.json in the project
-        bool hasHostJsonFile;
-        using (project.Locks.UsingReadLock())
-        {
-            hasHostJsonFile = project
-                .GetSubItems("host.json")
-                .Any();
-        }
-
-        // Build problem description
-        problems = !hasHostJsonFile
-            ? "Consider adding missing host.json file required by Azure Functions runtime to your project."
-            : null;
-
-        return hasMsBuildProperty || hasExpectedPackageReference || hasHostJsonFile;
+        var checker = project.GetComponent<NuGetInstalledPackageChecker>();
+        return checker.IsPackageInstalled(project, IsolatedWorkerNuGetId.ID);
     }
 
     public static FunctionProjectWorkerModel GetFunctionProjectWorkerModel(this IProject project)
     {
-        if (IsolatedWorker.HasFunctionsPackageReference(project))
+        if (HasIsolatedWorkerPackageReference(project))
             return FunctionProjectWorkerModel.Isolated;
-        else if (DefaultWorker.HasFunctionsPackageReference(project))
+        else if (HasDefaultWorkerPackageReference(project))
             return FunctionProjectWorkerModel.Default;
         else
             return FunctionProjectWorkerModel.Unknown;

--- a/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Project/FunctionApp/FunctionAppProjectTechnologyProvider.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Project/FunctionApp/FunctionAppProjectTechnologyProvider.cs
@@ -12,7 +12,7 @@ public class FunctionAppProjectTechnologyProvider : IProjectTechnologyAnalyticsP
 {
     public IEnumerable<string> GetProjectTechnology(IProject project)
     {
-        if (project.IsAzureFunctionsProject())
+        if (project.IsAzureFunctionProject())
         {
             yield return "Azure Function";
         }

--- a/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Project/FunctionApp/FunctionProjectWorkerModelDetector.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Project/FunctionApp/FunctionProjectWorkerModelDetector.cs
@@ -6,23 +6,42 @@ using JetBrains.ProjectModel.NuGet.Packaging;
 
 namespace JetBrains.ReSharper.Azure.Project.FunctionApp;
 
-public static class FunctionAppProjectDetector
+/// <summary>
+/// Provides methods for detecting the worker model associated with an Azure Functions project
+/// based on installed NuGet package references.
+/// </summary>
+public static class FunctionProjectWorkerModelDetector
 {
     private static readonly NugetId DefaultWorkerNuGetId = new("Microsoft.NET.Sdk.Functions");
     private static readonly NugetId IsolatedWorkerNuGetId = new("Microsoft.Azure.Functions.Worker.Sdk");
 
+    /// <summary>
+    /// Determines if the given project has a default worker NuGet package reference installed.
+    /// </summary>
+    /// <param name="project">The project to check for the default worker NuGet package reference.</param>
+    /// <returns>True if the default worker NuGet package reference is installed; otherwise, false.</returns>
     public static bool HasDefaultWorkerPackageReference(this IProject project)
     {
         var checker = project.GetComponent<NuGetInstalledPackageChecker>();
         return checker.IsPackageInstalled(project, DefaultWorkerNuGetId.ID);
     }
 
+    /// <summary>
+    /// Determines if the given project has an isolated worker NuGet package reference installed.
+    /// </summary>
+    /// <param name="project">The project to check for the isolated worker NuGet package reference.</param>
+    /// <returns>True if the isolated worker NuGet package reference is installed; otherwise, false.</returns>
     public static bool HasIsolatedWorkerPackageReference(this IProject project)
     {
         var checker = project.GetComponent<NuGetInstalledPackageChecker>();
         return checker.IsPackageInstalled(project, IsolatedWorkerNuGetId.ID);
     }
 
+    /// <summary>
+    /// Determines the worker model for the specified Azure Functions project based on the installed NuGet package references.
+    /// </summary>
+    /// <param name="project">The Azure Functions project to analyse for worker model detection.</param>
+    /// <returns>The detected <see cref="FunctionProjectWorkerModel"/> indicating the worker model of the project.</returns>
     public static FunctionProjectWorkerModel GetFunctionProjectWorkerModel(this IProject project)
     {
         if (HasIsolatedWorkerPackageReference(project))

--- a/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Project/RunnableProject/AzureFunctionsRunnableProjectProvider.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Project/RunnableProject/AzureFunctionsRunnableProjectProvider.cs
@@ -2,8 +2,10 @@
 
 using System.Collections.Generic;
 using JetBrains.Application.Parts;
+using JetBrains.Application.Threading;
 using JetBrains.ProjectModel;
-using JetBrains.ReSharper.Azure.Project.FunctionApp;
+using JetBrains.ProjectModel.Properties;
+using JetBrains.ProjectModel.Properties.Managed;
 using JetBrains.ReSharper.Features.Running;
 using JetBrains.Rider.Model;
 using JetBrains.Util;
@@ -22,15 +24,48 @@ public class AzureFunctionsRunnableProjectProvider(ILogger logger) : IRunnablePr
             return null;
         }
 
-        var projectOutputs = project.GetAzureFunctionsCompatibleProjectOutputs(out var problems, logger);
-
-        if (projectOutputs.IsEmpty())
+        if (!project.IsAzureFunctionProject())
         {
-            logger.Trace("No project output was found, return null");
+            logger.Trace("Project is not an Azure Function project, return null");
             return null;
         }
 
-        logger.Trace($"AzureFunctionsRunnableProjectProvider returned RunnableProject {fullName}");
+        var projectOutputs = new List<ProjectOutput>();
+        string? problems = null;
+
+        foreach (var tfm in project.TargetFrameworkIds)
+        {
+            var configuration = project.ProjectProperties.TryGetConfiguration<IManagedProjectConfiguration>(tfm);
+            if (configuration == null || (configuration.OutputType != ProjectOutputType.LIBRARY &&
+                                          configuration.OutputType != ProjectOutputType.CONSOLE_EXE))
+            {
+                logger.Trace($"Project OutputType = {configuration?.OutputType}, skip configuration");
+                continue;
+            }
+
+            var projectOutputPath = project.GetOutputFilePath(tfm);
+            // Azure Functions host needs the tfm folder, not the bin folder
+            var workingDirectoryPath = projectOutputPath.Directory
+                .NormalizeSeparators(FileSystemPathEx.SeparatorStyle.Unix)
+                .TrimFromEnd("/bin");
+
+            var projectOutput = new ProjectOutput(
+                tfm.ToRdTargetFrameworkInfo(),
+                projectOutputPath.NormalizeSeparators(FileSystemPathEx.SeparatorStyle.Unix),
+                ["host", "start", "--pause-on-error"],
+                workingDirectoryPath,
+                string.Empty,
+                null,
+                []
+            );
+
+            projectOutputs.Add(projectOutput);
+        }
+
+        if (!HasHostJsonFile(project))
+        {
+            problems = "Consider adding missing host.json file required by Azure Functions runtime to your project.";
+        }
 
         return new Rider.Model.RunnableProject(
             name,
@@ -42,6 +77,16 @@ public class AzureFunctionsRunnableProjectProvider(ILogger logger) : IRunnablePr
             problems,
             []
         );
+    }
+
+    private static bool HasHostJsonFile(IProject project)
+    {
+        using (project.Locks.UsingReadLock())
+        {
+            return project
+                .GetSubItems("host.json")
+                .Any();
+        }
     }
 
     public IEnumerable<RunnableProjectKind> HiddenRunnableProjectKinds => EmptyList<RunnableProjectKind>.Instance;

--- a/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Project/RunnableProject/AzureFunctionsRunnableProjectProvider.cs
+++ b/PluginsAndFeatures/azure-toolkit-for-rider/src/dotnet/ReSharper.Azure/Azure.Project/RunnableProject/AzureFunctionsRunnableProjectProvider.cs
@@ -62,11 +62,6 @@ public class AzureFunctionsRunnableProjectProvider(ILogger logger) : IRunnablePr
             projectOutputs.Add(projectOutput);
         }
 
-        if (!HasHostJsonFile(project))
-        {
-            problems = "Consider adding missing host.json file required by Azure Functions runtime to your project.";
-        }
-
         return new Rider.Model.RunnableProject(
             name,
             fullName,
@@ -77,16 +72,6 @@ public class AzureFunctionsRunnableProjectProvider(ILogger logger) : IRunnablePr
             problems,
             []
         );
-    }
-
-    private static bool HasHostJsonFile(IProject project)
-    {
-        using (project.Locks.UsingReadLock())
-        {
-            return project
-                .GetSubItems("host.json")
-                .Any();
-        }
     }
 
     public IEnumerable<RunnableProjectKind> HiddenRunnableProjectKinds => EmptyList<RunnableProjectKind>.Instance;


### PR DESCRIPTION
Before that there was a logic that checks `AzureFunctionsVersion` MSBuild property, specific nuget packages, `host.json` file. Moreover, in different places different logic was used. Sometimes it causes a problem because of the project references and transitive nuget dependencies (see: https://youtrack.jetbrains.com/issue/RIDER-131333).

This change should simplify the detection to just `AzureFunctionsVersion` MSBuild property by using `IsAzureFunctionProject` platform method because it is enough for most cases. 